### PR TITLE
template dsl does not work

### DIFF
--- a/lib/Dancer/Core/DSL.pm
+++ b/lib/Dancer/Core/DSL.pm
@@ -194,7 +194,7 @@ sub setting {
 sub set { shift->setting(@_) }
 
 sub template {
-    my ($self) = @_;
+    my $self = shift;
     my $template = $self->engine('template');
 
     $template->context($self->app->context);


### PR DESCRIPTION
template 'index', {};

cause below error.

Can't use string ("index") as a HASH ref while "strict refs" in use at ../dancer2/lib/Dancer/Core/Role/Template.pm line 123
