### PR TITLE
add a layout_pathname() method

### DIFF
--- a/lib/Dancer/Core/Role/Template.pm
+++ b/lib/Dancer/Core/Role/Template.pm
@@ -45,18 +45,24 @@ sub _template_name {
     return $view;
 }
 
-sub view {
+sub view_pathname {
     my ($self, $view) = @_;
 
     $view = $self->_template_name($view);
     return path($self->views, $view);
 }
 
+sub layout_pathname {
+    my ( $self, $layout ) = @_;
+
+    $layout = $self->_template_name($layout);
+    return path($self->views,'layouts', $layout);
+}
+
 sub render_layout {
     my ($self, $layout, $tokens, $content) = @_;
 
-    my $layout_name = $self->_template_name($layout);
-    my $layout_path = path($self->views, 'layouts', $layout_name);
+    my $layout_path = $self->layout_pathname($layout);
 
     # FIXME: not sure if I can "just call render"
     $self->render($layout_path, {%$tokens, content => $content});
@@ -64,7 +70,7 @@ sub render_layout {
 
 sub apply_renderer {
     my ($self, $view, $tokens) = @_;
-    $view = $self->view($view) if ! ref $view;
+    $view = $self->view_pathname($view) if ! ref $view;
     $tokens = $self->_prepare_tokens_options($tokens);
 
     $self->execute_hooks('before_template_render', $tokens);


### PR DESCRIPTION
The goal is to encapsulate the template-as-filename
logic in view_pathname and layout_pathname such that
template systems that don't use files (like TemplateDeclare)
will have an easy way to overload them.

WARNING: I don't know if that's the right solution. It makes sense to me, but I've changed the method view() to view_pathname() so that it can have its sister method layour_pathname(). Feel free to alter to your taste, if you so desire. :-)
