### PR TITLE
Add build prerequisite on Test::Trap which is used in t/logger_console.t...

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -10,7 +10,8 @@ my %WriteMakefileArgs = (
   'BUILD_REQUIRES'     => {
                            'File::Find' => '0',
                            'File::Temp' => '0',
-                           'Test::More' => '0'
+                           'Test::More' => '0',
+                           'Test::Trap' => '0',
   },
   'CONFIGURE_REQUIRES' => {
                            'ExtUtils::MakeMaker' => '6.30'


### PR DESCRIPTION
.logger_console test fails otherwise.
