### PR TITLE
dancer_version -> dancer_major_version

### DIFF
--- a/lib/Dancer/Core/DSL.pm
+++ b/lib/Dancer/Core/DSL.pm
@@ -27,7 +27,7 @@ sub dsl_keywords {
         [core_debug   => 1],
         [dance        => 1],
         [dancer_app   => 1],
-        [dancer_version => 1],
+        [dancer_major_version => 1],
         [debug        => 1],
         [del          => 1],
         [dirname      => 1],
@@ -86,7 +86,7 @@ sub dsl_keywords_as_list {
 }
 
 sub dancer_app { shift->app }
-sub dancer_version { (split /\./, $Dancer::VERSION)[0] }
+sub dancer_major_version { (split /\./, $Dancer::VERSION)[0] }
 sub dsl { shift }
 
 sub debug   { shift->log(debug   => @_) }

--- a/lib/Dancer/Plugin.pm
+++ b/lib/Dancer/Plugin.pm
@@ -46,7 +46,7 @@ in order to set some options.
 The option C<is_global> (boolean) is used to declare a global/non keyword (by
 default all keywords are global). A non global keyword must be called from
 within a route handler (eg: C<session> or C<param>) whereas a global one can be called
-frome everywhere (eg: C<dancer_version> or C<setting>).
+frome everywhere (eg: C<dancer_major_version> or C<setting>).
 
     register my_symbol_to_export => sub {
         # ... some code 
@@ -129,12 +129,12 @@ sub register_plugin {
 
     # if the caller has not a dsl, we cant register the plugin 
     return if ! $caller->can('dsl');
-    my $dancer_version = $caller->dsl->dancer_version;
+    my $dancer_major_version = $caller->dsl->dancer_major_version;
     my $plugin_version = eval "\$${plugin}::VERSION" || '??';
 
     # make sure the plugin is compatible with this version of Dancer
-    grep /^$dancer_version$/, @{ $supported_versions }
-      or croak "$plugin $plugin_version does not support Dancer $dancer_version.";
+    grep { $_ == $dancer_major_version } @$supported_versions
+      or croak "$plugin $plugin_version does not support Dancer $dancer_major_version.";
 
 
     # we have a $dsl in our caller, we can register our symbols then

--- a/t/dsl.t
+++ b/t/dsl.t
@@ -19,5 +19,5 @@ any ['get', 'post'], '/'  => sub {
     is $r->[2][0], 'POST';
 }
 
-is dancer_version, 2, 'dancer_version';
+is dancer_major_version, 2, 'dancer_major_version';
 done_testing;


### PR DESCRIPTION
In my opinion, dancer_version DSL keyword should be renamed to dancer_major_version (or something shorter, but not dancer_version). Because it's really only the major version, not the full version.

In addition, dancer_version already exists as a template token, and in this case it contains the full version. So it would be confusing to have both 'dancer_version' meaning 2 different things.
