### PR TITLE
allow before hook to populate the response's content

### DIFF
--- a/lib/Dancer/Core/Dispatcher.pm
+++ b/lib/Dancer/Core/Dispatcher.pm
@@ -45,18 +45,18 @@ sub dispatch {
 
         # warn "looking for $http_method $path_info";
 
+        ROUTE:
         foreach my $route (@{ $app->routes->{$http_method} }) {
             # warn "testing route ".$route->regexp;
 
             # TODO next if $r->has_options && (not $r->validate_options($request));
             # TODO store in route cache
 
-            my $match = $route->match($http_method => $path_info);
-            if ($match) {
-                # warn "got a match";
-                $context->request->_set_route_params($match);
-            }
+            # go to the next route if no match
+            my $match = $route->match($http_method => $path_info) 
+                or next ROUTE;
 
+            $context->request->_set_route_params($match);
 
             # if the request has been altered by a before filter, we should not continue
             # with this route handler, we should continue to walk through the
@@ -64,17 +64,18 @@ sub dispatch {
 #            next if $context->request->path_info ne $path_info 
 #                 || $context->request->method ne uc($http_method);
 
-            # go to the next route if no match
-            next if !$match;
-            my $content;
             $app->execute_hooks('core.app.before_request', $context);
+            my $response = $context->response;
 
-            if (! $context->response->is_halted) {
-                eval { $content = $route->execute($context) };
+            my $content;
+            if ( $response->is_halted ) {
+                # if halted, it comes from the 'before' hook. Take its content
+                $content = $response->content;
+            }
+            else {
+                $content = eval { $route->execute($context) };
                 return $self->response_internal_error($@) if $@;    # 500
             }
-
-            my $response = $context->response;
 
             # routes should use 'content_type' as default, or 'text/html'
             if (!$response->header('Content-type')) {
@@ -86,20 +87,19 @@ sub dispatch {
             }
 
             # serialize if needed
-            if (defined $app->config->{serializer}) {
-                $content = $app->config->{serializer}->serialize($content) 
-                    if ref($content); 
-            }
+            $content = $app->config->{serializer}->serialize($content) 
+                if ref $content and defined $app->config->{serializer}; 
 
             $response->content(defined $content ? $content : '');
+
             $response->encode_content;
 
-            return $response if $context->response->is_halted;
+            return $response if $response->is_halted;
 
             # pass the baton if the response says so...
             if ($response->has_passed) {
-                $context->response->has_passed(0);
-                next;
+                $response->has_passed(0);  # clear for the next round
+                next ROUTE;
             }
 
             $app->execute_hooks('core.app.after_request', $response);


### PR DESCRIPTION
This patch is to accommodate plugins that needs to short-circuit
the route's main code (in my case, that's D::P::Cache::CHI).

With this patch, if the 'before' hook halts the response,
the response content is taken from whatever the hook put in
$context->response->content, not from $route->execute($context).

The grooming of the content (serializing, content-type filling,
content encoding), however, is still done.
