### PR TITLE
Fix tests failing from PR52 merge

### DIFF
--- a/lib/Dancer/Core/Runner.pm
+++ b/lib/Dancer/Core/Runner.pm
@@ -134,6 +134,6 @@ sub start {
 }
 
 # Used by 'logger' to get a name from a Runner
-sub name { "runner" };
+sub name { "runner" }
 
 1;

--- a/t/app.t
+++ b/t/app.t
@@ -2,12 +2,12 @@ use strict;
 use warnings;
 use Test::More;
 use Test::Fatal;
+use Dancer;
 use Dancer::Core::App;
 use Dancer::Core::Dispatcher;
 use Dancer::Core::Hook;
 use Dancer::FileUtils;
 use File::Spec;
-use File::Basename 'dirname';
 
 # our app/dispatcher object
 my $app = Dancer::Core::App->new(

--- a/t/config.t
+++ b/t/config.t
@@ -17,6 +17,8 @@ my $location = File::Spec->rel2abs(path(dirname(__FILE__), 'config'));
     use Moo;
     with 'Dancer::Core::Role::Config';
 
+    sub name { 'Prod' }
+
     sub _build_environment {'production'}
     sub _build_config_location {$location}
     sub default_config { $runner->default_config }

--- a/t/logger.t
+++ b/t/logger.t
@@ -20,7 +20,7 @@ my $_logs = [];
     }
 }
 
-my $logger = Dancer::Logger::Test->new();
+my $logger = Dancer::Logger::Test->new(app_name => 'test');
 
 is $logger->log_level, 'debug';
 $logger->debug("foo");

--- a/t/logger_console.t
+++ b/t/logger_console.t
@@ -6,7 +6,7 @@ use Capture::Tiny 'capture_stderr';
 plan tests => 4;
 
 use Dancer::Logger::Console;
-my $l = Dancer::Logger::Console->new(log_level => 'core');
+my $l = Dancer::Logger::Console->new(app_name => 'test', log_level => 'core');
 
 for my $level (qw{core debug warning error}) {
     my $stderr = capture_stderr { $l->$level("$level") };


### PR DESCRIPTION
Basically, Apps created manually need a 'name' method.
There was one error that I couldn't find out why it appeared (in app.t) but it got solved.
We still need to make silent a log message on t/dispatcher.t
