### PR TITLE
Test vars() from within hooks/routes

### DIFF
--- a/t/vars.t
+++ b/t/vars.t
@@ -9,19 +9,19 @@ use Dancer::Test;
 
     hook before => sub {
         var("xpto" => "foo");
-#        vars->{zbr} => 'ugh';
+        vars->{zbr} = 'ugh';
     };
 
     get '/bar' => sub {
         var("xpto");
     };
 
-    # get '/baz' => sub {
-    #     vars->{zbr};
-    # };
+    get '/baz' => sub {
+        vars->{zbr};
+    };
 }
 
 response_content_is [GET => '/bar'], 'foo';
-# response_content_is [GET => '/baz'], 'ugh';
+response_content_is [GET => '/baz'], 'ugh';
 
 done_testing;


### PR DESCRIPTION
In Dancer 1 one could do vars->{foo}. It seems it is no longer supported.
If it is the case, we should document it.
If not, we should fix it, because it is not working (uncomment the test
I leaved commented in this file).
