### PR TITLE
make dancer_response returns a Dancer::Core::Response

### DIFF
--- a/lib/Dancer/Test.pm
+++ b/lib/Dancer/Test.pm
@@ -74,7 +74,7 @@ sub dancer_response {
 
     # use Data::Dumper;
     # warn "Env created : ".Dumper($env);
-    $_dispatcher->dispatch($env, $request)->to_psgi;
+    $_dispatcher->dispatch($env, $request);
 }
 
 sub response_status_is {
@@ -86,7 +86,7 @@ sub response_status_is {
 
     my $tb = Test::Builder->new;
     local $Test::Builder::Level = $Test::Builder::Level + 1;
-    $tb->is_eq( $response->[0], $status, $test_name );
+    $tb->is_eq( $response->status, $status, $test_name );
 }
 
 sub route_exists {
@@ -135,7 +135,7 @@ sub response_status_isnt {
         
         my $tb = Test::Builder->new;
         local $Test::Builder::Level = $Test::Builder::Level + 1;
-        $tb->$cmp( $response->[2][0], $want, $test_name );
+        $tb->$cmp( $response->content, $want, $test_name );
     }
 }
     
@@ -184,7 +184,7 @@ sub response_headers_are_deeply {
     my $response = _dancer_response($app, _expand_req($req));
     
     is_deeply(
-        _sort_headers( $response->[1] ),
+        _sort_headers( $response->headers_to_array ),
         _sort_headers( $expected ),
         $test_name
     );

--- a/t/ajax_plugin.t
+++ b/t/ajax_plugin.t
@@ -19,16 +19,16 @@ my $r = dancer_response( POST => '/test',  {
                 ['X-Requested-With' => 'XMLHttpRequest'],
             ], 
         });
-is $r->[2][0], "{some: 'json'}", "ajax works with POST";
+is $r->content, "{some: 'json'}", "ajax works with POST";
 
 $r = dancer_response( GET => '/test',  { 
             headers => [
                 ['X-Requested-With' => 'XMLHttpRequest'],
             ], 
         });
-is $r->[2][0], "{some: 'json'}", "ajax works with GET";
+is $r->content, "{some: 'json'}", "ajax works with GET";
 
 $r = dancer_response( POST => '/test' );
-is $r->[0], 404, 'ajax does not match if no XMLHttpRequest';
+is $r->status, 404, 'ajax does not match if no XMLHttpRequest';
 
 done_testing;

--- a/t/any.t
+++ b/t/any.t
@@ -14,9 +14,9 @@ use Test::More import => ['!pass'];
 use Dancer::Test 'App';
 
 my $r = dancer_response( POST => '/test' );
-is $r->[2][0], 'POST';
+is $r->content, 'POST';
 
 $r = dancer_response( GET => '/test' );
-is $r->[2][0], 'GET';
+is $r->content, 'GET';
      
 done_testing;

--- a/t/dsl.t
+++ b/t/dsl.t
@@ -11,12 +11,12 @@ any ['get', 'post'], '/'  => sub {
 
 {
     my $r = dancer_response GET => '/';
-    is $r->[2][0], 'GET';
+    is $r->content, 'GET';
 }
 
 {
     my $r = dancer_response POST => '/';
-    is $r->[2][0], 'POST';
+    is $r->content, 'POST';
 }
 
 is int(dancer_version), 2, 'dancer_version';

--- a/t/error.t
+++ b/t/error.t
@@ -52,8 +52,8 @@ subtest "send_error in route" => sub {
     use Dancer::Test 'App';
     my $r = dancer_response GET => '/error';
 
-    is $r->[0], 500, 'send_error sets the status to 500';
-    like $r->[2][0], qr{This is a custom error message},
+    is $r->status, 500, 'send_error sets the status to 500';
+    like $r->content, qr{This is a custom error message},
         'Error message looks good';
 };
 
@@ -70,8 +70,8 @@ subtest "send_error with custom stuff" => sub {
 
     my $r = dancer_response GET => '/error/42';
 
-    is $r->[0], 542, 'send_error sets the status to 542';
-    like $r->[2][0], qr{Error 542},
+    is $r->status, 542, 'send_error sets the status to 542';
+    like $r->content, qr{Error 542},
         'Error message looks good';
 };
 

--- a/t/hooks.t
+++ b/t/hooks.t
@@ -72,7 +72,7 @@ subtest 'serializer hooks' => sub {
     require 'JSON.pm';
     my $r = dancer_response get => '/json';
     my $json = JSON::to_json([foo => 42, added_in_hook => 1]);
-    is $r->[2][0], $json, 'response is serialized';
+    is $r->content, $json, 'response is serialized';
     is $tests_flags->{before_serializer}, 1, 'before_serializer was called';
     is $tests_flags->{after_serializer},  1, 'after_serializer was called';
 };

--- a/t/plugin_syntax.t
+++ b/t/plugin_syntax.t
@@ -22,13 +22,13 @@ subtest 'global and route keywords' => sub {
     }
 
     my $r = dancer_response(GET => '/');
-    is($r->[2][0], '/', 'route defined by a plugin');
+    is($r->content, '/', 'route defined by a plugin');
 
     $r = dancer_response(GET => '/foo');
-    is($r->[2][0], 'foo', 'DSL keyword wrapped by a plugin');
+    is($r->content, 'foo', 'DSL keyword wrapped by a plugin');
 
     $r = dancer_response(GET => '/app');
-    is($r->[2][0], 'main', 'app name is correct');
+    is($r->content, 'main', 'app name is correct');
 };
 
 subtest 'plugin old syntax' => sub {
@@ -40,7 +40,7 @@ subtest 'plugin old syntax' => sub {
     }
 
     my $r = dancer_response GET => '/foo/plugin';
-    is $r->[2][0], 'foo plugin';
+    is $r->content, 'foo plugin';
 };
 
 subtest caller_dsl => sub {
@@ -50,7 +50,7 @@ subtest caller_dsl => sub {
     }
 
     my $r = dancer_response GET => '/sitemap';
-    is $r->[2][0], '^\/$, ^\/app$, ^\/foo$, ^\/foo\/plugin$, ^\/sitemap$'
+    is $r->content, '^\/$, ^\/app$, ^\/foo$, ^\/foo\/plugin$, ^\/sitemap$'
    
 };
 
@@ -83,7 +83,7 @@ subtest 'hooks in plugins' => sub {
 
     is $counter, 0, "the hook has not been executed";
     my $r = dancer_response(GET => '/hooks_plugin');
-    is($r->[2][0], 'hook for plugin', '... route is rendered');
+    is($r->content, 'hook for plugin', '... route is rendered');
     is $counter, 1, "... and the hook has been executed exactly once";
 
     dancer_response(GET => '/hook_with_var');

--- a/t/session.t
+++ b/t/session.t
@@ -44,19 +44,19 @@ subtest simple_session_as_dsl => sub {
     get '/write/:value' => sub { session user => param('value') };
 
     my $r = dancer_response GET => '/read';
-    is $r->[2][0], '';
+    is $r->content, '';
 
     $r = dancer_response GET => '/write/42';
-    is $r->[2][0], '42';
+    is $r->content, '42';
 
     $r = dancer_response GET => '/read';
-    is $r->[2][0], '42';
+    is $r->content, '42';
     
     $r = dancer_response GET => '/write/sukria';
-    is $r->[2][0], 'sukria';
+    is $r->content, 'sukria';
 
     $r = dancer_response GET => '/read';
-    is $r->[2][0], 'sukria';
+    is $r->content, 'sukria';
 
 };
 done_testing;

--- a/t/splat.t
+++ b/t/splat.t
@@ -18,7 +18,7 @@ my $resp = dancer_response(get => '/foo/bar/baz', {
 });
 
 is_deeply [@splat], [qw(foo bar baz)], "splat behaves as expected";
-is $resp->[0], 200, "got a 200";
-is_deeply $resp->[2], [ 3 ], "got expected response";
+is $resp->status, 200, "got a 200";
+is_deeply $resp->content, 3, "got expected response";
 
 done_testing;


### PR DESCRIPTION
The test function 'dancer_response' was returning its psgi
representation, and I changed that to just returning the
Dancer::Core::Response object. The motivation for doing that
is 3-fold:

a) it's more intuitive for 'dancer_response' to return a, well,
Dancer::Core::Response, and make further tests easier to read:

```
is $res->status => 200;

versus

is $res->[0] => 200;

Also, nothing is lost as, if one really desires the psgi
```

format, one can still do '$res->to_psgi'.

b) while it's not 100% compatible with Dancer1's 'dancer_response,
it's going to be close as things like

```
$res->{content}
```

will still work (thanks to Moo and Moose stashing their attributes
as a good ol' hash ref)

In that regard, if the return values of dancer_response do
turn out to cause problem for many plugins, I'm considering having
a 'v1_behavior' flag for Test::Dancer that would make dancer_response
returns the same hashref than in Dancer1. But then, having peeps add this flag
will probably be just as much work as changing all $res->{stuff} to
$res->stuff, so... I don't know, we'll see later.
