### PR TITLE
Update lib/Dancer/Core/Types.pm

### DIFF
--- a/lib/Dancer/Core/Types.pm
+++ b/lib/Dancer/Core/Types.pm
@@ -4,7 +4,6 @@ package Dancer::Core::Types;
 
 use strict;
 use warnings;
-use Carp 'croak';
 use Scalar::Util 'blessed', 'looks_like_number';
 use MooX::Types::MooseLike::Base qw/:all/;
 use MooX::Types::MooseLike::Numeric qw/:all/;


### PR DESCRIPTION
seems we're not using Carp at the moment
