### PR TITLE
towards MooX::Types::MooseLike 0.16

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,6 +1,7 @@
 {{$NEXT}}
 
     [ BUG FIXES ]
+    * MooX::Types::MooseLike 0.16 to fix type issues (https://github.com/mateu/MooX-Types-MooseLike/issues/14)
     * Fix dist.ini, and numerous missing pod names (Damien Krotkine)
     * Add warning in Makefile.PL to inform about Dist::Zilla (Damien Krotkine)
     * Update README (Damien Krotkine)

--- a/dist.ini
+++ b/dist.ini
@@ -45,6 +45,7 @@ skip = ^t::lib::
 [Prereqs]
 Moo = 0.009014
 Moo::Role = 0
+MooX::Types::MooseLike = 0.16
 Carp = 0
 Exporter = 5.57
 Encode = 0
@@ -66,7 +67,6 @@ JSON = 0
 ; Used in DSL (send_error)
 Template::Tiny = 0
 URI::Escape = 0
-parent = 0
 
 [Prereqs / Recommends]
 ; Serializers

--- a/lib/Dancer/Core/Role/Template.pm
+++ b/lib/Dancer/Core/Role/Template.pm
@@ -50,7 +50,7 @@ has views => (
 
 has layout => (
     is => 'rw',
-    isa => Str,
+    isa => Maybe[Str],
 );
 
 has engine => (

--- a/lib/Dancer/Core/Types.pm
+++ b/lib/Dancer/Core/Types.pm
@@ -5,11 +5,11 @@ package Dancer::Core::Types;
 use strict;
 use warnings;
 use Scalar::Util 'blessed', 'looks_like_number';
-use MooX::Types::MooseLike 0.11;
+use MooX::Types::MooseLike 0.16;
 use MooX::Types::MooseLike::Base qw/:all/;
 use MooX::Types::MooseLike::Numeric qw/:all/;
 
-use Exporter 'import';
+use base 'Exporter';
 our @EXPORT;
 our @EXPORT_OK;
 
@@ -89,8 +89,9 @@ for my $type (qw/App Request Response Context Runner Dispatcher MIME/) {
 
 MooX::Types::MooseLike::register_types($definitions, __PACKAGE__);
 
-# Export everything by default.
 @EXPORT = (@MooX::Types::MooseLike::Base::EXPORT_OK, @EXPORT_OK);
+
+# Export everything by default.
 
 1;
 


### PR DESCRIPTION
this is similar to Yanick's PR, 

it sets layout type to Maybe[Str], but leaves the path issue unresolved for now

I thought maybe one step at a time would be easier to merge and to work with.

00-compile.t works, but one test fails due to the path issue.
