### PR TITLE
type: set prefix to Maybe[DancerPrefix]

### DIFF
--- a/lib/Dancer/Core/App.pm
+++ b/lib/Dancer/Core/App.pm
@@ -401,7 +401,7 @@ has context => (
 
 has prefix => (
     is => 'rw',
-    isa => DancerPrefix,
+    isa => Maybe[DancerPrefix],
     coerce => sub {
         my ($prefix) = @_;
         return undef if defined($prefix) and $prefix eq "/";

--- a/lib/Dancer/Core/Route.pm
+++ b/lib/Dancer/Core/Route.pm
@@ -56,7 +56,7 @@ The prefix to prepend to the C<regexp>. Optional.
 
 has prefix => (
     is => 'ro',
-    isa => DancerPrefix,
+    isa => Maybe[DancerPrefix],
 );
 
 =attr options


### PR DESCRIPTION
since not easily visible: this PR commits to branch Sawyer's "fixed-types-tests".

My reasoning:

DancerPrefix is not prefix. Documentation repeatedly says that prefix can be set to undef, e.g. to unset a previously set prefix, so prefix needs to accept undef,but DancerPrefix doesn't have to. Would it be more  consistent if DancerPrefix and prefix behave the same way? I don't know.

I guess it's worth a try. Anyway. this needs to be changed in two different places to pass test.
