### PR TITLE
fix cookie tests 

### DIFF
--- a/lib/Dancer/Core/Cookie.pm
+++ b/lib/Dancer/Core/Cookie.pm
@@ -76,7 +76,6 @@ has path => (
     is       => 'rw',
     isa      => Str,
     required => 0,
-    default  => sub { '/' },
 );
 
 has secure => (

--- a/t/cookie.t
+++ b/t/cookie.t
@@ -16,7 +16,6 @@ my $cookie = Dancer::Core::Cookie->new(name => "foo");
 isa_ok $cookie => 'Dancer::Core::Cookie';
 can_ok $cookie => 'to_header';
 
-
 note "Setting values";
 
 is $cookie->value("foo") => "foo";
@@ -26,10 +25,9 @@ ok $cookie->value( [qw(a b c)] );
 is $cookie->value => 'a';
 is_deeply [$cookie->value] => [qw(a b c)];
 
-ok $cookie->value( { x => 1, y => 2 });
+ok $cookie->value({x => 1, y => 2});
 like $cookie->value => qr/^[xy]$/; # hashes doesn't store order...
 is_deeply [sort $cookie->value] => [sort (1, 2, 'x', 'y')];
-
 
 note "accessors and defaults";
 
@@ -41,7 +39,7 @@ ok !$cookie->domain;
 is $cookie->domain("dancer.org") => "dancer.org";
 is $cookie->domain => "dancer.org";
 
-is $cookie->path => '/';
+ok ! $cookie->path; #no more default paths
 is $cookie->path("/foo") => "/foo";
 is $cookie->path => "/foo";
 
@@ -52,7 +50,6 @@ is $cookie->secure => 1;
 ok !$cookie->http_only;
 is $cookie->http_only(1) => 1;
 is $cookie->http_only => 1;
-
 
 note "expiration strings";
 
@@ -65,65 +62,71 @@ my $year = 365 * $day;
 
 ok !$cookie->expires;
 my %times = (
-             "+2"                        => "Tue, 15-Jun-2010 00:00:02 GMT",
-             "+2h"                       => "Tue, 15-Jun-2010 02:00:00 GMT",
-             "-2h"                       => "Mon, 14-Jun-2010 22:00:00 GMT",
-             "1 hour"                    => "Tue, 15-Jun-2010 01:00:00 GMT",
-             "3 weeks 4 days 2 hours 99 min 0 secs" => "Sat, 10-Jul-2010 03:39:00 GMT",
-             "2 months"                  => "Sat, 14-Aug-2010 00:00:00 GMT",
-             "12 years"                  => "Sun, 12-Jun-2022 00:00:00 GMT",
+	"+2"                                   => "Tue, 15-Jun-2010 00:00:02 GMT",
+	"+2h"                                  => "Tue, 15-Jun-2010 02:00:00 GMT",
+	"-2h"                                  => "Mon, 14-Jun-2010 22:00:00 GMT",
+	"1 hour"                               => "Tue, 15-Jun-2010 01:00:00 GMT",
+	"3 weeks 4 days 2 hours 99 min 0 secs" => "Sat, 10-Jul-2010 03:39:00 GMT",
+	"2 months"                             => "Sat, 14-Aug-2010 00:00:00 GMT",
+	"12 years"                             => "Sun, 12-Jun-2022 00:00:00 GMT",
 
-             1288817656 => "Wed, 03-Nov-2010 20:54:16 GMT",
-             1288731256 => "Tue, 02-Nov-2010 20:54:16 GMT",
-             1288644856 => "Mon, 01-Nov-2010 20:54:16 GMT",
-             1288558456 => "Sun, 31-Oct-2010 20:54:16 GMT",
-             1288472056 => "Sat, 30-Oct-2010 20:54:16 GMT",
-             1288385656 => "Fri, 29-Oct-2010 20:54:16 GMT",
-             1288299256 => "Thu, 28-Oct-2010 20:54:16 GMT",
-             1288212856 => "Wed, 27-Oct-2010 20:54:16 GMT",
+	1288817656 => "Wed, 03-Nov-2010 20:54:16 GMT",
+	1288731256 => "Tue, 02-Nov-2010 20:54:16 GMT",
+	1288644856 => "Mon, 01-Nov-2010 20:54:16 GMT",
+	1288558456 => "Sun, 31-Oct-2010 20:54:16 GMT",
+	1288472056 => "Sat, 30-Oct-2010 20:54:16 GMT",
+	1288385656 => "Fri, 29-Oct-2010 20:54:16 GMT",
+	1288299256 => "Thu, 28-Oct-2010 20:54:16 GMT",
+	1288212856 => "Wed, 27-Oct-2010 20:54:16 GMT",
 
-             # Anything not understood is passed through
-             "basset hounds got long ears" => "basset hounds got long ears",
-             "+2 something"                => "+2 something",
-            );
+	# Anything not understood is passed through
+	"basset hounds got long ears" => "basset hounds got long ears",
+	"+2 something"                => "+2 something",
+);
 
-for my $exp (keys %times) {
-    my $want = $times{$exp};
+for my $exp ( keys %times ) {
+	my $want = $times{$exp};
 
-    $cookie->expires($exp);
-    is $cookie->expires => $want;
+	$cookie->expires($exp);
+	is $cookie->expires => $want;
 }
-
 
 note "to header";
 
 my @cake = (
-            {
-             cookie => { name      => 'bar',
-                         value     => 'foo',
-                         expires   => '+2h',
-                         secure    => 1 },
-             expected => sprintf("bar=foo; path=/; expires=%s; Secure", $times{'+2h'}),
-            },
-            {
-             cookie => { name      => 'bar',
-                         value     => 'foo',
-                         domain    => 'dancer.org',
-                         path      => '/dance',
-                         http_only => 1 },
-             expected => "bar=foo; path=/dance; domain=dancer.org; HttpOnly",
-            },
-            {
-             cookie => { name      => 'bar',
-                         value     => 'foo',
-                         path      => undef },
-             expected => "bar=foo",
-            },
-           );
+	{
+		cookie => {
+			name    => 'bar',
+			value   => 'foo',
+			expires => '+2h',
+			secure  => 1
+		},
+		expected =>
+		  sprintf( "bar=foo; expires=%s; Secure", $times{'+2h'} ),
+	},
+	{
+		cookie => {
+			name      => 'bar',
+			value     => 'foo',
+			domain    => 'dancer.org',
+			path      => '/dance',
+			http_only => 1
+		},
+		expected => "bar=foo; path=/dance; domain=dancer.org; HttpOnly",
+	},
+	{
+		cookie => {
+			name  => 'bar',
+			value => 'foo'
+		},
+		#path => undef is no longer allowed
+		expected => "bar=foo",
+	},
+);
 
 for my $cook (@cake) {
-    my $c = Dancer::Core::Cookie->new(%{$cook->{cookie}});
-    is $c->to_header => $cook->{expected};
+	my $c = Dancer::Core::Cookie->new( %{ $cook->{cookie} } );
+	is $c->to_header => $cook->{expected};
 }
 
 done_testing;


### PR DESCRIPTION
Whether it is a good idea that Dancer shouldn't put default path in cookies, i can't say. Yanik researched it and spec rfc6265 confirms it: cookie path is not required by spec.

Sawyer suggested to not require a path in https://github.com/PerlDancer/Dancer2/pull/91.

This commit fixes the tests accordingly. (Most of the whitespace changes in the commit are unintentional. Sorry! Should I be using perltidy? Should we copy .perltidyrc from old Dancer?)

PS: Travis: All three of my mini-PRs together fix all type related issues. Then only hooks.t doesn't pass. 
