### PR TITLE
add dzil perltidy?

### DIFF
--- a/.perltidyrc
+++ b/.perltidyrc
@@ -1,8 +1,6 @@
 -l=79   # Max line width is 79 cols
 -i=4    # Indent level is 4 cols
 -ci=4   # Continuation indent is 4 cols
-
--b 
 -se     # Errors to STDERR
 -vt=2   # Maximal vertical tightness
 -cti=0  # No extra indentation for closing brackets
@@ -25,10 +23,9 @@
 -ci=2   # Continuation indent is 2 cols
 
 # we use version control, so just rewrite the file
--b
+# instead of -b we use dist::zilla::perltidy now
 
 # for the up-tight folk :)
 -pt=2   # High parenthesis tightness
 -bt=2   # High brace tightness
 -sbt=2  # High square bracket tightness
-

--- a/dist.ini
+++ b/dist.ini
@@ -15,7 +15,7 @@ homepage   = http://perldancer.org/
 
 ;adds 'dzil perltidy' command 
 [PerlTidy]
-; currently you need to do 'dzil perltidy .perltidyrc'
+perltidyrc = .perltidyrc
 
 ; -- fetch & generate files
 [GatherDir]


### PR DESCRIPTION
Hey @Dolmen and everybody else,

what do you think about perltidy? I had some white space issues lately. This is .perltidyrc file from Dancer 1, so I thought it's an ok starting point.

This PR also adds the `dzil perltidy .perltidyrc` command replacing `run_perltidy.sh` in old Dancer.

PS: I also filter out emacs backup files. That wasn't covered  by PrunceCruft. I figure others developers might also be useing emacs. 

PPS: Old run_perltidy.sh only applied perltidy to *.pm, this one applies perltidy also to *.t and *.pl
