### PR TITLE
session cookie is for the whole site

### DIFF
--- a/lib/Dancer/Core/Role/Session.pm
+++ b/lib/Dancer/Core/Role/Session.pm
@@ -137,6 +137,7 @@ sub cookie {
         value     => $self->id,
         secure    => $self->session_secure,
         http_only => $self->session_is_http_only,
+        path      => '/',
     );
 
     if (my $expires = $self->session_expires) {


### PR DESCRIPTION
Since the cookie doesn't default to have path=/ anymore,
we have to be explicit.
