### PR TITLE
Default cookie path to '/'.

### DIFF
--- a/lib/Dancer/Core/Cookie.pm
+++ b/lib/Dancer/Core/Cookie.pm
@@ -38,7 +38,7 @@ sub to_header {
     my $no_httponly = defined( $self->http_only ) && $self->http_only == 0;
 
     my @headers = $self->name . '=' . $value;
-    push @headers, "path=" . $self->path        if $self->path;
+    push @headers, "path=" . $self->path || '/';
     push @headers, "expires=" . $self->expires  if $self->expires;
     push @headers, "domain=" . $self->domain    if $self->domain;
     push @headers, "Secure"                     if $self->secure;


### PR DESCRIPTION
This is what Dancer1 does, so it seems reasonable to keep the same behaviour.

(I'm fairly sure the defacto default if the cookie header doesn't specify a path
is to treat it as / anyway, but this can't hurt.)
