### PR TITLE
Fix Dancer::Test to simplify Dancer::Plugin and Dancer app test

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,5 +1,8 @@
 {{$NEXT}}
 
+    [ EVO ]
+    * Dancer::Test use hash as option to simplifier test in plugin and apps
+
     [ BUG FIXES ]
     * The engine configuration is now passed down to
       Dancer::Template::Implementation::ForkedTiny (Damien Krotkine).

--- a/lib/Dancer/Test.pm
+++ b/lib/Dancer/Test.pm
@@ -325,17 +325,22 @@ to test.
     use t::lib::Foo;
     use t::lib::Bar;
 
-    use Dancer::Test 't::lib::Foo', 't::lib::Bar';
+    use Dancer::Test apps => ['t::lib::Foo', 't::lib::Bar'];
 
 =cut
 
 sub import {
-    my ($class, @applications) = @_;
-    my ($caller, $script) = caller;
+    my ($class, %options) = @_;
 
-    # if no app is passed, assume the caller is one.
-    @applications = ($caller) 
-        if ! @applications && $caller->can('dancer_app');
+    my @applications;
+    if (ref $options{apps} eq ref([])) {
+        @applications = @{$options{apps}};
+    } else {
+        my ($caller, $script) = caller;
+
+        # if no app is passed, assume the caller is one.
+        @applications = ($caller) if $caller->can('dancer_app');
+    }
     
     # register the apps to the test dispatcher
     $_dispatcher->apps([ map { $_->dancer_app } @applications ]);

--- a/t/ajax_plugin.t
+++ b/t/ajax_plugin.t
@@ -12,7 +12,7 @@ use Test::More import => ['!pass'];
     };
 }
 
-use Dancer::Test 'App';
+use Dancer::Test apps => ['App'];
 
 my $r = dancer_response( POST => '/test',  {
             headers => [

--- a/t/any.t
+++ b/t/any.t
@@ -15,7 +15,7 @@ use Test::More import => ['!pass'];
     };
 }
 
-use Dancer::Test 'App';
+use Dancer::Test apps => ['App'];
 
 my $r = dancer_response( POST => '/test' );
 is $r->content, 'POST';

--- a/t/error.t
+++ b/t/error.t
@@ -48,7 +48,7 @@ subtest "send_error in route" => sub {
         };
     }
 
-    use Dancer::Test 'App';
+    use Dancer::Test apps => ['App'];
     my $r = dancer_response GET => '/error';
 
     is $r->status, 500, 'send_error sets the status to 500';

--- a/t/error_template.t
+++ b/t/error_template.t
@@ -27,7 +27,7 @@ use Test::More;
 
 }
 
-use Dancer::Test 'PrettyError';
+use Dancer::Test apps => ['PrettyError'];
 
 subtest "/error" => sub {
     my $r = dancer_response GET => '/error';

--- a/t/plugin_multiple_apps.t
+++ b/t/plugin_multiple_apps.t
@@ -21,7 +21,7 @@ use Test::More;
     };
 }
 
-use Dancer::Test 'App', 't::lib::SubApp1', 't::lib::SubApp2';
+use Dancer::Test apps => ['App', 't::lib::SubApp1', 't::lib::SubApp2'];
 
 # make sure both apps works as epxected
 response_content_is '/subapp1', 1;

--- a/t/redirect.t
+++ b/t/redirect.t
@@ -13,7 +13,7 @@ subtest 'basic redirects' => sub {
         get '/redirect' => sub { header 'X-Foo' => 'foo'; redirect '/'; };
         get '/redirect_querystring' => sub { redirect '/login?failed=1' };
     }
-    use Dancer::Test 'App';
+    use Dancer::Test apps => ['App'];
 
     response_status_is  [ GET => '/' ] => 200;
     response_content_is [ GET => '/' ] => "home";
@@ -46,7 +46,7 @@ subtest 'absolute and relative redirects' => sub {
         get '/absolute' => sub { redirect "/absolute"; };
         get '/relative' => sub { redirect "somewhere/else"; };
     }
-    use Dancer::Test 'App';
+    use Dancer::Test apps => ['App'];
 
     response_headers_include
       [ GET => '/absolute_with_host' ],
@@ -68,7 +68,7 @@ subtest 'redirect behind a proxy' => sub {
         set behind_proxy => 1;
         get '/bounce'   => sub { redirect '/' };
     }
-    use Dancer::Test 'App';
+    use Dancer::Test apps => ['App'];
 
     $ENV{X_FORWARDED_HOST} = "nice.host.name";
     response_headers_include

--- a/t/template_default_tokens.t
+++ b/t/template_default_tokens.t
@@ -27,7 +27,7 @@ my $views = File::Spec->rel2abs(
     };
 }
 
-use Dancer::Test 'Foo';
+use Dancer::Test apps => ['Foo'];
 
 my $expected = "perl_version: $]
 dancer_version: ${Dancer::VERSION}


### PR DESCRIPTION
Dancer1 and Dancer2 take params from hash.

Dancer1 take 'appdir' as an option.
Dancer2 take 'apps' as an option.

For a plugin compatible with Dancer1 and Dancer2 with can just do this :

use Dancer::Test appdir => '..', apps => ['MyApp1','MyApp2'];

so both will work fine.
