### PR TITLE
Rollback dist ini, upgrade your bundle

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -6,16 +6,11 @@ copyright_year   = 2012
 main_module = lib/Dancer.pm
 version = 1.9999_02
 
-[@Filter]
+[@Dancer]
 ; Required version of the bundle
--bundle=@Dancer
--remove=GatherDir
 :version = 0.0001
 test_compile_skip = ^Dancer::(?:Serializer|Session)::YAML$
 autoprereqs_skip = ^t::lib::|^t::app::|XS$
-
-[GatherDir]
-include_dotfiles = 1
 
 ; -- static meta-information
 [MetaResources]


### PR DESCRIPTION
the Dist::Zilla::PluginBundle::Dancer has been update to support
dotfiles.
