### PR TITLE
chosing latest MIME::Base64

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -47,8 +47,8 @@ HTTP::Date = 0
 HTTP::Body = 0
 HTTP::Headers = 0
 MIME::Types = 0
-; 3.21 has the URL safe variants
-MIME::Base64 = 3.21
+; 3.13 has the URL safe variants
+MIME::Base64 = 3.13
 ; Used only for the Standalone server for development
 HTTP::Server::Simple::PSGI = 0
 ; JSON is just a serialiser, so in theory should be optional.


### PR DESCRIPTION
MIME::Base64's latest version on CPAN is 3.13, which fixes the encode_base64url() behaviour. I believe Dave made a typo when setting it to 3.21, as he probably meant 3.12. Since version 3.13 fixes an issue in 3.12, I figured we might as well bump the requirement.
