### PR TITLE
Dancer::Test route_exists delegates to route_status_is with wrong argument order

### DIFF
--- a/lib/Dancer/Test.pm
+++ b/lib/Dancer/Test.pm
@@ -227,7 +227,7 @@ registry.
 =cut 
 
 sub route_exists {
-    response_status_is(@_, 200);
+    response_status_is($_[0], 200, $_[1]);
 }
 
 =func route_doesnt_exist([$method, $path], $test_name)


### PR DESCRIPTION
route_exists passes calls route_status_is `@_, 200`
However, route_status_is expects `$_[0], 200, $_[1]`
