### PR TITLE
Dancer::Core::Dispatch responds to changes of path_info by before_request hooks

### DIFF
--- a/t/path_info.t
+++ b/t/path_info.t
@@ -1,0 +1,23 @@
+use Test::More import => ['!pass'], tests => 1;
+use Dancer 2.0 ':syntax';
+use Dancer::Test;
+use strict;
+use warnings;
+
+
+get '/' => sub {
+    return 'Forbidden';
+};
+
+get '/default' => sub {
+    return 'Default';
+};
+
+hook before => sub {
+    request->path_info('/default');
+};
+
+response_content_like ( [ GET => '/' ], qr{Default}, 
+    'Changing request->path_info worked' );
+
+done_testing();


### PR DESCRIPTION
Currently, changing path_info within a before_request hook is ignored in Dancer::Core::Dispatch. The proposed change re-scans the apps and their routes to match the new path_info and method. A single test is included along with this change.
