### PR TITLE
'cookie' keyword now behaves like described in Dancer2::Manual::Keywords

### DIFF
--- a/lib/Dancer2/Core/Context.pm
+++ b/lib/Dancer2/Core/Context.pm
@@ -67,7 +67,10 @@ sub cookies { shift->request->cookies(@_) }
 sub cookie {
     my $self = shift;
 
-    return $self->request->cookies->{$_[0]} if @_ == 1;
+	if (@_ == 1) {
+		my $cookie = $self->request->cookies->{$_[0]}	or return;
+		return $cookie->value;
+	}
 
     # writer
     my ($name, $value, %options) = @_;


### PR DESCRIPTION
It used to be that: cookie 'cookieName' would return a D2::Core::Cookie object. That was contrary to documentation (the Dancer2::Manual::Keywords under construction). Now it returns either a string or an array (based on context)
