### PR TITLE
Dancer::Plugin::Bcrypt marks itself as deprecated in favor of Dancer::Plugin::Passphrase

### DIFF
--- a/lib/Dancer2/Plugins.pod
+++ b/lib/Dancer2/Plugins.pod
@@ -88,9 +88,10 @@ Provides dead-simple profiling of your app using L<Devel::NYTProf> - enables
 profiling for each request individually, serves up a list of profiling runs, and
 generates & sends the HTML reports produced by C<nytprofhtml>.
 
-=item L<Dancer2::Plugin::Bcrypt>
+=item L<Dancer2::Plugin::Passphrase>
 
-Provides simple effective password hashing and validation using Bcrypt.
+Provides simple effective password hashing and validation using Bcrypt, MD5,
+SHA among other.
 
 =item L<Dancer2::Plugin::Cache::CHI>
 


### PR DESCRIPTION
Since I suggest a pull request to Dancer::Plugin::Passphrase, creating Dancer2::Plugin::Passphrase this documentation update may make sense.
