### PR TITLE
Give Dancer2::Test the ability to handle multiselect inputs

### DIFF
--- a/lib/Dancer2/Test.pm
+++ b/lib/Dancer2/Test.pm
@@ -149,9 +149,15 @@ sub _build_request_from_env {
 
     if (defined $options->{params}) {
         my @params;
-        foreach my $p (keys %{$options->{params}}) {
-            push @params,
-              uri_escape($p) . '=' . uri_escape($options->{params}->{$p});
+        while( my ($p, $value) = each %{$options->{params}} ) {
+            if ( ref($value) eq 'ARRAY' ) {
+                for my $v (@$value) {
+                    push @params, uri_escape($p) . '=' . uri_escape($v);
+                }
+            }
+            else {
+                push @params, uri_escape($p) . '=' . uri_escape($value);
+            }
         }
         $env->{QUERY_STRING} = join('&', @params);
     }
@@ -226,8 +232,15 @@ sub _build_env_from_request {
     # TODO
     if (my $params = $request->{_query_params}) {
         my @params;
-        foreach my $p (keys %{$params}) {
-            push @params, uri_escape($p) . '=' . uri_escape($params->{$p});
+        while(my ($p, $value) = each %{$params}) {
+            if ( ref($value) eq 'ARRAY' ) {
+                for my $v (@$value) {
+                    push @params, uri_escape($p) . '=' . uri_escape($v);
+                }
+            }
+            else {
+                push @params, uri_escape($p) . '=' . uri_escape($value);
+            }
         }
         $env->{QUERY_STRING} = join('&', @params);
     }

--- a/t/dancer-test.t
+++ b/t/dancer-test.t
@@ -3,7 +3,7 @@
 use strict;
 use warnings;
 
-use Test::More tests => 47;
+use Test::More tests => 48;
 
 use Dancer2 ':syntax';
 use Dancer2::Test;
@@ -71,3 +71,13 @@ $file_response = dancer_response(POST => '/upload', {
     files => [{ filename => $temp->filename, name => 'test' }] } );
 is $file_response->content, 'testfile', 'file uploaded with supplied filename';
 
+## Check multiselect/multi parameters get through ok
+get '/multi' => sub {
+    my $t = param('test');
+    return join('', @$t) if ref($t) eq 'ARRAY';
+    return 'bad';
+};
+$param_response = dancer_response(GET => '/multi', {
+    params => { test => ['foo', 'bar'] } });
+is $param_response->content, 'foobar',
+    'multi values for same key get echoed back';


### PR DESCRIPTION
Dancer2::Test treats key => value params as always being scalar values.
However, it is possible to send multiple values per key in an http form.
multiselects/checkboxes etc. This gives Dancer2::Test the ability to
handle that (Dancer2 supports this fine, it's just the tests that don't)
