### PR TITLE
gitignore: ignore new Dancer2-* instead of old Dancer-2.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,7 +14,7 @@ contrib/logs/
 tools/plugins_auto_tests/perlbrew
 tools/plugins_auto_tests/plugins_list
 tools/plugins_auto_tests/result.csv
-Dancer-[1-9]*
+Dancer2-*
 t/sessions
 /.tidyall.d
 /perltidy.LOG


### PR DESCRIPTION
I had some unnecessary warnings during make because of some old directories. 
