### PR TITLE
remove cover.sh

### DIFF
--- a/cover.sh
+++ b/cover.sh
@@ -1,4 +1,0 @@
-perl Makefile.PL && make clean
-perl Makefile.PL
-make
-cover -test -coverage=subroutine -coverage=branch


### PR DESCRIPTION
I am new to devel::cover, but it appears to me that we can simply use

./Build testcover  

these days and don't need the cover shell script any longer. Just my 2 cents.
