### PR TITLE
re-export MooseLike::Numeric as per gh#156

### DIFF
--- a/lib/Dancer2/Core/Types.pm
+++ b/lib/Dancer2/Core/Types.pm
@@ -13,7 +13,6 @@ use Exporter 'import';
 our @EXPORT;
 our @EXPORT_OK;
 
-
 =head1 DESCRIPTION
 
 Type definitions for Moo attributes. These are defined as subroutines. 
@@ -160,9 +159,11 @@ for my $type (
 
 MooX::Types::MooseLike::register_types($definitions, __PACKAGE__);
 
-# Export everything by default.
-@EXPORT = (@MooX::Types::MooseLike::Base::EXPORT_OK, @EXPORT_OK);
-
+# Re-export everything by default, as per GH#156
+@EXPORT = (
+    @MooX::Types::MooseLike::Base::EXPORT_OK,
+    @MooX::Types::MooseLike::Numeric::EXPORT_OK, @EXPORT_OK
+);
 1;
 
 =head1 SEE ALSO

--- a/t/types.t
+++ b/t/types.t
@@ -1,8 +1,10 @@
 use strict;
 use warnings;
-use Test::More tests => 46;
+use Test::More;
 use Test::Fatal;
 use Dancer2::Core::Types;
+use MooX::Types::MooseLike::Base;
+use MooX::Types::MooseLike::Numeric;
 
 
 ok(exception { Str->(undef) }, 'Str does not accept undef value',);
@@ -192,3 +194,14 @@ like(
 ok( exception { Dancer2HTTPMethod->(undef) },
     'Dancer2Method does not accept undef value',
 );
+
+#as per gH #156
+foreach my $type (
+    @MooX::Types::MooseLike::Base::EXPORT_OK,
+    @MooX::Types::MooseLike::Numeric::EXPORT_OK
+  )
+{
+    ok(defined &$type, "type '$type' exists");
+}
+
+done_testing;


### PR DESCRIPTION
please double check if this is what we want. Feels a bit like namespace pollution. Thanks!

gh #156
