### PR TITLE
Dancer is not a prereq (GH257)

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -10,7 +10,7 @@ version = 0.04
 ; Required version of the bundle
 :version = 0.0002
 test_compile_skip = ^Dancer::(?:Serializer|Session)::YAML$
-autoprereqs_skip = ^t::lib::|^t::app::|XS$
+autoprereqs_skip = ^t::lib::|^t::app::|XS$|^Dancer$
 
 ; -- static meta-information
 [MetaResources]


### PR DESCRIPTION
I don't know how we get Dancer as prereq, but this eliminates it. Do we want a test for that?

https://github.com/PerlDancer/Dancer2/issues/257
