### PR TITLE
Correct the spelling of "retrieve".

### DIFF
--- a/lib/Dancer2/Core/Context.pm
+++ b/lib/Dancer2/Core/Context.pm
@@ -127,7 +127,7 @@ sub _build_session {
         # if we have a session cookie, try to retrieve the session
         if (defined $session_id) {
             eval { $session = $engine->retrieve(id => $session_id) };
-            croak "Fail to retreive session: $@"
+            croak "Fail to retrieve session: $@"
               if $@ && $@ !~ /Unable to retrieve session/;
         }
     }

--- a/t/lib/FooPlugin.pm
+++ b/t/lib/FooPlugin.pm
@@ -7,7 +7,7 @@ on_plugin_import {
 };
 
 sub _html_sitemap {
-    join(', ', _retreive_get_urls( @_ ));
+    join(', ', _retrieve_get_urls( @_ ));
 }
 
 register foo_wrap_request => sub {
@@ -22,7 +22,7 @@ register foo_route => sub {
 };
 
 # taken from SiteMap
-sub _retreive_get_urls {
+sub _retrieve_get_urls {
     my $dsl = shift;
     my ($route, @urls);
 


### PR DESCRIPTION
See:
- https://rt.cpan.org/Ticket/Display.html?id=85962
- http://en.wiktionary.org/wiki/retrieve .
