### PR TITLE
HEAD request drops the body of the response.

### DIFF
--- a/lib/Dancer2/Core/Dispatcher.pm
+++ b/lib/Dancer2/Core/Dispatcher.pm
@@ -134,6 +134,21 @@ sub dispatch {
     return $self->response_not_found($context);
 }
 
+# In the case of a HEAD request, we need to drop the body, but we also
+# need to keep the value of the Content-Length header.
+# Because there's a trigger on the content field to change the value of
+# the C-L header everytime we change the value, we need to modify a around
+# modifier to change the value of content and restore the length.
+around 'dispatch' => sub {
+    my ($orig, $self, $env, $request) = @_;
+    my $response = $orig->($self, $env, $request);
+    return $response unless defined $request && $request->is_head;
+    my $cl = $response->header('Content-Length');
+    $response->content('');
+    $response->header('Content-Length' => $cl);
+    return $response;
+};
+
 sub response_internal_error {
     my ($self, $error) = @_;
 

--- a/t/any.t
+++ b/t/any.t
@@ -24,7 +24,7 @@ is $r->content, 'POST';
 $r = dancer_response(GET => '/test');
 is $r->content, 'GET';
 
-for my $method (qw(GET HEAD POST PUT DELETE OPTIONS PATCH)) {
+for my $method (qw(GET POST PUT DELETE OPTIONS PATCH)) {
     my $r = dancer_response($method => '/all');
     is $r->content, $method;
 }

--- a/t/http_methods.t
+++ b/t/http_methods.t
@@ -1,7 +1,7 @@
 use strict;
 use warnings;
 
-use Test::More tests => 6;
+use Test::More tests => 8;
 
 use Dancer2;
 use Dancer2::Test;
@@ -19,3 +19,8 @@ while (my ($method, $http) = each %method) {
     eval "$method '/' => sub { '$method' }";
     response_content_is [$http => '/'], $method, $method;
 }
+
+eval "get '/head' => sub {'HEAD'}";
+my $resp = dancer_response('HEAD', '/head');
+is $resp->content, '', 'HEAD';
+is $resp->header('Content-Length'), 4, 'Content-Length for HEAD';


### PR DESCRIPTION
For a HEAD request, the body of the response should be empty ('').  By
implementing an 'around' modifier to the 'dispath' method, we can drop
the body if the request is HEAD.

The reason to use an 'around' modifier in this case, is that the
Content-Length head should contains the correct lenght of the response.

Closes #286.
