### PR TITLE
Fix for the default tests of a new generatd app.

### DIFF
--- a/lib/Dancer2/Test.pm
+++ b/lib/Dancer2/Test.pm
@@ -836,7 +836,7 @@ sub _find_dancer_apps_for_dispatcher {
 
     for (my $deep = 0; $deep < 5; $deep++) {
         my $caller = caller($deep);
-        next if !$caller->can('dancer_app');
+        next if !$caller || !$caller->can('dancer_app');
 
         return $_dispatcher->apps([$caller->dancer_app]);
     }

--- a/script/dancer2
+++ b/script/dancer2
@@ -995,7 +995,7 @@ use warnings;
 
 # the order is important
 use $appname;
-use Dancer2::Test;
+use Dancer2::Test apps => ['$appname'];
 
 route_exists [GET => '/'], 'a route handler is defined for /';
 response_status_is ['GET' => '/'], 200, 'response status is 200 for /';


### PR DESCRIPTION
The tests of an app generated by the `dancer2` scripts are failing
because the tests can't load the application.

By specifiying the name of the application to load in the test we can
make them pass.

Also, in the Dancer2::Test module, before calling the 'can' method on
the caller, we check if the caller is defined, that way, instead of
failing the tests because we can't call a method on an undefined object,
we fail with a useful message for the user.

Closes #293
