### PR TITLE
Check 'show_errors' when returning an internal error.

### DIFF
--- a/lib/Dancer2/Core/Dispatcher.pm
+++ b/lib/Dancer2/Core/Dispatcher.pm
@@ -85,7 +85,7 @@ sub dispatch {
                 my $error = $@;
                 if ($error) {
                     $app->log(error => "Route exception: $error");
-                    return $self->response_internal_error($error);
+                    return $self->response_internal_error($context, $error);
                 }
             }
 
@@ -135,14 +135,16 @@ sub dispatch {
 }
 
 sub response_internal_error {
-    my ($self, $error) = @_;
+    my ($self, $context, $error) = @_;
 
     # warn "got error: $error";
 
     return Dancer2::Core::Error->new(
+        context      => $context,
         status       => 500,
         title        => 'Internal Server Error',
-        content      => "Internal Server Error\n\n$error\n",
+        content      => "Internal Server Error",
+        exception    => $error,
         content_type => 'text/plain'
     )->throw;
 }
@@ -188,7 +190,7 @@ __END__
     my $resp = $dispatcher->dispatch($env)->to_psgi;
 
     # Capture internal error of a response (if any) after a dispatch
-    $dispatcher->response_internal_error($error);
+    $dispatcher->response_internal_error($context, $error);
 
     # Capture response not found for an application the after dispatch
     $dispatcher->response_not_found($context);

--- a/lib/Dancer2/Core/Error.pm
+++ b/lib/Dancer2/Core/Error.pm
@@ -109,8 +109,11 @@ sub supported_hooks {
 =cut
 
 has show_errors => (
-    is  => 'ro',
-    isa => Bool,
+    is      => 'ro',
+    isa     => Bool,
+    default => sub {
+        $_[0]->context->app->setting('show_errors') if $_[0]->has_context;
+    },
 );
 
 =attr charset
@@ -354,9 +357,12 @@ sub throw {
 
     $self->execute_hook('core.error.before', $self);
 
+    my $message = $self->content;
+    $message .= "\n\n".$self->exception if $self->show_errors && defined $self->exception;
+
     $self->response->status($self->status);
     $self->response->header($self->content_type);
-    $self->response->content($self->content);
+    $self->response->content($message);
     $self->response->halt(1);
 
     $self->execute_hook('core.error.after', $self->response);

--- a/t/dispatcher.t
+++ b/t/dispatcher.t
@@ -17,6 +17,7 @@ my $buffer = {};
 my $app = Dancer2::Core::App->new(name => 'main');
 
 $app->setting(logger => engine('logger'));
+$app->setting(show_errors => 1);
 
 # a simple / route
 $app->add_route(

--- a/t/error.t
+++ b/t/error.t
@@ -86,5 +86,22 @@ subtest 'Response->error()' => sub {
     ok $resp->is_halted, 'response is halted';
 };
 
+subtest 'Error with show_errors: 0' => sub {
+    my $err = Dancer2::Core::Error->new(
+        context     => $c,
+        exception   => 'our exception',
+        show_errors => 0
+    )->throw;
+    unlike $err->content => qr/our exception/;
+};
+
+subtest 'Error with show_errors: 1' => sub {
+    my $err = Dancer2::Core::Error->new(
+        context     => $c,
+        exception   => 'our exception',
+        show_errors => 1
+    )->throw;
+    like $err->content => qr/our exception/;
+};
 
 done_testing;


### PR DESCRIPTION
When returning an internal error, exceptions should not be returned in
the response if the value of 'show_errors' is set to false in the
configuration.

In order to do this, instead of passing the message and the exception as
a single value to Dancer2::Core::Error, we separate them and use the
correct attribute when creating the object.

When the method `throw` is called, the value of 'show_errors' is
checked, and if it's false, the exception is not used in the message.

Tests are updated accordingly to this change.

Closes #216
