### PR TITLE
fix the correct option for JSON and UTF-8

### DIFF
--- a/lib/Dancer2/Core/Dispatcher.pm
+++ b/lib/Dancer2/Core/Dispatcher.pm
@@ -109,7 +109,13 @@ sub dispatch {
                 # TODO make the response object self-serializable? With a
                 # is_serialized attribute
                 if ( my $serializer = ref($content) && $app->config->{serializer} ) {
-                    $content = $serializer->serialize($content);
+                    my $options = {};
+                    if (lc($app->config->{charset}) eq 'utf-8') {
+                      if (ref($serializer) eq 'Dancer2::Serializer::JSON') {
+                        $options->{utf8} = 1;
+                      }
+                    }
+                    $content = $serializer->serialize($content, $options);
                     $response->content_type($serializer->content_type);
                 }
 


### PR DESCRIPTION
This patch sets the correct option for serializer JSON when charset is UTF-8

According to JSON Documentation to encode a utf-8 string option utf8 => 1 must be given.
