### PR TITLE
Support changing views and layout inside the module.

### DIFF
--- a/lib/Dancer2/Core/Role/Config.pm
+++ b/lib/Dancer2/Core/Role/Config.pm
@@ -253,8 +253,8 @@ my $_setters = {
           $self->_get_config_for_engine(template => $value, $config);
         my $engine_attrs = {config => $engine_options};
         $engine_attrs->{layout} ||= $config->{layout};
-        $engine_attrs->{views} ||= $config->{'views'} || path($self->config_location, 'views');
-
+        $engine_attrs->{views}  ||= $config->{views}
+            || path($self->config_location, 'views');
         return Dancer2::Core::Factory->create(
             template => $value,
             %{$engine_attrs},
@@ -287,6 +287,18 @@ my $_setters = {
         my ($self, $traces) = @_;
         require Carp;
         $Carp::Verbose = $traces ? 1 : 0;
+    },
+    views => sub {
+        my ($self, $value, $config) = @_;
+        if (ref($self) eq 'Dancer2::Core::App' && defined $self->server) {
+            $self->engine('template')->views($value);
+        }
+    },
+    layout => sub {
+        my ($self, $value, $config) = @_;
+        if (ref($self) eq 'Dancer2::Core::App' && defined $self->server) {
+            $self->engine('template')->layout($value);
+        }
     },
 };
 

--- a/lib/Dancer2/Core/Runner.pm
+++ b/lib/Dancer2/Core/Runner.pm
@@ -136,6 +136,8 @@ sub default_config {
         host         => ($ENV{DANCER_SERVER}       || '0.0.0.0'),
         port         => ($ENV{DANCER_PORT}         || '3000'),
         is_daemon    => ($ENV{DANCER_DAEMON}       || 0),
+        views        => ($ENV{DANCER_VIEWS}        ||
+                         path($self->config_location, 'views')),
         appdir       => $self->location,
         import_warnings => 1,
     };

--- a/t/template.t
+++ b/t/template.t
@@ -82,4 +82,25 @@ layout bottom
 
 content added in after_layout_render';
 
+{
+
+    package Foo;
+
+    use Dancer2;
+    set views    => '/this/is/our/path';
+
+    get '/default_views'          => sub {set 'views'};
+    get '/set_views_via_settings' => sub {set views => '/other/path' };
+    get '/get_views_via_settings' => sub {set 'views'};
+}
+
+use Dancer2::Test apps => ['Foo'];
+
+my $r = dancer_response GET => '/default_views';
+is $r->content, '/this/is/our/path';
+
+dancer_response      GET => '/set_views_via_settings';
+$r = dancer_response GET => '/get_views_via_settings';
+is $r->content, '/other/path';
+
 done_testing;


### PR DESCRIPTION
Chaning the values of 'views' and 'layout' inside the module (or the
route) needs to modify the value of the template engine.

By adding a trigger to the 'views' and 'layout' keys in the config, we
can alter the existing template.

Closes #251.
