### PR TITLE
Methods to return path of views and layout.

### DIFF
--- a/lib/Dancer2/Core/Error.pm
+++ b/lib/Dancer2/Core/Error.pm
@@ -175,7 +175,7 @@ sub _build_error_template {
     # look for a template named after the status number.
     # E.g.: views/404.tt  for a TT template
     return $self->status
-      if -f $self->context->app->engine('template')->view($self->status);
+      if -f $self->context->app->engine('template')->view_pathname($self->status);
 
     return undef;
 }

--- a/lib/Dancer2/Core/Role/Template.pm
+++ b/lib/Dancer2/Core/Role/Template.pm
@@ -10,6 +10,25 @@ use Data::Dumper;
 use Moo::Role;
 with 'Dancer2::Core::Role::Engine';
 
+=head1 DESCRIPTION
+
+This role provides methods and attributes needed for working with template.
+
+All Dancer's templates engine should consume this role, and they B<need> to
+implement a C<render> method. This method will receive three arguments:
+
+=over 4
+
+=item $self
+
+=item $template
+
+=item $tokens
+
+=back
+
+=cut
+
 sub supported_hooks {
     qw/
       engine.template.before_render
@@ -23,6 +42,12 @@ sub _build_type {'Template'}
 
 requires 'render';
 
+=method name
+
+The name of the template engine (e.g.: Simple).
+
+=cut
+
 has name => (
     is      => 'ro',
     lazy    => 1,
@@ -31,11 +56,25 @@ has name => (
 
 sub _build_name { (my $name = ref shift) =~ s/^Dancer2::Template:://; $name; }
 
+
+=method charset
+
+The charset.  The default value is B<UTF-8>.
+
+=cut
+
 has charset => (
     is      => 'ro',
     isa     => Str,
     default => sub {'UTF-8'},
 );
+
+
+=method default_tmpl_ext
+
+The default file extension.  If not provided, B<tt> is used.
+
+=cut
 
 has default_tmpl_ext => (
     is      => 'rw',
@@ -43,15 +82,33 @@ has default_tmpl_ext => (
     default => sub { shift->config->{extension} || 'tt' },
 );
 
+=method views
+
+Path to the directory containing the views.
+
+=cut
+
 has views => (
     is  => 'rw',
     isa => Maybe [Str],
 );
 
+=method layout
+
+Path to the directory containing the layouts.
+
+=cut
+
 has layout => (
     is  => 'rw',
     isa => Maybe [Str],
 );
+
+=method engine
+
+Contains the engine.
+
+=cut
 
 has engine => (
     is      => 'ro',
@@ -67,26 +124,53 @@ sub _template_name {
     return $view;
 }
 
-sub view {
+=method view_pathname($view)
+
+Returns the full path to the requested view.
+
+=cut
+
+sub view_pathname {
     my ($self, $view) = @_;
 
     $view = $self->_template_name($view);
     return path($self->views, $view);
 }
 
+=method layout_pathname($layout)
+
+Returns the full path to the requested layout.
+
+=cut
+
+sub layout_pathname {
+    my ($self, $layout) = @_;
+    $layout = $self->_template_name($layout);
+    return path($self->views, 'layouts', $layout);
+}
+
+=method render_layout($layout, $tokens, \$content)
+
+Render the layout with the applied tokens
+
+=cut
+
 sub render_layout {
     my ($self, $layout, $tokens, $content) = @_;
 
-    my $layout_name = $self->_template_name($layout);
-    my $layout_path = path($self->views, 'layouts', $layout_name);
+    $layout = $self->layout_pathname($layout);
 
     # FIXME: not sure if I can "just call render"
-    $self->render($layout_path, {%$tokens, content => $content});
+    $self->render($layout, {%$tokens, content => $content});
 }
+
+=method apply_renderer($view, $tokens)
+
+=cut
 
 sub apply_renderer {
     my ($self, $view, $tokens) = @_;
-    $view = $self->view($view) if !ref $view;
+    $view = $self->view_pathname($view) if !ref $view;
     $tokens = $self->_prepare_tokens_options($tokens);
 
     $self->execute_hook('engine.template.before_render', $tokens);
@@ -98,6 +182,10 @@ sub apply_renderer {
     defined $content and return $content;
     return;
 }
+
+=method apply_layout
+
+=cut
 
 sub apply_layout {
     my ($self, $content, $tokens, $options) = @_;
@@ -150,6 +238,10 @@ sub _prepare_tokens_options {
 
     return $tokens;
 }
+
+=method process($view, $tokens, $options)
+
+=cut
 
 sub process {
     my ($self, $view, $tokens, $options) = @_;

--- a/t/template_ext.t
+++ b/t/template_ext.t
@@ -30,7 +30,7 @@ is(
 );
 
 is(
-    $tt->view('foo'),
+    $tt->view_pathname('foo'),
     File::Spec->catfile($views, 'foo.foo'),
     "view('foo') gives filename with right extension as configured",
 );


### PR DESCRIPTION
Rename the `view' method to`view_pathname', to make it more explicit
about the meaning of that method.  Also add a `layout_pathname' method,
that returns the full path to the layout.

Add documentation for the role so other developpers can implement
different plugins to support more templating engines.

This is a reimplementation of the work done by Yannick on #32.
