### PR TITLE
Fix config structure

### DIFF
--- a/script/dancer2
+++ b/script/dancer2
@@ -920,9 +920,10 @@ template: \"simple\"
 
 # template: \"template_toolkit\"
 # engines:
-#   template_toolkit:
-#     start_tag: '[%'
-#     end_tag:   '%]'
+#   template:
+#     template_toolkit:
+#       start_tag: '<%'
+#       end_tag:   '%>'
 
 ",
 


### PR DESCRIPTION
Config file changed structure. Fix it.
Also, if template toolkit defaults to [% ... %], no sense to show that as an option in config file.
