### PR TITLE
Implement the code to support the 'startup_info' directive.

### DIFF
--- a/lib/Dancer2/Core/Runner.pm
+++ b/lib/Dancer2/Core/Runner.pm
@@ -136,6 +136,7 @@ sub default_config {
         host         => ($ENV{DANCER_SERVER}       || '0.0.0.0'),
         port         => ($ENV{DANCER_PORT}         || '3000'),
         is_daemon    => ($ENV{DANCER_DAEMON}       || 0),
+        startup_info => ($ENV{DANCER_STARTUP_INFO} || 0),
         appdir       => $self->location,
         import_warnings => 1,
     };

--- a/lib/Dancer2/Core/Server/Standalone.pm
+++ b/lib/Dancer2/Core/Server/Standalone.pm
@@ -5,7 +5,7 @@ package Dancer2::Core::Server::Standalone;
 use Moo;
 use Dancer2::Core::Types;
 with 'Dancer2::Core::Role::Server';
-use HTTP::Server::Simple::PSGI;
+use parent 'HTTP::Server::Simple::PSGI';
 
 =head1 DESCRIPTION
 
@@ -37,12 +37,8 @@ has backend => (
 
 sub _build_backend {
     my $self    = shift;
-    my $backend = HTTP::Server::Simple::PSGI->new($self->port);
-
-    $backend->host($self->host);
-    $backend->app($self->psgi_app);
-
-    return $backend;
+    $self->app($self->psgi_app);
+    return $self;
 }
 
 =method start
@@ -57,6 +53,31 @@ sub start {
     $self->is_daemon
       ? $self->backend->background()
       : $self->backend->run();
+}
+
+=method print_banner
+
+=cut
+
+sub print_banner {
+    my $self = shift;
+    my $pid = $$;
+
+    return unless $self->runner->config->{startup_info};
+
+    print STDERR ">> Dancer v2.$Dancer2::VERSION server pid $pid listening "
+        ."on http://".$self->host.":".$self->port."\n";
+
+    # all loaded plugins
+    foreach my $module ( grep { $_ =~ m{^Dancer2/Plugin/} } keys %INC ) {
+        warn "fjkdsjflsdjflksd";
+        $module =~ s{/}{::}g;  # change / to ::
+        $module =~ s{\.pm$}{}; # remove .pm at the end
+        my $version = $module->VERSION;
+
+        defined $version or $version = 'no version number defined';
+        print STDERR ">> $module ($version)\n";
+    }
 }
 
 1;

--- a/script/dancer2
+++ b/script/dancer2
@@ -959,6 +959,9 @@ show_errors: 1
 # DO NOT EVER USE THIS FEATURE IN PRODUCTION 
 # OR TINY KITTENS SHALL DIE WITH LOTS OF SUFFERING
 auto_reload: 0
+
+# show banner
+startup_info: 1
 ",
 
 'production.yml' =>


### PR DESCRIPTION
By default, if the environment variable DANCER_STARTUP_INFO is not set,
and the setting 'startup_info' is also not set, silence the banner from
HTTP::Server::Simple.  In the case one of the setting is true, display
Dancer's banner with some additional informations.

This is based on the work done by Maurice Mengel.

Closes #210
