### PR TITLE
Cleaning up code that still used `eval "use $class"`.

### DIFF
--- a/lib/Dancer2/Core/DSL.pm
+++ b/lib/Dancer2/Core/DSL.pm
@@ -6,6 +6,7 @@ use Moo;
 use Dancer2::Core::Hook;
 use Dancer2::Core::Error;
 use Dancer2::FileUtils;
+use Dancer2::ModuleLoader;
 use Carp;
 
 with 'Dancer2::Core::Role::DSL';
@@ -147,8 +148,8 @@ sub load_app {
     my ($self, $app_name, %options) = @_;
 
     # set the application
-    eval "use $app_name";
-    croak "Unable to load application \"$app_name\" : $@" if $@;
+    my ($res, $error) = Dancer2::ModuleLoader->load($app_name);
+    $res or croak "Unable to load application \"$app_name\" : $error";
 
     croak "$app_name is not a Dancer2 application"
       if !$app_name->can('dancer_app');

--- a/lib/Dancer2/Core/Runner.pm
+++ b/lib/Dancer2/Core/Runner.pm
@@ -7,6 +7,7 @@ use Dancer2::Core::MIME;
 use Carp 'croak';
 
 use Dancer2::FileUtils;
+use Dancer2::ModuleLoader;
 use File::Basename;
 use File::Spec;
 
@@ -85,8 +86,8 @@ sub _build_server {
     my $server_name  = $self->config->{apphandler};
     my $server_class = "Dancer2::Core::Server::${server_name}";
 
-    eval "use $server_class";
-    croak "Unable to load $server_class : $@" if $@;
+    my ($res, $error) = Dancer2::ModuleLoader->load($server_class);
+    $res or croak "Unable to load $server_class : $error";
 
     return $server_class->new(
         host      => $self->config->{host},


### PR DESCRIPTION
Convert remaining `eval "use $class"` statements to use  `Dancer2::ModuleLoader->load($class)`.
