### PR TITLE
Full config merging support

### DIFF
--- a/lib/Dancer2/Core/Role/Config.pm
+++ b/lib/Dancer2/Core/Role/Config.pm
@@ -19,6 +19,7 @@ use File::Spec;
 use Config::Any;
 use Dancer2::Core::Types;
 use Dancer2::FileUtils qw/dirname path/;
+use Hash::Merge::Simple;
 use Carp 'croak', 'carp';
 
 requires 'location';
@@ -149,14 +150,14 @@ sub _build_config {
     my ($self) = @_;
     my $location = $self->config_location;
 
-    my $config = {};
-    $config = $self->default_config
-      if $self->can('default_config');
+    my $default = {};
+    $default = $self->default_config
+        if $self->can('default_config');
 
-    foreach my $file (@{$self->config_files}) {
-        my $current = $self->load_config_file($file);
-        $config = {%{$config}, %{$current}};
-    }
+    my $config = Hash::Merge::Simple->merge( $default,
+        map {$self->load_config_file($_)}
+            @{$self->config_files}
+    );
 
     $config = $self->_normalize_config($config);
     return $self->_compile_config($config);

--- a/t/config.t
+++ b/t/config.t
@@ -45,7 +45,17 @@ my $location = File::Spec->rel2abs(path(dirname(__FILE__), 'config'));
     use Moo;
     with 'Dancer2::Core::Role::Config';
 
-    sub _build_environment     {"staging"}
+    sub _build_environment     {'staging'}
+    sub location               {$location}
+    sub default_config         { $runner->default_config }
+
+    package Merging;
+    use Moo;
+    with 'Dancer2::Core::Role::Config';
+
+    sub name {'Merging'}
+
+    sub _build_environment     {'merging'}
     sub location               {$location}
     sub default_config         { $runner->default_config }
 
@@ -87,6 +97,16 @@ like(
     exception { $fail->config },
     qr{YAML}, 'Configuration file parsing failure',
 );
+
+note "config merging";
+my $m = Merging->new;
+# Check the 'application' top-level key; its the only key that
+# is currently a HoH in the test configurations
+is_deeply $m->config->{application},
+  { some_feature    => 'bar',
+    another_setting => 'baz',
+  },
+  "full merging of configuration hashes";
 
 note "config parsing";
 

--- a/t/config/config.yml
+++ b/t/config/config.yml
@@ -1,3 +1,6 @@
 main: 1
 charset: 'UTF-8'
 show_errors: 1
+
+application:
+   some_feature: foo

--- a/t/config/environments/merging.yml
+++ b/t/config/environments/merging.yml
@@ -1,0 +1,3 @@
+application:
+  some_feature: bar
+  another_setting: baz


### PR DESCRIPTION
Use Hash::Merge::Simple to recursively merge configuration hashes.
While this adds another dependency, Hash::Merge::Simple is the hash
merging code from Catalyst::Utils with appropriate attribution..

Closes #31 and #221.
