### PR TITLE
Remove perltidy warnings

### DIFF
--- a/xt/perltidy.rc
+++ b/xt/perltidy.rc
@@ -25,7 +25,7 @@
 -ci=2 # Continuation indent is 2 cols
 
 # we use version control, so just rewrite the file
--b
+# -b # -- should not be active for dzil plugin
 
 ## for the up-tight folk :)
 #-pt=2 # High parenthesis tightness


### PR DESCRIPTION
The latest perltidy configuration added by @sukria creates tons of warnings like these ones:

```
Ignoring -b; you may not specify a destination stream and -b together
Ignoring -b; you may not specify a source array and -b together
```

I think the configuration file was used standalone, and the `-b` option should be turned off when using as a dzil plugin.
This pull request just comments that `-b` in the configuration file.
