### PR TITLE
Remove multiple definition of `core_debug'.

### DIFF
--- a/lib/Dancer2.pm
+++ b/lib/Dancer2.pm
@@ -190,13 +190,14 @@ L<Data::Dumper>
 =cut
 
 sub core_debug {
+    return unless $ENV{DANCER_DEBUG_CORE};
+
     my $msg = shift;
     my (@stuff) = @_;
 
     my $vars = @stuff ? Dumper( \@stuff ) : '';
 
     my ( $package, $filename, $line ) = caller;
-    return unless $ENV{DANCER_DEBUG_CORE};
 
     chomp $msg;
     print STDERR "core: $msg\n$vars";

--- a/lib/Dancer2/Core/DSL.pm
+++ b/lib/Dancer2/Core/DSL.pm
@@ -24,7 +24,6 @@ sub dsl_keywords {
         [ context              => 0 ],
         [ cookie               => 0 ],
         [ cookies              => 0 ],
-        [ core_debug           => 1 ],
         [ dance                => 1 ],
         [ dancer_app           => 1 ],
         [ dancer_version       => 1 ],
@@ -391,14 +390,6 @@ sub to_dumper {
 }
 
 sub log { shift->app->log(@_) }
-
-sub core_debug {
-    my $msg = shift;
-    return unless $ENV{DANCER_DEBUG_CORE};
-
-    chomp $msg;
-    print STDERR "core: $msg\n";
-}
 
 =head1 SEE ALSO
 

--- a/lib/Dancer2/Core/Role/DSL.pm
+++ b/lib/Dancer2/Core/Role/DSL.pm
@@ -63,7 +63,7 @@ sub _compile_keyword {
     my ( $self, $keyword, $is_global ) = @_;
 
     my $compiled_code = sub {
-        core_debug( "["
+        Dancer2::core_debug( "["
               . $self->app->name
               . "] -> $keyword("
               . join( ', ', map { defined() ? $_ : '<undef>' } @_ )
@@ -95,15 +95,6 @@ sub _construct_export_map {
         $map{$keyword} = $self->_compile_keyword( $keyword, $is_global );
     }
     return \%map;
-}
-
-# TODO move that elsewhere
-sub core_debug {
-    my $msg = shift;
-    return unless $ENV{DANCER_DEBUG_CORE};
-
-    chomp $msg;
-    print STDERR "core: $msg\n";
 }
 
 1;


### PR DESCRIPTION
The function `core_debug' was implemented in three different places, each time
with a slighly different definition.

The only definition we keep is the one in Dancer2, and we don't need to export
it in the DSL, since this sould be used _only_ by Dancer2.
