### PR TITLE
Display custom 500 page/template on internal server errors

### DIFF
--- a/lib/Dancer2/Core/Dispatcher.pm
+++ b/lib/Dancer2/Core/Dispatcher.pm
@@ -159,10 +159,7 @@ sub response_internal_error {
     return Dancer2::Core::Error->new(
         context      => $context,
         status       => 500,
-        title        => 'Internal Server Error',
-        content      => "Internal Server Error",
         exception    => $error,
-        content_type => 'text/plain'
     )->throw;
 }
 

--- a/t/dispatcher.t
+++ b/t/dispatcher.t
@@ -172,8 +172,8 @@ foreach my $test (
         },
         expected => [
             500,
-            [ 'Content-Length', "Content-Type", 'text/plain' ],
-            qr{^Internal Server Error\n\nCan't locate object method "fail" via package "Fail" \(perhaps you forgot to load "Fail"\?\) at t/dispatcher\.t line \d+.*$}s
+            [ 'Content-Length', "Content-Type", 'text/html' ],
+            qr{Internal Server Error.*Can't locate object method "fail" via package "Fail" \(perhaps you forgot to load "Fail"\?\) at t/dispatcher\.t line \d+.*$}ms
         ]
     }
   )


### PR DESCRIPTION
Populating the Core::Error object for an internal server error
(status 500) with content in the Dispatcher was short circuiting
the logic in Core::Error that looks for a puplic/500.html or similar
views template.

Resolves #86.
