### PR TITLE
The request and response are able to (de)serialize data by themeselves.

### DIFF
--- a/lib/Dancer2/Core/Context.pm
+++ b/lib/Dancer2/Core/Context.pm
@@ -54,7 +54,11 @@ has request => (
 
 sub _build_request {
     my ($self) = @_;
-    Dancer2::Core::Request->new( env => $self->env );
+    my $req = Dancer2::Core::Request->new( env => $self->env );
+    if (defined $self->app && defined $self->app->config->{serializer}) {
+        $req->serializer($self->app->config->{serializer});
+    }
+    return $req;
 }
 
 # a buffer for per-request variables
@@ -104,7 +108,14 @@ A L<Dancer2::Core::Response> object, used to set content, headers and HTTP statu
 has response => (
     is      => 'rw',
     isa     => InstanceOf ['Dancer2::Core::Response'],
-    default => sub { Dancer2::Core::Response->new },
+    lazy    => 1,
+    default => sub {
+        my $self = shift;
+        my $resp = Dancer2::Core::Response->new;
+        $resp->serializer($self->app->config->{serializer})
+            if $self->app->config->{serializer};
+        return $resp;
+    },
 );
 
 =method cookies

--- a/lib/Dancer2/Core/Dispatcher.pm
+++ b/lib/Dancer2/Core/Dispatcher.pm
@@ -60,8 +60,13 @@ sub dispatch {
 
             $context->request->_set_route_params($match);
 
-            $context->request->deserialize
-              if $context->request->serializer( $app->settings->{serializer} );
+            if ($context->request->has_serializer) {
+                $context->request->deserialize;
+                if ($context->request->serializer->has_error) {
+                    $app->log("core" => "Failed to deserialize the request : "
+                                  .$context->request->serializer->error);
+                }
+            }
 
    # if the request has been altered by a before filter, we should not continue
    # with this route handler, we should continue to walk through the
@@ -75,7 +80,6 @@ sub dispatch {
 
             my $content;
             if ( $response->is_halted ) {
-
                 # if halted, it comes from the 'before' hook. Take its content
                 $content = $response->content;
             }
@@ -104,17 +108,6 @@ sub dispatch {
                 $response = $context->response($content);
             }
             else {
-
-                # serialize if needed
-                # TODO make the response object self-serializable? With a
-                # is_serialized attribute
-                if ( my $serializer =
-                    ref($content) && $app->config->{serializer} )
-                {
-                    $content = $serializer->serialize($content);
-                    $response->content_type( $serializer->content_type );
-                }
-
                 $response->content( defined $content ? $content : '' );
                 $response->encode_content;
             }

--- a/lib/Dancer2/Core/Request.pm
+++ b/lib/Dancer2/Core/Request.pm
@@ -413,9 +413,10 @@ parameters
 =cut
 
 has serializer => (
-    is       => 'rw',
-    isa      => Maybe( ConsumerOf ['Dancer2::Core::Role::Serializer'] ),
-    required => 0,
+    is        => 'rw',
+    isa       => Maybe( ConsumerOf ['Dancer2::Core::Role::Serializer'] ),
+    required  => 0,
+    predicate => 1,
 );
 
 =method data()
@@ -448,12 +449,8 @@ sub deserialize {
       unless grep { $self->method eq $_ } qw/ PUT POST PATCH /;
 
     # try to deserialize
-    my $data = eval { $self->serializer->deserialize( $self->body ) };
-    if ($@) {
-
-        # TODO add logging
-        return;
-    }
+    my $data = $self->serializer->deserialize($self->body);
+    return if !defined $data;
 
     $self->{_body_params} = $data;
 

--- a/t/serializer_json.t
+++ b/t/serializer_json.t
@@ -22,4 +22,12 @@ for my $test (@tests) {
     is( $actual, $expected );
 }
 
+use Dancer2::Core::Response;
+my $resp = Dancer2::Core::Response->new(
+    content => '---',
+    serializer => Dancer2::Serializer::JSON->new(),
+);
+
+$resp->serialize();
+
 done_testing();


### PR DESCRIPTION
This change makes the API for the request and response object to be a little
more identical when it comes to (de)serialization of data.

The main addition is the attribute 'serializer' to the Response object.  When
the content is set on this object, it will verify if a serializer is set and
if the data needs to be serialized (e.g.: do we have a ref ?).  If that's the
case the serialization will be done from the object itself, and the dispatcher
does not have to deal with it.

An attribute 'error' is added to the role 'Serializer', where a message is
stored in case of an error while dealing with the data, and a message is
logged.
