### PR TITLE
Clean up "Dancer::" references from dist.ini

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -24,8 +24,8 @@ add_files_in = README.md
 [@Dancer]
 ; Required version of the bundle
 :version = 0.0004
-test_compile_skip = ^(.*\.pod$|Dancer::(?:Serializer|Session)::YAML)$
-autoprereqs_skip = ^t::lib::|^t::app::|XS$|^Dancer$
+test_compile_skip = ^.*\.pod$
+autoprereqs_skip = ^t::lib::|^t::app::|XS$
 
 ; -- static meta-information
 [MetaResources]
@@ -78,7 +78,7 @@ Template::Tiny = 0
 JSON::XS = 0
 ; Used for PSGI
 Plack::Request = 0
-; Developers are expected to write tests and so use Dancer::Test
+; Developers are expected to write tests and so use Dancer2::Test
 ; that depends on Test::More. So Test::More is needed for more than
 ; just tests of the Dancer distribution
 Test::More = 0
@@ -94,7 +94,7 @@ Pod::Simple::Search = 0
 Pod::Simple::SimpleTree = 0
 
 [Prereqs / Suggests]
-; Used by Dancer::Session::YAML
+; Used by Dancer2::Session::YAML
 YAML::Any = 0
 Fcntl = 0
 


### PR DESCRIPTION
No need to be skipping the test compile for `Dancer::*::YAML` modules after the namespace change to Dancer2.

Plus s/Dancer/Dancer2/ in a couple of comments.
