### PR TITLE
Mickey/route fixes

### DIFF
--- a/lib/Dancer2/Core/Route.pm
+++ b/lib/Dancer2/Core/Route.pm
@@ -41,7 +41,7 @@ Required. Coerce from Dancer2's route I<patterns>.
 =cut
 
 has regexp => (
-    is       => 'rw',
+    is       => 'ro',
     required => 1,
 );
 
@@ -90,7 +90,7 @@ sub _check_options {
 # private attributes
 
 has _should_capture => (
-    is  => 'rw',
+    is  => 'ro',
     isa => Bool,
 );
 
@@ -103,7 +103,7 @@ has _match_data => (
 );
 
 has _params => (
-    is      => 'rw',
+    is      => 'ro',
     isa     => ArrayRef,
     default => sub { [] },
 );


### PR DESCRIPTION
- a regexp wasn't checked for leading slash (with prefix concatenation can lead to weird results)
- _init_prefix was running an unsuccessful check of the route and prefix which was problematic because 1. it wasn't done right (testing compiled regex against regex string) and 2. was meant to silently ignore route definitions that started with the prefix (thus making sure "/admin/adminuser" will not work and the user will not even know about it)
- a bunch of small fixes to correct, clean and move _init_prefix and _init_regexp functionality to BUILDARGS instead of BUILD to allow the attributes: regexp, spec_route, _params, _should_capture to become 'ro' as they should be.
