### PR TITLE
Cleanup duplicate HTTP status codes between Core::Error and Core::HTTP

### DIFF
--- a/lib/Dancer2/Core/Error.pm
+++ b/lib/Dancer2/Core/Error.pm
@@ -4,6 +4,7 @@ package Dancer2::Core::Error;
 use Moo;
 use Carp;
 use Dancer2::Core::Types;
+use Dancer2::Core::HTTP;
 use Data::Dumper;
 use Dancer2::FileUtils 'path';
 
@@ -34,67 +35,12 @@ Create a new Dancer2::Core::Error object. For available arguments see ATTRIBUTES
 
 =cut
 
-my %error_title = (
-    400 => "Bad Request",
-    401 => "Unauthorized",
-    402 => "Payment Required",
-    403 => "Forbidden",
-    404 => "Not Found",
-    405 => "Method Not Allowed",
-    406 => "Not Acceptable",
-    407 => "Proxy Authentication Required",
-    408 => "Request Timeout",
-    409 => "Conflict",
-    410 => "Gone",
-    411 => "Length Required",
-    412 => "Precondition Failed",
-    413 => "Request Entity Too Large",
-    414 => "Request-URI Too Long",
-    415 => "Unsupported Media Type",
-    416 => "Requested Range Not Satisfiable",
-    417 => "Expectation Failed",
-    418 => "I'm a teapot",
-    420 => "Enhance Your Calm",
-    422 => "Unprocessable Entity",
-    423 => "Locked",
-    424 => "Failed Dependency",
-    424 => "Method Failure",
-    425 => "Unordered Collection",
-    426 => "Upgrade Required",
-    428 => "Precondition Required",
-    429 => "Too Many Requests",
-    431 => "Request Header Fields Too Large",
-    444 => "No Response",
-    449 => "Retry With",
-    450 => "Blocked by Windows Parental Controls ",
-    451 => "Unavailable For Legal Reasons ",
-    451 => "Redirect",
-    494 => "Request Header Too Large ",
-    495 => "Cert Error",
-    496 => "No Cert ",
-    497 => "HTTP to HTTPS",
-    499 => "Client Closed Request",
-    500 => "Internal Server Error",
-    501 => "Not Implemented",
-    502 => "Bad Gateway",
-    503 => "Service Unavailable",
-    504 => "Gateway Timeout",
-    505 => "HTTP Version Not Supported",
-    506 => "Variant Also Negotiates ",
-    507 => "Insufficient Storage ",
-    508 => "Loop Detected ",
-    509 => "Bandwidth Limit Exceeded ",
-    510 => "Not Extended",
-    511 => "Network Authentication Required ",
-    598 => "Network read timeout error ",
-    599 => "Network connect timeout error ",
-);
-
 =method supported_hooks ();
 
 =cut
 
 =attr show_errors
+
 =cut
 
 has show_errors => (
@@ -144,8 +90,9 @@ has title => (
 sub _build_title {
     my ($self) = @_;
     my $title = 'Error ' . $self->status;
-    $title .= ' - ' . $error_title{ $self->status }
-      if $error_title{ $self->status };
+    if ( my $msg = Dancer2::Core::HTTP->status_message($self->status) ) {
+        $title .= ' - ' . $msg;
+    }
 
     return $title;
 }

--- a/lib/Dancer2/Core/HTTP.pm
+++ b/lib/Dancer2/Core/HTTP.pm
@@ -8,30 +8,31 @@ use warnings;
 my $HTTP_CODES = {
 
     # informational
-    # 100 => 'Continue', # only on HTTP 1.1
-    # 101 => 'Switching Protocols', # only on HTTP 1.1
+    100 => 'Continue',               # only on HTTP 1.1
+    101 => 'Switching Protocols',    # only on HTTP 1.1
+    102 => 'Processing',             # WebDAV; RFC 2518
 
-    # processed codes
+    # processed
     200 => 'OK',
     201 => 'Created',
     202 => 'Accepted',
-
-    # 203 => 'Non-Authoritative Information', # only on HTTP 1.1
+    203 => 'Non-Authoritative Information', # only on HTTP 1.1
     204 => 'No Content',
     205 => 'Reset Content',
     206 => 'Partial Content',
+    207 => 'Multi-Status',           # WebDAV; RFC 4918
+    208 => 'Already Reported',       # WebDAV; RFC 5842
+    # 226 => 'IM Used'               # RFC 3229
 
     # redirections
     301 => 'Moved Permanently',
     302 => 'Found',
-
-    # 303 => '303 See Other', # only on HTTP 1.1
+    303 => '303 See Other',          # only on HTTP 1.1
     304 => 'Not Modified',
-
-    # 305 => '305 Use Proxy', # only on HTTP 1.1
+    305 => '305 Use Proxy',          # only on HTTP 1.1
     306 => 'Switch Proxy',
-
-    # 307 => '307 Temporary Redirect', # on HTTP 1.1
+    307 => 'Temporary Redirect',     # only on HTTP 1.1
+    # 308 => 'Permanent Redirect'    # approved as experimental RFC
 
     # problems with request
     400 => 'Bad Request',
@@ -52,6 +53,27 @@ my $HTTP_CODES = {
     415 => 'Unsupported Media Type',
     416 => 'Requested Range Not Satisfiable',
     417 => 'Expectation Failed',
+    418 => "I'm a teapot",             # RFC 2324
+    # 419 => 'Authentication Timeout', # not in RFC 2616
+    420 => 'Enhance Your Calm',
+    422 => 'Unprocessable Entity',
+    423 => 'Locked',
+    424 => 'Failed Dependency',        # Also used for 'Method Failure'
+    425 => 'Unordered Collection',
+    426 => 'Upgrade Required',
+    428 => 'Precondition Required',
+    429 => 'Too Many Requests',
+    431 => 'Request Header Fields Too Large',
+    444 => 'No Response',
+    449 => 'Retry With',
+    450 => 'Blocked by Windows Parental Controls',
+    451 => 'Unavailable For Legal Reasons',
+    451 => 'Redirect',
+    494 => 'Request Header Too Large',
+    495 => 'Cert Error',
+    496 => 'No Cert',
+    497 => 'HTTP to HTTPS',
+    499 => 'Client Closed Request',
 
     # problems with server
     500 => 'Internal Server Error',
@@ -60,6 +82,14 @@ my $HTTP_CODES = {
     503 => 'Service Unavailable',
     504 => 'Gateway Timeout',
     505 => 'HTTP Version Not Supported',
+    506 => 'Variant Also Negotiates',
+    507 => 'Insufficient Storage',
+    508 => 'Loop Detected',
+    509 => 'Bandwidth Limit Exceeded',
+    510 => 'Not Extended',
+    511 => 'Network Authentication Required',
+    598 => 'Network read timeout error',
+    599 => 'Network connect timeout error',
 };
 
 for my $code ( keys %$HTTP_CODES ) {
@@ -88,11 +118,30 @@ status.
 
 sub status {
     my ( $class, $status ) = @_;
+    return if ! defined $status;
     return $status if $status =~ /^\d+/;
     if ( exists $HTTP_CODES->{$status} ) {
         return $HTTP_CODES->{$status};
     }
     return undef;
+}
+
+=func status_message(status_code)
+
+    Dancer2::Core::HTTP->status_message(200); # returns 'OK'
+
+    Dancer2::Core::HTTP->status_message('error'); # returns 'Internal Server Error'
+
+Returns the HTTP status message for the given status code.
+
+=cut
+
+sub status_message {
+    my ( $class, $status ) = @_;
+    return if ! defined $status;
+    my $code = $class->status($status);
+    return if ! defined $code || ! exists $HTTP_CODES->{$code};
+    return $HTTP_CODES->{ $code };
 }
 
 1;

--- a/t/http_status.t
+++ b/t/http_status.t
@@ -1,0 +1,44 @@
+use strict;
+use warnings;
+use Test::More tests => 11;
+
+use Dancer2::Core::HTTP;
+
+note "HTTP status"; {
+    my @tests = (
+        { status => undef,          expected => undef },
+        { status => 200,            expected => 200   },
+        { status => 'Not Found',    expected => 404   },
+        { status => 'bad_request',  expected => 400   },
+        { status => 'i_m_a_teapot', expected => 418   },
+        { status => 'error',        expected => 500   },
+        { status => 911,            expected => 911   },
+    );
+
+    for my $test (@tests) {
+        my $status_text = defined $test->{status}
+            ? $test->{status} : 'undef'; 
+        is( Dancer2::Core::HTTP->status( $test->{status} ),
+            $test->{expected},
+            "HTTP status looks good for $status_text" );
+    }
+}
+
+
+note "HTTP status_message"; {
+    my @tests = (
+        { status => undef,   expected => undef                   },
+        { status => 200,     expected => 'OK'                    },
+        { status => 'error', expected => 'Internal Server Error' },
+        { status => 911,     expected => undef                   },
+    );
+
+    for my $test (@tests) {
+        my $status_text = defined $test->{status}
+            ? $test->{status} : 'undef'; 
+        is( Dancer2::Core::HTTP->status_message( $test->{status} ),
+            $test->{expected},
+            "HTTP status message looks good for $status_text" );
+    }
+}
+


### PR DESCRIPTION
Consolidate the list of HTTP status codes into Core::HTTP, add tests.

ALso adds a helper to return the http status message for a given status code.
(Used in Core::Error in place of the list of error codes.)
