### PR TITLE
Add Request->dispatch_path and use that for route matching.

### DIFF
--- a/lib/Dancer2/Core/Request.pm
+++ b/lib/Dancer2/Core/Request.pm
@@ -671,6 +671,30 @@ sub uri_base {
     return $canon;
 }
 
+=method dispatch_path()
+
+The part of the C<path> after C<base>. This is the path used
+for dispatching the request to routes.
+
+=cut
+
+sub dispatch_path {
+    my $self = shift;
+
+    my $path = $self->path;
+
+    # Want $self->base->path, without needing the URI object,
+    # and trim any trailing '/'.
+    my $base = '';
+    $base .= $self->script_name if defined $self->script_name;
+    $base =~ s|/+$||;
+
+    # Remove base from fron of path.
+    $path =~ s|^(\Q$base\E)?||;
+    $path =~ s|^/+|/|;
+    return $path;
+}
+
 =method uri_for(path, params)
 
 Constructs a URI from the base and the passed path.  If params (hashref) is

--- a/lib/Dancer2/Core/Route.pm
+++ b/lib/Dancer2/Core/Route.pm
@@ -126,7 +126,7 @@ sub match {
     }
 
     my %params;
-    my @values = $request->path =~ $self->regexp;
+    my @values = $request->dispatch_path =~ $self->regexp;
 
     # the regex comments are how we know if we captured
     # a splat or a megasplat

--- a/t/request.t
+++ b/t/request.t
@@ -124,6 +124,7 @@ sub run_test {
     is( $req->uri_base, 'http://localhost:5000/foo/',
         'keeping trailing slash if not only',
     );
+    is $req->dispatch_path, '/bar/baz';
 
     $env->{'PATH_INFO'}   = '/';
     $env->{'SCRIPT_NAME'} = '';


### PR DESCRIPTION
Dispatch "should" be done on the "path you would append to Request->base",
but its currently being done on the "full" path. Altering Request->path to
match this behaviour is likely to cause backward compatibility issues..

Add a request->dispatch_path method to calculate the path to be used for
dispatch and use that in route->match.

Closes #373.
