### PR TITLE
Move request deserialization from Dispatcher to Content & Request.

### DIFF
--- a/lib/Dancer2/Core/Dispatcher.pm
+++ b/lib/Dancer2/Core/Dispatcher.pm
@@ -64,14 +64,6 @@ sub dispatch {
 
             $context->request->_set_route_params($match);
 
-            if ($context->request->has_serializer) {
-                $context->request->deserialize;
-                if ($context->request->serializer->has_error) {
-                    $app->log( core => "Failed to deserialize the request : "
-                                  .$context->request->serializer->error);
-                }
-            }
-
    # if the request has been altered by a before filter, we should not continue
    # with this route handler, we should continue to walk through the
    # rest

--- a/t/deserialize.t
+++ b/t/deserialize.t
@@ -1,7 +1,7 @@
 use strict;
 use warnings;
 
-use Test::More tests => 6;
+use Test::More tests => 5;
 
 {
 
@@ -52,15 +52,16 @@ my $r    = dancer_response(
 my $content = Encode::decode( 'UTF-8', $r->content );
 is( $content, "utf8 : $utf8", 'utf-8 string returns the same' );
 
-my $req = Dancer2::Core::Request->new(
-    method       => 'PUT',
-    path         => '/from_params',
-    content_type => 'application/json',
-    body         => "---",
-    serializer   => Dancer2::Serializer::JSON->new(),
-);
+note 'Check serialization errors'; {
+    my $serializer = Dancer2::Serializer::JSON->new();
+    my $req = Dancer2::Core::Request->new(
+        method       => 'PUT',
+        path         => '/from_params',
+        content_type => 'application/json',
+        body         => "---",
+        serializer   => $serializer,
+    );
 
-ok !$req->serializer->has_error;
-$req->deserialize();
-ok $req->serializer->has_error;
-like $req->serializer->error, qr/malformed number/;
+    ok $req->serializer->has_error, "Invalid JSON threw error in serializer";
+    like $req->serializer->error, qr/malformed number/, ".. of a 'malformed number'";
+}


### PR DESCRIPTION
Add the serialization engine to the Request object when built from within
the Context, rather than doing it later from within the Dispatcher.

Deserialization then occurs when the Request object is instantiated.

Closes #369.
