### PR TITLE
Catch case when heuristic for Runner location gives '' as subdir.

### DIFF
--- a/lib/Dancer2/Core/Runner.pm
+++ b/lib/Dancer2/Core/Runner.pm
@@ -103,7 +103,7 @@ sub _build_location {
             last;
         }
 
-        $subdir = Dancer2::FileUtils::path( $subdir, '..' );
+        $subdir = Dancer2::FileUtils::path( $subdir, '..' ) || '.';
         last if File::Spec->rel2abs($subdir) eq File::Spec->rootdir;
 
     }


### PR DESCRIPTION
The test suit starts of with caller of the test case, such as t/runner.t
That is converted to the dirname 't'. The heuristic for calculating the
location looks for 't/bin' which doesn't exist, so tries again at 't/..'.
However FileUtils::normalize_path('t/..') now returns the empty string ''.

Next time through the loop, it was asserting if '/bin' and '/lib' exist,
which do on debian based boxen exiting the for loop. The relative path ''
was then made absolute to the cwd, making it look like travis was ignoring
the 't' directory. (To reproduce the travis failure under OS X, ensure
/lib exists.)

If the subdir becomes empty, converting it to '.' fixes the issue.
