### PR TITLE
Bugfix Request->dispatch_path when env->{PATH_INFO} is empty.

### DIFF
--- a/lib/Dancer2/Core/Request.pm
+++ b/lib/Dancer2/Core/Request.pm
@@ -684,9 +684,11 @@ sub dispatch_path {
     $base .= $self->script_name if defined $self->script_name;
     $base =~ s|/+$||;
 
-    # Remove base from fron of path.
+    # Remove base from front of path.
     $path =~ s|^(\Q$base\E)?||;
     $path =~ s|^/+|/|;
+    # PSGI spec notes that '' should be considered '/'
+    $path = '/' if $path eq '';
     return $path;
 }
 


### PR DESCRIPTION
In #329 @xsawyerx pointed out an edge case in which Request->dispatch_path
was being incorrectly calculated. Convert `''` to `'/'` to cover this case.

Update the request tests to cover all combinations (allowable in the PSGI
spec) of SCRIPT_NAME, PATH_INFO and REQUEST_URI being empty and/or set.
