### PR TITLE
Use Class::Load(::XS)

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -23,7 +23,7 @@ add_files_in = README.md
 
 [@Dancer]
 ; Required version of the bundle
-:version = 0.0006
+:version = 0.0007
 autoprereqs_skip = ^t::lib::|^t::app::|XS$
 
 ; -- static meta-information
@@ -72,6 +72,7 @@ JSON = 0
 URI::Escape = 0
 parent = 0
 Template::Tiny = 0
+Class::Load = 0
 
 
 [Prereqs / Recommends]
@@ -98,6 +99,7 @@ Pod::Simple::SimpleTree = 0
 ; Used by Dancer2::Session::YAML
 YAML::Any = 0
 Fcntl = 0
+Class::Load::XS = 0
 
 ; -- test requirements
 [Prereqs / TestRequires]

--- a/lib/Dancer2/ModuleLoader.pm
+++ b/lib/Dancer2/ModuleLoader.pm
@@ -5,7 +5,7 @@ package Dancer2::ModuleLoader;
 use strict;
 use warnings;
 
-use Module::Runtime qw/ use_module /;
+use Class::Load 'try_load_class';
 
 =head1 DESCRIPTION
 
@@ -84,11 +84,7 @@ In list context, returns 1 if successful, C<(0, "error message")> if not.
 sub require {
     my ( $class, $module, $version ) = @_;
 
-    eval {
-        defined $version
-          ? use_module( $module, $version )
-          : use_module($module);
-    }
+    try_load_class( $module, defined $version ? ( -version => $version ) : ())
       or return wantarray ? ( 0, $@ ) : 0;
 
     return 1;


### PR DESCRIPTION
Our Module::Loader does things Class::Load doesn't.

But:
- Class::Load uses Module::Runtime, that we used before, therefore, it should be slower than before (one more indirection layer)
- Class::Load can use Class::Load::XS if it is installed, but not sure how faster it will run

So, I am not sure of the relevance of this change.
