### PR TITLE
Generate simple app.psgi from dancer2 script. do() it from bin/app.pl

### DIFF
--- a/lib/Dancer2/Cookbook.pod
+++ b/lib/Dancer2/Cookbook.pod
@@ -56,6 +56,7 @@ command:
 
     $ dancer2 -a mywebapp
     + mywebapp
+    + mywebapp/app.psgi
     + mywebapp/bin
     + mywebapp/bin/app.pl
     + mywebapp/config.yml
@@ -866,7 +867,7 @@ you want to make your app available to the world, it probably won't suit you.
 To edit your files without the need to restart the webserver on each file change,
 simply start your Dancer2 app using L<plackup> and L<Plack::Loader::Shotgun>:
 
-    $ plackup -L Shotgun bin/app.pl
+    $ plackup -I lib -L Shotgun app.psgi
     HTTP::Server::PSGI: Accepting connections at http://0:5000/
 
 Point your browser at it. Files can now be changed in your favorite editor and
@@ -1008,7 +1009,7 @@ This example configuration uses TCP/IP:
 
 Launch your application:
 
-    plackup -s FCGI --port 5000 bin/app.pl
+    plackup -I lib -s FCGI --port 5000 app.psgi
 
 This example configuration uses a socket:
 
@@ -1025,7 +1026,7 @@ This example configuration uses a socket:
 
 Launch your application:
 
-    plackup -s FCGI --listen /tmp/fcgi.sock bin/app.pl
+    plackup -I lib -s FCGI --listen /tmp/fcgi.sock app.psgi
 
 
 =head2 Plack middlewares
@@ -1097,8 +1098,8 @@ C<Corona> is a C<Coro> based web server.
 To start your application, just run plackup (see L<Plack> and specific servers
 above for all available options):
 
-   $ plackup bin/app.pl
-   $ plackup -E deployment -s Starman --workers=10 -p 5001 -a bin/app.pl
+   $ plackup -I lib app.psgi
+   $ plackup -I lib -E deployment -s Starman --workers=10 -p 5001 -a app.psgi
 
 As you can see, the scaffolded Perl script for your app can be used as a PSGI
 startup file.
@@ -1114,13 +1115,12 @@ Enable it as you would enable any Plack middleware. First you need to install
 L<Plack::Middleware::Deflater>, then in the handler (usually F<app.psgi>) edit
 it to use L<Plack::Builder>, as described above:
 
-    use Dancer2;
     use MyWebApp;
     use Plack::Builder;
 
     builder {
         enable 'Deflator';
-        dance;
+        MyWebApp->dance;
     };
 
 To test if content compression works, trace the HTTP request and response
@@ -1171,7 +1171,7 @@ following:
         <Location />
             SetHandler perl-script
             PerlHandler Plack::Handler::Apache2
-            PerlSetVar psgi_app /websites/myapp.example.com/app.pl
+            PerlSetVar psgi_app /websites/myapp.example.com/app.psgi
         </Location>
 
         ErrorLog  /websites/myapp.example.com/logs/error_log
@@ -1207,7 +1207,7 @@ A basic PSGI service description (usually in /etc/ubic/service/application):
 
     __PACKAGE__->new(
         server => 'Starman',
-        app => '/path/to/your/application/app.pl',
+        app => '/path/to/your/application/app.psgi',
         port => 5000,
         user => 'www-data',
     );
@@ -1227,7 +1227,7 @@ A basic script to start an application: (in /service/application/run)
     export PERL5LIB='/path/to/your/application/lib'
 
     exec 2>&1 \
-    /usr/local/bin/plackup -s Starman -a /path/to/your/application/app.pl -p 5000
+    /usr/local/bin/plackup -s Starman -a /path/to/your/application/app.psgi -p 5000
 
 
 =head2 Running stand-alone behind a proxy / load balancer
@@ -1376,7 +1376,7 @@ with Nginx:
 You will need plackup to start a worker listening on a socket :
 
     cd YOUR_PROJECT_PATH
-    sudo -u www plackup -E production -s Starman --workers=2 -l THE_PATH_OF_YOUR_PLACKUP_SOCKET_HERE.sock -a bin/app.pl
+    sudo -u www plackup -E production -s Starman --workers=2 -l THE_PATH_OF_YOUR_PLACKUP_SOCKET_HERE.sock -a app.psgi
 
 A good way to start this is to use C<daemontools> and place this line
 with all environments variables in the "run" file.

--- a/lib/Dancer2/Manual.pod
+++ b/lib/Dancer2/Manual.pod
@@ -49,7 +49,7 @@ View the web application at:
 Note that as Dancer2 supports the L<PSGI> specification, you can also use the C<plackup> tool
 (provided by L<Plack>) for launching the application:
 
-    plackup ./bin/app.pl -p 5000
+    plackup -Ilib app.psgi -p 5000
 
 =head1 USAGE
 

--- a/script/dancer2
+++ b/script/dancer2
@@ -163,11 +163,13 @@ sub app_tree($) {
     return {
         "Makefile.PL"        => FILE,
         "MANIFEST.SKIP"      => FILE,
+        "app.psgi"           => FILE,
         lib                  => {
-         $LIB_PATH => {
-            $LIB_FILE => FILE,}
+            $LIB_PATH => {
+                $LIB_FILE => FILE,
+            }
         },
-        "bin" => {
+        bin                  => {
             "+app.pl" => FILE,
         },
         "config.yml"         => FILE,
@@ -534,7 +536,7 @@ use Plack::Runner;
 set apphandler => 'PSGI';
 set environment => 'production';
 
-my \$psgi = path(\$RealBin, '..', 'bin', 'app.pl');
+my \$psgi = path(\$RealBin, '..', 'app.psgi');
 die \"Unable to read startup script: \$psgi\" unless -r \$psgi;
 
 Plack::Runner->run(\$psgi);
@@ -553,7 +555,7 @@ use Plack::Handler::FCGI;
 set apphandler => 'PSGI';
 set environment => 'production';
 
-my \$psgi = path(\$RealBin, '..', 'bin', 'app.pl');
+my \$psgi = path(\$RealBin, '..', 'app.psgi');
 my \$app = do(\$psgi);
 die "Unable to read startup script: \$@" if \$@;
 my \$server = Plack::Handler::FCGI->new(nproc => 5, detach => 1);
@@ -563,10 +565,31 @@ my \$server = Plack::Handler::FCGI->new(nproc => 5, detach => 1);
 
 "app.pl" =>
 
-"$PERL_INTERPRETER
-use Dancer2;
-use $appname;
-dance;
+qq{$PERL_INTERPRETER
+use warnings;
+use strict;
+use lib;
+use FindBin '\$Bin';
+use Dancer2::FileUtils qw/path/;
+
+# Check for lib dir
+if (
+    grep
+      { -f path( \$Bin, '..', \$_ ) }
+        qw/.dancer Makefile.PL/
+) {
+    my \$lib = path(\$Bin, '..', 'lib');
+    -d \$lib && lib->import(\$lib);
+}
+
+my \$psgi_file = path(\$Bin, '..', 'app.psgi');
+do(\$psgi_file) or die "Unable to read app.psgi: \$@";
+},
+
+"app.psgi" =>
+
+"use $appname;
+$appname->dance;
 ",
 
 "$LIB_FILE" =>
@@ -1484,6 +1507,7 @@ Here is an application created with dancer2:
 
     $ dancer2 -a MyWeb::App
     + MyWeb-App
+	+ MyWeb-App/app.psgi
 	+ MyWeb-App/bin
 	+ MyWeb-App/bin/app.pl
 	+ MyWeb-App/config.yml


### PR DESCRIPTION
As noted in #374, generate `./app.psgi`, and revise the content of the generated `bin/app.pl` to add
"../lib" to @INC then do() the new `app.psgi` file. i.e. logic similar to the now deleted ModuleLoader->use_lib (@xsaywerx++) was added to `bin/app.pl`; it's a more sane place for those who prefer the inbuilt server over
plackup.
