### PR TITLE
Remove Core::debug

### DIFF
--- a/lib/Dancer2.pm
+++ b/lib/Dancer2.pm
@@ -167,14 +167,10 @@ sub import {
         postponed_hooks => $server->postponed_hooks,
     );
 
-    Dancer2::Core::debug("binding import method to $caller");
     _set_import_method_to_caller($caller);
 
     # register the app within the runner instance
-    Dancer2::Core::debug("binding app to $caller");
     $server->register_application($app);
-
-    Dancer2::Core::debug("exporting DSL symbols for $caller");
 
     # load the DSL, defaulting to Dancer2::Core::DSL
     load_class( $final_args{dsl} );

--- a/lib/Dancer2/Core.pm
+++ b/lib/Dancer2/Core.pm
@@ -5,27 +5,6 @@ package Dancer2::Core;
 use strict;
 use warnings;
 
-=func debug
-
-Output a message to STDERR and take further arguments as some data structures using 
-L<Data::Dumper>
-
-=cut
-
-sub debug {
-    return unless $ENV{DANCER_DEBUG_CORE};
-
-    my $msg = shift;
-    my (@stuff) = @_;
-
-    my $vars = @stuff ? Dumper( \@stuff ) : '';
-
-    my ( $package, $filename, $line ) = caller;
-
-    chomp $msg;
-    print STDERR "core: $msg\n$vars";
-}
-
 =func camelize
 
 Camelize a underscore-separated-string.

--- a/lib/Dancer2/Core/App.pm
+++ b/lib/Dancer2/Core/App.pm
@@ -254,7 +254,7 @@ sub api_version {2}
 
 sub register_plugin {
     my ( $self, $plugin ) = @_;
-    Dancer2::Core::debug("Registered $plugin");
+    $self->log( debug => "Registered $plugin");
     push @{ $self->plugins }, $plugin;
 }
 

--- a/lib/Dancer2/Core/Role/DSL.pm
+++ b/lib/Dancer2/Core/Role/DSL.pm
@@ -66,14 +66,7 @@ sub export_symbols_to {
 sub _compile_keyword {
     my ( $self, $keyword, $is_global ) = @_;
 
-    my $compiled_code = sub {
-        Dancer2::Core::debug( "["
-              . $self->app->name
-              . "] -> $keyword("
-              . join( ', ', map { defined() ? $_ : '<undef>' } @_ )
-              . ")" );
-        $self->$keyword(@_);
-    };
+    my $compiled_code = sub { $self->$keyword(@_); };
 
     if ( !$is_global ) {
         my $code = $compiled_code;

--- a/lib/Dancer2/Core/Role/Hookable.pm
+++ b/lib/Dancer2/Core/Role/Hookable.pm
@@ -67,7 +67,6 @@ sub _add_postponed_hooks {
         $h_type = 'engine';
     }
 
-#    Dancer2::Core::debug("looking for hooks for $h_type/$h_name");
     # keep only the hooks we want
     $postponed_hooks = $postponed_hooks->{$h_type}{$h_name};
     return unless defined $postponed_hooks;
@@ -80,7 +79,6 @@ sub _add_postponed_hooks {
           or croak "$h_name $h_type does not support the hook `$name'. ("
           . join( ", ", @{$caller} ) . ")";
 
-#        Dancer2::Core::debug("Adding hook '$name' to $self");
         $self->add_hook($hook);
     }
 }


### PR DESCRIPTION
Solved #364. If it is really debug (used for a limited amount of time while developing a feature) use print to STDERR. In the other hand, if the data is relevant in the future, use a logger.
