### PR TITLE
Fix for #424. Fixed logger.t to prevent warning on windows. Fixed regex used in test

### DIFF
--- a/t/logger.t
+++ b/t/logger.t
@@ -30,7 +30,7 @@ $logger->debug("foo");
 
 # Hard to make caller(6) work when we deal with the logger directly,
 # so do not check for a specific filename.
-like $_logs->[0], qr{debug \@2010-06-1\d \d\d:00:00> foo in };
+like $_logs->[0], qr{debug \@2010-06-1\d \d\d:\d\d:00> foo in };
 
 subtest 'log level and capture' => sub {
     use Dancer2::Logger::Capture;
@@ -77,5 +77,9 @@ subtest 'logger file' => sub {
     my $txt = <$log_file>;
     like $txt, qr/Danger! Warning!/;
 };
-
+# Explicitly close the logger file handle for those systems that
+# do not allow "open" files to be unlinked (Windows). GH#424.
+my $log_engine = engine('logger');
+close $log_engine->fh;
+    
 done_testing;


### PR DESCRIPTION
These fixes were on the advice of @veryrusty

Windows doesn't allow open files to be unlinked. Not explicitly closing the file would throw a permission denied warning while running tests. This is now fixed.

One of the tests uses a regex that checks for date and time in the log incorrectly. The regex wasn't accounting for when a log would be generated in a time zone that was X hours and 30 or 45 mins ahead of GMT. This is also been fixed.
