### PR TITLE
CSS file paths for default errors should be relocatable.

### DIFF
--- a/lib/Dancer2/Core/Error.pm
+++ b/lib/Dancer2/Core/Error.pm
@@ -146,11 +146,14 @@ sub default_error_page {
 
     require Template::Tiny;
 
+    my $uri_base = $self->has_context ?
+        $self->context->request->uri_base : ''; 
     my $opts = {
-        title   => $self->title,
-        charset => $self->charset,
-        content => $self->message,
-        version => Dancer2->VERSION,
+        title    => $self->title,
+        charset  => $self->charset,
+        content  => $self->message,
+        version  => Dancer2->VERSION,
+        uri_base => $uri_base,
     };
 
     Template::Tiny->new->process( \<<"END_TEMPLATE", $opts, \my $output );
@@ -158,7 +161,7 @@ sub default_error_page {
 <html>
 <head>
 <title>[% title %]</title>
-<link rel="stylesheet" href="/css/error.css" />
+<link rel="stylesheet" href="[% uri_base %]/css/error.css" />
 <meta http-equiv="Content-type" content="text/html; charset='[% charset %]'" />
 </head>
 <body>

--- a/t/dancer-test.t
+++ b/t/dancer-test.t
@@ -16,8 +16,17 @@ my @routes = (
     '/foo',
     [ GET => '/foo' ],
     Dancer2::Core::Request->new(
-        path   => '/foo',
-        method => 'GET',
+        env => {
+            'psgi.url_scheme' => 'http',
+            REQUEST_METHOD    => 'GET',
+            QUERY_STRING      => '',
+            SERVER_NAME       => 'localhost',
+            SERVER_PORT       => 5000,
+            SERVER_PROTOCOL   => 'HTTP/1.1',
+            SCRIPT_NAME       => '',
+            PATH_INFO         => '/foo',
+            REQUEST_URI       => '/foo',
+        }
     ),
     Dancer2::Core::Response->new(
         content => 'fighter',

--- a/t/dispatcher.t
+++ b/t/dispatcher.t
@@ -167,8 +167,12 @@ foreach my $test (@tests) {
 
 foreach my $test (
     {   env => {
-            REQUEST_METHOD => 'GET',
-            PATH_INFO      => '/error',
+            REQUEST_METHOD    => 'GET',
+            PATH_INFO         => '/error',
+            'psgi.uri_scheme' => 'http',
+            SERVER_NAME       => 'localhost',
+            SERVER_PORT       => 5000,
+            SERVER_PROTOCOL   => 'HTTP/1.1',
         },
         expected => [
             500,

--- a/t/error.t
+++ b/t/error.t
@@ -35,6 +35,8 @@ subtest 'basic defaults of Error object' => sub {
     is $e->status,  500,                                 'code';
     is $e->title,   'Error 500 - Internal Server Error', 'title';
     is $e->message, undef,                               'message';
+    like $e->content, qr!http://localhost:5000/foo/css!,
+        "error content contains css path relative to uri_base";
 };
 
 subtest "send_error in route" => sub {


### PR DESCRIPTION
With Dancer2 apps being able 'relocatable' (able to be mounted via URLMap 
without adding a prefix), ensure the default error content also
adjusts paths to their css files appropriately.

Includes a simple test case. Also update dispatcher.t and dancer-test.t
so there is sufficient content in their request envs to calculate uri_base
to shhh use of uninitialized var warnings.
