### PR TITLE
Update docs to include lib

### DIFF
--- a/lib/Dancer2/Cookbook.pod
+++ b/lib/Dancer2/Cookbook.pod
@@ -852,7 +852,7 @@ webserver using HTTP::Server::Simple::PSGI.
 
 Simply fire up your app:
 
-    $ perl bin/app.pl
+    $ perl -Ilib bin/app.pl
     >> Listening on 0.0.0.0:3000
     == Entering the dance floor ...
 
@@ -866,7 +866,7 @@ you want to make your app available to the world, it probably won't suit you.
 To edit your files without the need to restart the webserver on each file change,
 simply start your Dancer2 app using L<plackup> and L<Plack::Loader::Shotgun>:
 
-    $ plackup -L Shotgun bin/app.pl
+    $ plackup -L Shotgun -Ilib bin/app.pl
     HTTP::Server::PSGI: Accepting connections at http://0:5000/
 
 Point your browser at it. Files can now be changed in your favorite editor and
@@ -1008,7 +1008,7 @@ This example configuration uses TCP/IP:
 
 Launch your application:
 
-    plackup -s FCGI --port 5000 bin/app.pl
+    plackup -s FCGI --port 5000 -Ilib bin/app.pl
 
 This example configuration uses a socket:
 
@@ -1025,7 +1025,7 @@ This example configuration uses a socket:
 
 Launch your application:
 
-    plackup -s FCGI --listen /tmp/fcgi.sock bin/app.pl
+    plackup -s FCGI --listen /tmp/fcgi.sock -Ilib bin/app.pl
 
 
 =head2 Plack middlewares
@@ -1097,8 +1097,8 @@ C<Corona> is a C<Coro> based web server.
 To start your application, just run plackup (see L<Plack> and specific servers
 above for all available options):
 
-   $ plackup bin/app.pl
-   $ plackup -E deployment -s Starman --workers=10 -p 5001 -a bin/app.pl
+   $ plackup -Ilib bin/app.pl
+   $ plackup -E deployment -s Starman --workers=10 -p 5001 -Ilib -a bin/app.pl
 
 As you can see, the scaffolded Perl script for your app can be used as a PSGI
 startup file.
@@ -1376,7 +1376,7 @@ with Nginx:
 You will need plackup to start a worker listening on a socket :
 
     cd YOUR_PROJECT_PATH
-    sudo -u www plackup -E production -s Starman --workers=2 -l THE_PATH_OF_YOUR_PLACKUP_SOCKET_HERE.sock -a bin/app.pl
+    sudo -u www plackup -E production -s Starman --workers=2 -l THE_PATH_OF_YOUR_PLACKUP_SOCKET_HERE.sock -Ilib -a bin/app.pl
 
 A good way to start this is to use C<daemontools> and place this line
 with all environments variables in the "run" file.

--- a/lib/Dancer2/Manual.pod
+++ b/lib/Dancer2/Manual.pod
@@ -40,7 +40,7 @@ Create a web application using the dancer script:
 
 And voilà! You can now run the web application:
 
-    bin/app.pl
+    perl -Ilib bin/app.pl
 
 View the web application at:
 
@@ -49,7 +49,7 @@ View the web application at:
 Note that as Dancer2 supports the L<PSGI> specification, you can also use the C<plackup> tool
 (provided by L<Plack>) for launching the application:
 
-    plackup ./bin/app.pl -p 5000
+    plackup -Ilib ./bin/app.pl -p 5000
 
 =head1 USAGE
 


### PR DESCRIPTION
Now that "lib" is not added:

```
$ dancer2 -a MyApp && cd MyApp && perl bin/app.pl
```

currently does not work, it fails to find MyApp.pm inside lib/. Assuming this is the intended behavior the documentation examples should be updated to reflect the need to manually include lib/. I've updated some bits of documentation here, but I surely missed some. Comments welcome.
