### PR TITLE
Include lib/ in app.pl script

### DIFF
--- a/script/dancer2
+++ b/script/dancer2
@@ -565,6 +565,8 @@ my \$server = Plack::Handler::FCGI->new(nproc => 5, detach => 1);
 
 "$PERL_INTERPRETER
 use Dancer2;
+use FindBin;
+use lib \"\$FindBin::Bin/../lib\";
 use $appname;
 dance;
 ",


### PR DESCRIPTION
To prevent the need to manually include lib/ as described in: https://github.com/PerlDancer/Dancer2/pull/429

This request invalidates https://github.com/PerlDancer/Dancer2/pull/429
