### PR TITLE
Force YAML::XS

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -97,7 +97,7 @@ Pod::Simple::SimpleTree = 0
 
 [Prereqs / Suggests]
 ; Used by Dancer2::Session::YAML
-YAML::Any = 0
+YAML::XS = 0
 Fcntl = 0
 Class::Load::XS = 0
 
@@ -105,7 +105,7 @@ Class::Load::XS = 0
 [Prereqs / TestRequires]
 Test::More = 0.92
 Capture::Tiny = 0.12
-YAML::Any = 0
+YAML::XS = 0
 HTTP::Server::Simple::PSGI = 0
 Test::Fatal = 0
 HTTP::Body = 0

--- a/lib/Dancer2/Serializer/YAML.pm
+++ b/lib/Dancer2/Serializer/YAML.pm
@@ -23,17 +23,17 @@ sub to_yaml {
 
 # class definition
 
-sub BUILD { eval "use YAML::Any ()"; croak "Fail to load YAML: $@" if $@ }
+sub BUILD { eval "use YAML::XS ()"; croak "Fail to load YAML: $@" if $@ }
 sub loaded {1}
 
 sub serialize {
     my ( $self, $entity ) = @_;
-    YAML::Any::Dump($entity);
+    YAML::XS::Dump($entity);
 }
 
 sub deserialize {
     my ( $self, $content ) = @_;
-    YAML::Any::Load($content);
+    YAML::XS::Load($content);
 }
 
 1;

--- a/lib/Dancer2/Session/YAML.pm
+++ b/lib/Dancer2/Session/YAML.pm
@@ -4,7 +4,7 @@ package Dancer2::Session::YAML;
 
 use Moo;
 use Dancer2::Core::Types;
-use YAML::Any;
+use YAML::XS;
 
 has _suffix => (
     is      => 'ro',
@@ -16,13 +16,13 @@ with 'Dancer2::Core::Role::SessionFactory::File';
 
 sub _freeze_to_handle {
     my ( $self, $fh, $data ) = @_;
-    print {$fh} YAML::Any::Dump($data);
+    print {$fh} YAML::XS::Dump($data);
     return;
 }
 
 sub _thaw_from_handle {
     my ( $self, $fh ) = @_;
-    return YAML::Any::LoadFile($fh);
+    return YAML::XS::LoadFile($fh);
 }
 
 1;


### PR DESCRIPTION
The *::Any modules are a lie. Whenever one of the backends has a bug it is propagated to the Any module, and we need to deal with it. As pointed in GH #433, without YAML::XS there are encoding problems, and deprecation warnings. My feeling is that is is better to require the real thing.
