### PR TITLE
call app in different way

### DIFF
--- a/script/dancer2
+++ b/script/dancer2
@@ -564,9 +564,8 @@ my \$server = Plack::Handler::FCGI->new(nproc => 5, detach => 1);
 "app.pl" =>
 
 "$PERL_INTERPRETER
-use Dancer2;
 use $appname;
-dance;
+${appname}->dance;
 ",
 
 "$LIB_FILE" =>


### PR DESCRIPTION
As requested in #374 

I would add the `use lib '../lib'` line as well. Solves usability, doesn't use FindBin, and makes me happy.
