### PR TITLE
[ghost] Can specify to which app the module belongs

### DIFF
--- a/lib/Dancer/Core/Role/Server.pm
+++ b/lib/Dancer/Core/Role/Server.pm
@@ -154,6 +154,10 @@ Adds another application to the C<apps> attribute (see above).
 
 sub register_application {
     my ($self, $app) = @_;
+
+    # verify that the app is not already present
+    return if grep { $app->name eq $_->name } @$self->apps;
+
     push @{ $self->apps }, $app;
     $app->server($self);
     $app->server->runner->postponed_hooks({

--- a/t/apps.t
+++ b/t/apps.t
@@ -1,0 +1,25 @@
+use strict;
+use warnings;
+
+use Test::More tests => 1;
+
+use Dancer app => 'MyApp';
+
+{
+    package Foo;
+
+    use Dancer app => 'MyApp';
+
+    get '/foo' => sub { 'foo' };
+}
+
+{
+    package Bar;
+
+    use Dancer app => 'SubApp';
+
+    get '/bar' => sub { 'bar' };
+}
+
+is @{runner()->server->apps} => 2, "2 apps";
+


### PR DESCRIPTION
With this patch, the different modules can be appended
to a previously defined app via

```
package Foo;

use Dancer app => 'myApp';

...
```

---

This is a ghost PR. DO NOT APPLY IT.
Useful to name an App? Also, is the test testing that? Relevant? Comment. If so, I'll prepare a clean PR.
