### PR TITLE
Don't futz with $^W. Import warnings and remove import_warnings

### DIFF
--- a/lib/Dancer2.pm
+++ b/lib/Dancer2.pm
@@ -116,6 +116,7 @@ sub import {
     my ( $caller, $script ) = caller;
 
     strict->import;
+    warnings->import;
     utf8->import;
 
     my @final_args;

--- a/lib/Dancer2/Config.pod
+++ b/lib/Dancer2/Config.pod
@@ -261,11 +261,6 @@ C<template> keyword. Check C<Dancer2> manpage for details.
 If true, C<config> will return an object instead of a hash reference. See
 L<Dancer2::Config::Object> for more information.
 
-=head3 import_warnings (boolean, default: enabled)
-
-If true, or not present, C<use warnings> will be in effect in scripts in which
-you import C<Dancer2>.  Set to a false value to disable this.
-
 =head3 startup_info (boolean)
 
 If set to true, prints a banner at the server start with information such as

--- a/lib/Dancer2/Cookbook.pod
+++ b/lib/Dancer2/Cookbook.pod
@@ -41,11 +41,11 @@ route specification, whose value is made available through C<params>
 - more on that later.
 
 Note that you don't need to use the C<strict> and C<warnings> pragma, they are
-already loaded by Dancer2.  (If you don't want the C<warnings> pragma (which can
-lead to undesired warnings about use of undef values, for example), then set the
-L<import_warnings|Dancer2::Config/import_warnings> setting to a false value.
+already loaded by Dancer2.
 
-
+If you I<really> do not want the C<warnings> pragma (for example, due to an 
+undesired warning about use of undef values), add a C<no warnings> pragma to
+the appropriate block in your module or psgi file.
 
 =head2 Starting a Dancer2 project
 

--- a/lib/Dancer2/Core/Role/Config.pm
+++ b/lib/Dancer2/Core/Role/Config.pm
@@ -269,10 +269,6 @@ sub _build_config_triggers {
 
     # TODO route_cache
     return {
-        import_warnings => sub {
-            my ( $self, $value ) = @_;
-            $^W = $value ? 1 : 0;
-        },
         traces => sub {
             my ( $self, $traces ) = @_;
             require Carp;

--- a/lib/Dancer2/Core/Runner.pm
+++ b/lib/Dancer2/Core/Runner.pm
@@ -71,7 +71,6 @@ sub default_config {
         views        => ( $ENV{DANCER_VIEWS}
               || path( $self->config_location, 'views' ) ),
         appdir          => $self->location,
-        import_warnings => 1,
     };
 }
 


### PR DESCRIPTION
An alternative approach to #427. Use warnings->import when importing Dancer2 to ensure any code using it has the warnings pragma enabled (just like strict and utf8).

Remove the import_config setting and its trigger that mucks with $^W and purge it from the POD. If anyone really wants to set $^W, they can add it to their app or psgi file and be in control of the results.
