### PR TITLE
Before hook check moved out of routes matching in dispatcher

### DIFF
--- a/lib/Dancer2/Core/App.pm
+++ b/lib/Dancer2/Core/App.pm
@@ -240,6 +240,7 @@ sub _init_for_context {
 
 sub supported_hooks {
     qw/
+      core.app.before_route_match
       core.app.before_request
       core.app.after_request
       core.app.route_exception

--- a/lib/Dancer2/Core/Dispatcher.pm
+++ b/lib/Dancer2/Core/Dispatcher.pm
@@ -51,7 +51,7 @@ sub dispatch {
 
         $app->log( core => "looking for $http_method $path_info" );
 
-        $app->execute_hook( 'core.app.before_request', $context );
+        $app->execute_hook( 'core.app.before_route_match', $context );
         if ( $context->response->is_halted ) {
             if ( ! $context->response->header('Content-type') ) {
                 if ( exists( $app->config->{content_type} ) ) {

--- a/lib/Dancer2/Core/Dispatcher.pm
+++ b/lib/Dancer2/Core/Dispatcher.pm
@@ -92,7 +92,8 @@ sub dispatch {
 
             # next if $context->request->path_info ne $path_info
             #         || $context->request->method ne uc($http_method);
-
+            
+            $app->execute_hook( 'core.app.before_request', $context );
             my $response = $context->response;
 
             my $content;

--- a/lib/Dancer2/Core/Role/Hookable.pm
+++ b/lib/Dancer2/Core/Role/Hookable.pm
@@ -23,6 +23,7 @@ sub BUILD { }
 # their own aliases for their own hooks
 sub hook_aliases {
     {   before                 => 'core.app.before_request',
+        before_match           => 'core.app.before_route_match',
         before_request         => 'core.app.before_request',
         after                  => 'core.app.after_request',
         after_request          => 'core.app.after_request',

--- a/t/before_reading_params.t
+++ b/t/before_reading_params.t
@@ -1,0 +1,47 @@
+use strict;
+use warnings;
+use Test::More;
+
+use Test::TCP;
+use LWP::UserAgent;
+
+
+Test::TCP::test_tcp(
+    client => sub {
+        my $port = shift;
+
+        #Enter with a language-equipped URL
+        my $ua = LWP::UserAgent->new;
+        $ua->cookie_jar({file => "cookies.txt"});
+        my $res = $ua->get("http://127.0.0.1:$port/readthis/some");
+        ok($res->is_success);
+        is($res->content, 'some');
+    },
+    server => sub {
+        my $port = shift;
+        use Dancer2;
+
+        hook before => sub {
+            my $context = shift;
+            my $p = $context->request->params->{string};
+            $context->vars->{test} = $p;
+        };
+
+        get '/readthis/:string' => sub {
+            return vars->{test};
+        };      
+
+        set(show_errors  => 1,
+            startup_info => 1,
+            public => '.',
+            environment  => 'development',
+            port         => $port,
+            logger       => 'console',
+            log          => 'debug',
+            );
+
+        Dancer2->runner->server->port($port);
+        start;
+    },
+);
+done_testing;

--- a/t/hook_changing_path.t
+++ b/t/hook_changing_path.t
@@ -21,7 +21,7 @@ Test::TCP::test_tcp(
         my $port = shift;
         use Dancer2;
 
-        hook before => sub {
+        hook before_match => sub {
             my $context = shift;
             my $path = $context->request->path_info();
             if($path =~ m/^\/prefix/)

--- a/t/hook_changing_path.t
+++ b/t/hook_changing_path.t
@@ -1,0 +1,52 @@
+use strict;
+use warnings;
+use Test::More;
+
+use Test::TCP;
+use LWP::UserAgent;
+
+
+Test::TCP::test_tcp(
+    client => sub {
+        my $port = shift;
+
+        #Enter with a language-equipped URL
+        my $ua = LWP::UserAgent->new;
+        $ua->cookie_jar({file => "cookies.txt"});
+        my $res = $ua->get("http://127.0.0.1:$port/prefix/configured");
+        ok($res->is_success);
+        is($res->content, 'prefix');
+    },
+    server => sub {
+        my $port = shift;
+        use Dancer2;
+
+        hook before => sub {
+            my $context = shift;
+            my $path = $context->request->path_info();
+            if($path =~ m/^\/prefix/)
+            {
+                $path =~ s/^\/prefix//;
+                $context->response( $context->request->forward($context, $path, { cut => 'prefix'}, undef));
+                $context->response->halt;
+            }
+        };
+
+        get '/configured' => sub {
+            return request->params->{'cut'};
+        };      
+
+        set(show_errors  => 1,
+            startup_info => 1,
+            public => '.',
+            environment  => 'development',
+            port         => $port,
+            logger       => 'console',
+            log          => 'debug',
+            );
+
+        Dancer2->runner->server->port($port);
+        start;
+    },
+);
+done_testing;


### PR DESCRIPTION
Run the test in the branch: t/hook_changing_path.t 
It will go well.
Now take it in a different directory and run it again (obviously still with Dancer2 in your @INC). It will fail.

It's a self contained test, why should it fail?

Problem is that the dispatcher runs before hooks during the route matching and the before hook we introduced change routes, modifying something we didn't configure (/prefix/configured) in something we did (/configured).

When the script is in the t directory this is not a problem because the Dancer2::Handler::File appends a megasplat route to the app's routes and the before hook can be triggered when testing /prefix/configured against it. 
In a directory different from t, Dancer2 environment can't determinate a public directory (under t we have a public...) so the Dancer2::Handler::File can't register itself to the app and the megasplat can't come saving us.

I tried to make the before hook triggered before the route matching, but I'm not sure this is the right thing to do. It makes sense for you?

This is still very dirty code. I left all the old halted context management inside the loop, just copying it also beofre it. But I want your feedback about the question before refactoring.


Problem I exposed has bad side effects in real world. I have a plugin that fails dzil test for that. A good workaround is creating a public directory under the t, but it's a bit dirty...

