### PR TITLE
Better session id needs to be rw fix

### DIFF
--- a/lib/Dancer2/Core/Session.pm
+++ b/lib/Dancer2/Core/Session.pm
@@ -39,6 +39,7 @@ has id => (
     is       => 'rw',
     isa      => Str,
     required => 1,
+    trigger  => sub { $_[0]->is_dirty(1) },
 );
 
 =attr data
@@ -79,7 +80,7 @@ has expires => (
 
 =attr is_dirty
 
-Boolean value for whether data in the session has been modified.
+Boolean value for whether the id, or the data in the session, has been modified.
 
 =cut
 

--- a/t/session_object.t
+++ b/t/session_object.t
@@ -23,8 +23,11 @@ subtest 'session attributes' => sub {
 
     my $id = $s1->id;
     ok defined($id), 'id is defined';
+
+    ok !$s1->is_dirty, 'session is not dirty';
     is(exception { $s1->id("new_$id") }, undef, 'id can be set');
     is($s1->id, "new_$id", '... new value found for id');
+    ok $s1->is_dirty, 'session is dirty after id change';
 
     my $s2 = $ENGINE->create;
     isnt($s1->id, $s2->id, "IDs are not the same");


### PR DESCRIPTION
Related to #460.

If the Session id attr is set, we should mark the Session as dirty.