### PR TITLE
Add :no_dsl import tag to Dancer2::Plugin

### DIFF
--- a/lib/Dancer2/Plugin.pm
+++ b/lib/Dancer2/Plugin.pm
@@ -360,24 +360,26 @@ sub import {
  # their first argument).
  # These modified versions of the DSL are then exported in the namespace of the
  # plugin.
-    for my $symbol ( keys %{ $dsl->keywords } ) {
+    unless (grep { $_ eq ':no_dsl' } @_) {
+        for my $symbol ( keys %{ $dsl->keywords } ) {
 
-        # get the original symbol from the real DSL
-        no strict 'refs';
-        no warnings qw( redefine once );
-        my $code = *{"Dancer2::Core::DSL::$symbol"}{CODE};
+            # get the original symbol from the real DSL
+            no strict 'refs';
+            no warnings qw( redefine once );
+            my $code = *{"Dancer2::Core::DSL::$symbol"}{CODE};
 
-        # compile it with $caller->dsl
-        my $compiled = sub {
-            carp
-              "DEPRECATED: $plugin calls '$symbol' instead of '\$dsl->$symbol'.";
-            $code->( $dsl, @_ );
-        };
+            # compile it with $caller->dsl
+            my $compiled = sub {
+                carp
+                  "DEPRECATED: $plugin calls '$symbol' instead of '\$dsl->$symbol'.";
+                $code->( $dsl, @_ );
+            };
 
-        # bind the newly compiled symbol to the caller's namespace.
-        *{"${plugin}::${symbol}"} = $compiled;
+            # bind the newly compiled symbol to the caller's namespace.
+            *{"${plugin}::${symbol}"} = $compiled;
 
-        $dsl_deprecation_wrapper = $compiled if $symbol eq 'dsl';
+            $dsl_deprecation_wrapper = $compiled if $symbol eq 'dsl';
+        }
     }
 
     # Finally, make sure our caller becomes a Moo::Role


### PR DESCRIPTION
This is a RFC PR, not for merging for now.

The current system to manage deprecation warnings in Dancer::Plugin is a single global scalar that fails in the presence of multiple plugins.

Yet most modern plugins don't need the legacy DSL imports. This new import tab, `:no_dsl` prevents those DSL commands from being imported into your own namespace.

The correct approach would be to remove that code entirely, or revert this tag to ':dsl', as an opt-in feature, but some old Dancer2::Plugins might be depending on the current behaviour.
