### PR TITLE
Rework halt to use with_return from Return::MultiLevel.

### DIFF
--- a/lib/Dancer2/Core/Context.pm
+++ b/lib/Dancer2/Core/Context.pm
@@ -184,6 +184,21 @@ sub redirect {
     $self->with_return->($self->response) if $self->has_with_return;
 }
 
+=method halt
+
+Flag the response object as 'halted'.
+
+If called during request dispatch, immediatly returns the response
+to the dispatcher and after hooks will not be run.
+
+=cut
+
+sub halt {
+   my ($self) = @_;
+   $self->response->halt;
+   # Short citcuit any remaining hook/route code
+   $self->with_return->($self->response) if $self->has_with_return;
+}
 
 =attr session
 

--- a/lib/Dancer2/Core/DSL.pm
+++ b/lib/Dancer2/Core/DSL.pm
@@ -151,7 +151,7 @@ sub prefix {
       : $app->lexical_prefix(@_);
 }
 
-sub halt { shift->app->context->response->halt }
+sub halt { shift->app->context->halt }
 
 sub _route_parameters {
     my ( $regexp, $code, $options );

--- a/t/dsl/halt.t
+++ b/t/dsl/halt.t
@@ -1,0 +1,54 @@
+use strict;
+use warnings;
+
+use Test::More;
+
+subtest 'halt within routes' => sub {
+    {
+
+        package App;
+        use Dancer2;
+
+        get '/' => sub { 'hello' };
+        get '/halt' => sub {
+            header 'X-Foo' => 'foo';
+            halt;
+        };
+        get '/shortcircuit' => sub {
+            context->response->content('halted');
+            halt;
+            redirect '/'; # won't get executed as halt returns immediately.
+        };
+    }
+    use Dancer2::Test apps => ['App'];
+
+    response_status_is  [ GET => '/shortcircuit' ] => 200;
+    response_content_is [ GET => '/shortcircuit' ] => "halted";
+
+    my $expected_headers = [
+        'X-Foo'        => 'foo',
+        'Server'       => "Perl Dancer2 $Dancer2::VERSION",
+    ];
+    response_headers_include [ GET => '/halt' ] => $expected_headers;
+
+};
+
+subtest 'halt in before halt' => sub {
+    {
+        package App;
+        use Dancer2;
+
+        hook before => sub {
+            my $context = shift;
+            $context->response->content('I was halted');
+            halt if $context->request->dispatch_path eq '/shortcircuit';
+        };
+
+    }
+
+    response_status_is  [ GET => '/shortcircuit' ] => 200;
+    response_content_is [ GET => '/shortcircuit' ] => "I was halted";
+
+};
+
+done_testing;


### PR DESCRIPTION
Move the `halt` mechanism in to the Context to the with_return handler can be applied to immediately stop processing a hook/route handler when `halt` is used.

Adds tests for using halt in a before hook and within a route handler. Should resolve the concerns of #472.
