### PR TITLE
Multiple reverse proxy support

### DIFF
--- a/lib/Dancer2/Core/Request.pm
+++ b/lib/Dancer2/Core/Request.pm
@@ -342,8 +342,8 @@ sub host {
     my ($self) = @_;
 
     return ( $self->is_behind_proxy )
-      ? ( $self->env->{HTTP_X_FORWARDED_HOST}
-          || $self->env->{X_FORWARDED_HOST} )
+      ? (split( /\s*,\s*/, ( $self->env->{HTTP_X_FORWARDED_HOST}
+          || $self->env->{X_FORWARDED_HOST} )))[0]
       : $self->env->{HTTP_HOST};
 }
 

--- a/t/redirect.t
+++ b/t/redirect.t
@@ -91,4 +91,34 @@ subtest 'redirect behind a proxy' => sub {
       "... or from X_FORWARDED_PROTOCOL";
 };
 
+subtest 'redirect behind multiple proxies' => sub {
+    {
+
+        package App;
+        use Dancer2;
+        prefix '/test2';
+        set behind_proxy => 1;
+        get '/bounce' => sub { redirect '/test2' };
+    }
+    use Dancer2::Test apps => ['App'];
+
+    delete $ENV{X_FORWARDED_PROTOCOL};
+    delete $ENV{HTTP_FORWARDED_PROTO};
+    $ENV{X_FORWARDED_HOST} = "proxy1.example, proxy2.example";
+    response_headers_include
+      [ GET      => '/test2/bounce' ],
+      [ Location => 'http://proxy1.example/test2' ],
+      "behind multiple proxies, host() is read from X_FORWARDED_HOST";
+
+    $ENV{HTTP_FORWARDED_PROTO} = "https";
+    response_headers_include [ GET => '/test2/bounce' ] =>
+      [ Location => 'https://proxy1.example/test2' ],
+      "... and the scheme is read from HTTP_FORWARDED_PROTO";
+
+    $ENV{X_FORWARDED_PROTOCOL} = "ftp";    # stupid, but why not?
+    response_headers_include [ GET => '/test2/bounce' ] =>
+      [ Location => 'ftp://proxy1.example/test2' ],
+      "... or from X_FORWARDED_PROTOCOL";
+};
+
 done_testing;


### PR DESCRIPTION
Apache for one allows the X-Forwarded-Host to be a comma seperated
list rather than a single value. See:
http://httpd.apache.org/docs/2.2/mod/mod_proxy.html#x-headers

In a case of:

[interwebs] -> [external proxy] -> [internal proxy] -> [Dancer]

The X-Forward-Host will look like "domain.example, domain.example". This will then be used in, e.g. redirects:

Location: http://domain.example, domain.example/redirected_page
