### PR TITLE
Fixed empty HTTP_REFERER calls.

### DIFF
--- a/lib/Dancer2/Core/Request.pm
+++ b/lib/Dancer2/Core/Request.pm
@@ -117,7 +117,7 @@ foreach my $attr ( @http_env_keys ) {
         is      => 'ro',
         isa     => Maybe[Str],
         lazy    => 1,
-        default => sub { $_[0]->env->{ 'HTTP_' . ( uc $attr ) } || '' },
+        default => sub { $_[0]->env->{ 'HTTP_' . ( uc $attr ) } },
     );
 }
 

--- a/t/request.t
+++ b/t/request.t
@@ -56,7 +56,6 @@ sub run_test {
     ok( !$req->is_delete );
     ok( !$req->is_patch );
     ok( !$req->is_head );
-    ok( !$req->referer );
 
     is $req->id,        1;
     is $req->to_string, '[#1] GET /foo/bar/baz';


### PR DESCRIPTION
When HTTP_REFERER is not set (which is a quite likely scenario), dancer
would die with:
    isa check for "referer" failed: undef is not a string!

This forces request->referer to return an empty string, rather than
undef (which is not a Str).
