### PR TITLE
Fixing Dist::Zilla build error 'Could not decode UTF-8 t/corpus/static/1...

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -126,6 +126,9 @@ LWP::Protocol::PSGI = 0.06
 [ExecDir]
 dir = script
 
+[ShareDir]
+dir = share
+
 [PerlTidy]
 perltidyrc = xt/perltidy.rc
 
@@ -138,4 +141,4 @@ perltidyrc = xt/perltidy.rc
 
 [Encoding]
 encoding = bytes
-match     = \.png$    ; these are all binary files
+match     = \.(png|ico|jpg)$    ; these are all binary files


### PR DESCRIPTION
...x1.png' on MacOSX.
