### PR TITLE
Deserialize body content for DELETE requests.

### DIFF
--- a/lib/Dancer2/Core/Request.pm
+++ b/lib/Dancer2/Core/Request.pm
@@ -482,8 +482,11 @@ sub deserialize {
 
     return unless $self->serializer->support_content_type($content_type);
 
+    # The latest draft of the RFC does not forbid DELETE to have content,
+    # rather the behaviour is undefined. Take the most lenient route and
+    # deserialize any content on delete as well.
     return
-      unless grep { $self->method eq $_ } qw/ PUT POST PATCH /;
+      unless grep { $self->method eq $_ } qw/ PUT POST PATCH DELETE /;
 
     # try to deserialize
     my $body = $self->_read_to_end();

--- a/t/deserialize.t
+++ b/t/deserialize.t
@@ -1,7 +1,7 @@
 use strict;
 use warnings;
 
-use Test::More tests => 9;
+use Test::More;
 
 {
 
@@ -21,8 +21,14 @@ use Test::More tests => 9;
         return join " : ", map { $_ => $p->{$_} } sort keys %$p;
     };
 
+    # This route is used for both toure and body params.
     post '/from/:town' => sub {
         my $p = params;
+        return $p;
+    };
+
+    any [qw/del patch/] => '/from/:town' => sub {
+        my $p = params('body');
         return $p;
     };
 }
@@ -72,18 +78,26 @@ note "Verify Serializers decode into characters"; {
 note "Decoding of mixed route and deserialized body params"; {
     # Check integers from request body remain integers
     # but route params get decoded.
-    my $r = dancer_response( Dancer2::Core::Request->new(
-        method       => 'POST',
-        path         => "/from/D\x{c3}\x{bc}sseldorf", # /from/d%C3%BCsseldorf
-        content_type => 'application/json',
-        body         => JSON::to_json({ population => 592393 }),
-        serializer   => Dancer2::Serializer::JSON->new(),
-    ));
+    my $r = dancer_response( generate_request( 'POST' ) );
 
     my $content = Encode::decode( 'UTF-8', $r->content );
     # Watch out for hash order randomization..
     like( $content, qr/[{,]"population":592393/, "Integer from JSON body remains integer" );
     like( $content, qr/[{,]"town":"Düsseldorf"/, "Route params are decoded" );
+}
+
+# Check body is deserialized on PATCH and DELETE.
+# The RFC states the behaviour for DELETE is undefined; We take the lenient
+# and deserialize it.
+# http://tools.ietf.org/html/draft-ietf-httpbis-p2-semantics-24#section-4.3.5
+note "Deserialze any body content that is allowed or undefined"; {
+    for my $method ( qw/delete patch/ ) {
+        my $r = dancer_response( generate_request( $method ) );
+        my $content = Encode::decode( 'UTF-8', $r->content );
+        # Only body params returned
+        is( $content, '{"population":592393}',
+            "JSON body deserialized for " . uc($method) . " requests" );
+    }
 }
 
 note 'Check serialization errors'; {
@@ -98,4 +112,17 @@ note 'Check serialization errors'; {
 
     ok $req->serializer->has_error, "Invalid JSON threw error in serializer";
     like $req->serializer->error, qr/malformed number/, ".. of a 'malformed number'";
+}
+
+done_testing();
+
+sub generate_request {
+    my $method = shift;
+    return Dancer2::Core::Request->new(
+        method       => uc $method,
+        path         => "/from/D\x{c3}\x{bc}sseldorf", # /from/d%C3%BCsseldorf
+        content_type => 'application/json',
+        body         => JSON::to_json({ population => 592393 }),
+        serializer   => Dancer2::Serializer::JSON->new(),
+    );
 }


### PR DESCRIPTION
The RFC doesn't forbid DELETE to have a content, rather it states the
behaviour is undefined. Closes #483.

Thanks to @yanick for passing on the issue when it was raised for Dancer1.
