### PR TITLE
Support all JSON configuration options

### DIFF
--- a/lib/Dancer2/Serializer/JSON.pm
+++ b/lib/Dancer2/Serializer/JSON.pm
@@ -25,17 +25,12 @@ sub loaded {1}
 sub serialize {
     my ( $self, $entity, $options ) = @_;
 
-    # Why doesn't $self->config have this?
-    my $config = $self->config;
+    my $config = eval { $self->context->app->config->{engines}->{JSON} };
 
-    if ( $config->{allow_blessed} && !defined $options->{allow_blessed} ) {
-        $options->{allow_blessed} = $config->{allow_blessed};
+    foreach (keys %$config) {
+        $options->{$_} = $config->{$_} unless defined $options->{$_};
     }
-    foreach my $name (qw(allow_nonref allow_unknown ascii canonical convert_blessed indent latin1 pretty shrink space_after space_before)) {
-        if ( defined $config->{$name} ) {
-            $options->{$name} = $config->{$name};
-        }
-    }
+
     $options->{utf8} = 1 if !defined $options->{utf8};
 
     JSON::to_json( $entity, $options );


### PR DESCRIPTION
As noted in issue #512 the current JSON serializer ignored most [JSON](https://metacpan.org/pod/JSON) configuration options. This should fix it.
