### PR TITLE
change PerlHandler -> PerlResponseHandler in docs

### DIFF
--- a/lib/Dancer2/Cookbook.pod
+++ b/lib/Dancer2/Cookbook.pod
@@ -1205,7 +1205,7 @@ following:
 
         <Location />
             SetHandler perl-script
-            PerlHandler Plack::Handler::Apache2
+            PerlResponseHandler Plack::Handler::Apache2
             PerlSetVar psgi_app /websites/myapp.example.com/app.pl
         </Location>
 


### PR DESCRIPTION
According to http://perl.apache.org/docs/2.0/user/handlers/http.html#HTTP_Request_Cycle_Phases
_"the `PerlHandler` directive has been renamed to `PerlResponseHandler` to better match the corresponding Apache phase name (response)."_

Somehow the original version works on Apache 2.2.14 on Ubuntu 10.04, but fails on compiled Apache 2.2.X. I guess Ubuntu / Debian packagers are polite.

Also, @miyagawa uses `PerlResponseHandler` in [Plack::Handler::Apache2 documentation](https://github.com/plack/Plack/blob/1.0030/lib/Plack/Handler/Apache2.pm#L210).
