### PR TITLE
Unbreak dispatch.cgi

### DIFF
--- a/lib/Dancer2/Core/Runner.pm
+++ b/lib/Dancer2/Core/Runner.pm
@@ -54,10 +54,11 @@ sub _build_server {
 # our Config role needs a default_config hash
 sub default_config {
 
-    $ENV{PLACK_ENV}
-      and $ENV{DANCER_APPHANDLER} = 'PSGI';
-
     my ($self) = @_;
+    if ($self->caller =~ /dispatch.cgi$/) {
+      $ENV{DANCER_APPHANDLER} = 'PSGI';
+    }
+
     {   apphandler   => ( $ENV{DANCER_APPHANDLER}   || 'Standalone' ),
         content_type => ( $ENV{DANCER_CONTENT_TYPE} || 'text/html' ),
         charset      => ( $ENV{DANCER_CHARSET}      || '' ),


### PR DESCRIPTION
When used through dispatch.cgi, Dancer::Core::Runner::default_config is instantiated by the 'use Dancer2', where PLACK_ENV is not set. This will set DANCER_APPHANDLER default to 'Standalone', which means that dispatch.cgi will not work unless you override Apphandler in your config to PSGI.
