### PR TITLE
Allow DSL class to be specified in config

### DIFF
--- a/lib/Dancer2.pm
+++ b/lib/Dancer2.pm
@@ -47,8 +47,6 @@ sub import {
       "parameters to 'use Dancer2' should be one of : 'key => value', ':script', or !<keyword>, where <keyword> is a DSL keyword you don't want to import";
     my %final_args = @final_args;
 
-    $final_args{dsl} ||= 'Dancer2::Core::DSL';
-
     # never instantiated the runner, should do it now
     if ( not defined $runner ) {
 
@@ -73,6 +71,10 @@ sub import {
 
     # register the app within the runner instance
     $server->register_application($app);
+
+    # use config dsl class, must extend Dancer2::Core::DSL
+    my $config_dsl = $app->setting('dsl_class') || 'Dancer2::Core::DSL';
+    $final_args{dsl} ||= $config_dsl;
 
     # load the DSL, defaulting to Dancer2::Core::DSL
     load_class( $final_args{dsl} );

--- a/lib/Dancer2/Config.pod
+++ b/lib/Dancer2/Config.pod
@@ -450,6 +450,20 @@ Dancer2 will honor your C<before_template_render> code, and all default
 variables. They will be accessible and interpolated on automatic
 served pages.
 
+=head2 dsl_class
+
+For complex applications that require extended DSL keywords or other
+functionality the DSL class used can be specified at import time or in the
+config settings.
+
+    dsl_class: 'My::DSL'
+
+This is the same as specifying
+
+    use Dancer2 dsl => 'My::DSL'
+
+in your module. dsl_class defaults to L<Dancer2::Core::DSL> if not specified
+
 =head2 DANCER_CONFDIR and DANCER_ENVDIR
 
 It's possible to set the configuration directory and environment directory using this two

--- a/t/dsl/extend.t
+++ b/t/dsl/extend.t
@@ -1,0 +1,55 @@
+#!/usr/bin/env perl
+
+# define a sample DSL extension that will be used in the rest of these test
+# This extends Dancer2::Core::DSL but provides an extra keyword
+#
+# Each test below creates a new package so it can load Dancer2
+BEGIN {
+
+    package Dancer2::Test::ExtendedDSL;
+
+    use Moo;
+    extends 'Dancer2::Core::DSL';
+
+    sub BUILD {
+        my ( $self ) = @_;
+        $self->register(foo => 1);
+    }
+
+    sub foo {
+        return $_[1];
+    }
+}
+
+package main;
+
+use Test::More tests => 5;
+
+package test1;
+use Test::More;
+
+use Dancer2 dsl => 'Dancer2::Test::ExtendedDSL';
+
+ok(defined &foo, 'use line dsl can foo');
+is(foo('bar'), 'bar', 'use line Foo returns bar');
+
+package test2;
+use Test::More;
+
+ok(!defined &foo, 'intermediate package has no polluted namespace');
+
+package test3;
+use Test::More;
+use FindBin;
+use File::Spec;
+
+BEGIN {
+    $ENV{DANCER_CONFDIR} = File::Spec->catdir($FindBin::Bin, 'extend_config');
+}
+
+use Dancer2;
+
+ok(defined &foo, 'config specified DSL can foo');
+is(foo('baz'), 'baz', 'config specified Foo returns baz');
+
+done_testing;

--- a/t/dsl/extend_config/config.yml
+++ b/t/dsl/extend_config/config.yml
@@ -1,0 +1,1 @@
+dsl_class: 'Dancer2::Test::ExtendedDSL'


### PR DESCRIPTION
This allows the DSL class to be used to be specified in the config with the key "dsl_class"
