### PR TITLE
Allow OPTIONS and PATCH requests in the standalone server.

### DIFF
--- a/lib/Dancer2/Core/Server/Standalone.pm
+++ b/lib/Dancer2/Core/Server/Standalone.pm
@@ -80,4 +80,18 @@ sub print_banner {
     }
 
 }
+
+=method valid_http_method
+
+Overrides method inherited from L<HTTP::Server::Simple>, allowing C<GET>, C<POST>,
+C<HEAD>, C<PUT>, C<DELETE>, C<OPTIONS> and C<PATCH> requests.
+
+=cut
+
+sub valid_http_method {
+    my $self   = shift;
+    my $method = shift or return 0;
+    return $method =~ /^(?:GET|POST|HEAD|PUT|DELETE|OPTIONS|PATCH)$/;
+}
+
 1;

--- a/t/server_standalone.t
+++ b/t/server_standalone.t
@@ -1,0 +1,39 @@
+use Test::More;
+use strict;
+use warnings;
+use Encode;
+use utf8;
+
+use Test::TCP 1.13;
+use HTTP::Headers;
+use HTTP::Request;
+use LWP::UserAgent;
+
+plan tests => 7;
+
+Test::TCP::test_tcp(
+    client => sub {
+        my $port = shift;
+        my $ua   = LWP::UserAgent->new;
+        # Ensure the standalone standaloneerver responds to all the
+        # HTTP methods the DSL supports
+        for my $method ( qw/HEAD GET PUT POST DELETE OPTIONS PATCH/ ) {
+            my $req = HTTP::Request->new($method => "http://127.0.0.1:$port/foo");
+            my $res = $ua->request($req);
+            ok( $res->is_success, "$method return a 200 response");
+        }
+    },
+    server => sub {
+        my $port = shift;
+        use Dancer2;
+        set charset => 'utf-8';
+
+        any '/foo' => sub {
+            header "Allow" => "HEAD,GET,PUT,POST,DELETE,OPTIONS,PATCH";
+            "foo";
+        };
+
+        Dancer2->runner->server->port($port);
+        start;
+    },
+);


### PR DESCRIPTION
Overrides the valid_http_method() method inherited from HTTP::Server::Simple
to allow all request types that the DSL supports in the standalone server. Closes #523.
