### PR TITLE
Coerce exception objects into strings for Dancer2::Core::Error

### DIFF
--- a/lib/Dancer2/Core/Error.pm
+++ b/lib/Dancer2/Core/Error.pm
@@ -201,8 +201,8 @@ The message of the error page.
 =cut
 
 has message => (
-    is  => 'ro',
-    isa => Str,
+    is      => 'ro',
+    isa     => Str,
 );
 
 sub full_message {
@@ -241,6 +241,14 @@ has exception => (
     is        => 'ro',
     isa       => Str,
     predicate => 1,
+    coerce    => sub {
+        # Until we properly support exception objects, we shouldn't barf on
+        # them because that hides the actual error, if object overloads "",
+        # which most exception objects do, this will result in a nicer string.
+        # other references will produce a meaningless error, but that is
+        # better than a meaningless stacktrace
+        return "$_[0]"
+    }
 );
 
 has response => (

--- a/t/error.t
+++ b/t/error.t
@@ -109,4 +109,33 @@ subtest 'Error with show_errors: 1' => sub {
     like $err->content => qr/our exception/;
 };
 
+subtest 'Error with exception object' => sub {
+    eval { MyTestException->throw('a test exception object') };
+    my $err = Dancer2::Core::Error->new(
+        context     => $c,
+        exception   => $@,
+        show_errors => 1,
+    )->throw;
+
+    like $err->content, qr/a test exception object/, 'Error content contains exception message';
+};
+
 done_testing;
+
+package MyTestException;
+
+use overload '""' => \&as_str;
+
+sub new {
+    return bless {};
+}
+
+sub throw {
+    my ( $class, $error ) = @_;
+    my $self = ref($class) ? $class : $class->new;
+    $self->{error} = $error;
+
+    die $self;
+}
+
+sub as_str { return $_[0]->{error} }


### PR DESCRIPTION
This tries to coerce exceptions into strings.

Fixes #538 
