### PR TITLE
Use a locally scoped variable to iterate through the execution of hooks

### DIFF
--- a/lib/Dancer2/Core/Role/Hookable.pm
+++ b/lib/Dancer2/Core/Role/Hookable.pm
@@ -138,7 +138,9 @@ sub execute_hook {
         $self->engine('logger')->core("Entering hook $name");
 
     my $res;
-    $res = $_->(@args) for @{ $self->hooks->{$name} };
+    for my $h ( @{ $self->hooks->{$name} } ) {
+        $res = $h->(@args);
+    }
     return $res;
 }
 

--- a/t/hooks.t
+++ b/t/hooks.t
@@ -83,6 +83,12 @@ my $tests_flags = {};
         $c->response->halt;
     };
 
+    hook after => sub {
+        # GH#540 - ensure setting default scalar does not
+        # interfere with hook execution (aliasing)
+        $_ = 42;
+    };
+
     hook on_route_exception => sub {
         my ($context, $error) = @_;
         is ref($context), 'Dancer2::Core::Context';


### PR DESCRIPTION
Previously $_ was used to iterate through the list of hook coderefs to
execute, however the aliasing involved allowed the hooks code to be
replaced if $_ was assigned within the hook code.

Resolves #540.
