### PR TITLE
Remove all test that use Dancer2::Test (except route PODs):

### DIFF
--- a/t/ajax_plugin.t
+++ b/t/ajax_plugin.t
@@ -1,9 +1,10 @@
 use strict;
 use warnings;
 use Test::More import => ['!pass'];
+use Plack::Test;
+use HTTP::Request::Common;
 
 {
-
     package AjaxApp;
     use Dancer2;
     use Dancer2::Plugin::Ajax;
@@ -21,30 +22,58 @@ use Test::More import => ['!pass'];
     ajax '/another/test' => sub {
         "{more: 'json'}";
     };
-
 }
 
-use Dancer2::Test apps => ['AjaxApp'];
+my $app = Dancer2->runner->server->psgi_app;
+is( ref $app, 'CODE', 'Got app' );
 
-my $r = dancer_response(
-    POST => '/test',
-    { headers => [ [ 'X-Requested-With' => 'XMLHttpRequest' ], ], }
-);
-is $r->content, "{some: 'json'}", "ajax works with POST";
-is $r->content_type, 'application/json', "Response content type from plugin config";
+test_psgi $app, sub {
+    my $cb = shift;
 
-$r = dancer_response(
-    GET => '/test',
-    { headers => [ [ 'X-Requested-With' => 'XMLHttpRequest' ], ], }
-);
-is $r->content, "{some: 'json'}", "ajax works with GET";
+    {
+        my $res = $cb->(
+            POST '/test', 'X-Requested-With' => 'XMLHttpRequest'
+        );
 
-$r = dancer_response( POST => '/another/test' );
-is $r->status, 404, 'ajax does not match if no XMLHttpRequest';
+        is( $res->content, q({some: 'json'}), 'ajax works with POST' );
+        is( $res->content_type, 'application/json', 'ajax content type' );
+    }
 
-# GitHub #143 - responst content type not munged if ajax route passes
-$r = dancer_response(GET => '/test');
-is $r->status, 200, "ajax route passed for an non-XMLHttpRequest";
-like $r->content_type, qr{^text/html}, "content type on non-XMLHttpRequest not munged";
+    {
+        my $res = $cb->( GET '/test', 'X-Requested-With' => 'XMLHttpRequest' );
+        is( $res->content, q({some: 'json'}), 'ajax works with GET' );
+    }
+
+    {
+        is(
+            $cb->( POST '/another/test' )->code,
+            404,
+            'ajax route passed for non-XMLHttpRequest',
+        );
+    }
+
+    {
+        # GitHub #143 - response content type not munged if ajax route passes
+        my $res = $cb->( GET '/test' );
+
+        is(
+            $res->code,
+            200,
+            'ajax route passed for non-XMLHttpRequest',
+        );
+
+        is(
+            $res->content,
+            'some text',
+            'ajax route has proper content for GET without XHR',
+        );
+
+        is(
+            $res->content_type,
+            'text/html',
+            'content type on non-XMLHttpRequest not munged',
+        );
+    }
+};
 
 done_testing;

--- a/t/any.t
+++ b/t/any.t
@@ -1,6 +1,8 @@
 use strict;
 use warnings;
 use Test::More import => ['!pass'];
+use Plack::Test;
+use HTTP::Request::Common;
 
 {
 
@@ -16,17 +18,23 @@ use Test::More import => ['!pass'];
     };
 }
 
-use Dancer2::Test apps => ['App'];
+my $app = Dancer2->runner->server->psgi_app;
+is( ref $app, 'CODE', 'Got app' );
 
-my $r = dancer_response( POST => '/test' );
-is $r->content, 'POST';
+test_psgi $app, sub {
+    my $cb = shift;
+    is( $cb->( POST '/test' )->content, 'POST', 'POST request successful' );
+    is( $cb->( GET '/test' )->content, 'GET', 'GET request successful' );
 
-$r = dancer_response( GET => '/test' );
-is $r->content, 'GET';
-
-for my $method (qw(GET POST PUT DELETE OPTIONS PATCH)) {
-    my $r = dancer_response( $method => '/all' );
-    is $r->content, $method;
-}
+    for my $method ( qw<GET POST PUT DELETE OPTIONS PATCH> ) {
+        my $req = HTTP::Request->new( $method => '/all' );
+        is(
+            $cb->($req)->content,
+            $method,
+            "$method request successful",
+        );
+    }
+};
 
 done_testing;
+

--- a/t/custom_dsl.t
+++ b/t/custom_dsl.t
@@ -1,12 +1,12 @@
 use strict;
 use warnings;
 use Test::More import => ['!pass'];
+use Plack::Test;
+use HTTP::Request::Common;
 
 use FindBin qw($Bin);
 use lib "$Bin/lib";
 use Dancer2 dsl => 'MyDancerDSL';
-use Dancer2::Test;
-
 
 envoie '/' => sub {
     request->method;
@@ -16,14 +16,14 @@ prend '/' => sub {
     request->method;
 };
 
-{
-    my $r = dancer_response GET => '/';
-    is $r->content, 'GET';
-}
+my $app = Dancer2->runner->server->psgi_app;
+is( ref $app, 'CODE', 'Got app' );
 
-{
-    my $r = dancer_response POST => '/';
-    is $r->content, 'POST';
-}
+test_psgi $app, sub {
+    my $cb = shift;
+
+    is( $cb->( GET '/' )->content, 'GET', '[GET /] Correct content' );
+    is( $cb->( POST '/' )->content, 'POST', '[POST /] Correct content' );
+};
 
 done_testing;

--- a/t/dispatcher.t
+++ b/t/dispatcher.t
@@ -4,7 +4,6 @@ use Test::More import => ['!pass'];
 use Carp 'croak';
 
 use Dancer2;
-use Dancer2::Test;
 use Dancer2::Core::App;
 use Dancer2::Core::Route;
 use Dancer2::Core::Dispatcher;
@@ -62,7 +61,8 @@ my @tests = (
         expected => [
             200,
             [   'Content-Length' => 4,
-                'Content-Type'   => 'text/html; charset=UTF-8'
+                'Content-Type'   => 'text/html; charset=UTF-8',
+                'Server'         => "Perl Dancer2 $Dancer2::VERSION",
             ],
             ["home"]
         ]
@@ -74,7 +74,8 @@ my @tests = (
         expected => [
             200,
             [   'Content-Length' => 12,
-                'Content-Type'   => 'text/html; charset=UTF-8'
+                'Content-Type'   => 'text/html; charset=UTF-8',
+                'Server'         => "Perl Dancer2 $Dancer2::VERSION",
             ],
             ["Hello Johnny"]
         ]
@@ -88,6 +89,7 @@ my @tests = (
             [   'Location'       => 'http://perldancer.org',
                 'Content-Length' => '0',
                 'Content-Type'   => 'text/html',
+                'Server'         => "Perl Dancer2 $Dancer2::VERSION",
             ],
             ['']
         ]
@@ -150,11 +152,11 @@ foreach my $test (@tests) {
 
     my $resp = $dispatcher->dispatch($env)->to_psgi;
 
-    is $resp->[0] => $expected->[0], "Return code ok.";
+    is( $resp->[0], $expected->[0], 'Return code ok' );
 
-    ok( Dancer2::Test::_include_in_headers( $resp->[1], $expected->[1] ),
-        "expected headers are there"
-    );
+    my %got_headers = @{ $resp->[1] };
+    my %exp_headers = @{ $expected->[1] };
+    is_deeply( \%got_headers, \%exp_headers, 'Correct headers' );
 
     if ( ref( $expected->[2] ) eq "Regexp" ) {
         like $resp->[2][0] => $expected->[2], "Contents ok. (test $counter)";

--- a/t/dsl.t
+++ b/t/dsl.t
@@ -1,22 +1,22 @@
 use strict;
 use warnings;
 use Test::More import => ['!pass'];
+use Plack::Test;
+use HTTP::Request::Common;
 
 use Dancer2;
-use Dancer2::Test;
 
 any [ 'get', 'post' ], '/' => sub {
     request->method;
 };
 
-{
-    my $r = dancer_response GET => '/';
-    is $r->content, 'GET';
-}
+my $app = Dancer2->runner->server->psgi_app;
+is( ref $app, 'CODE', 'Got app' );
 
-{
-    my $r = dancer_response POST => '/';
-    is $r->content, 'POST';
-}
+test_psgi $app, sub {
+    my $cb = shift;
+    is( $cb->( GET '/'  )->content, 'GET',  'GET / correct content'  );
+    is( $cb->( POST '/' )->content, 'POST', 'POST / correct content' );
+};
 
 done_testing;

--- a/t/error_template.t
+++ b/t/error_template.t
@@ -2,6 +2,8 @@ use strict;
 use warnings;
 
 use Test::More;
+use Plack::Test;
+use HTTP::Request::Common;
 
 {
 
@@ -28,38 +30,42 @@ use Test::More;
 
 }
 
-use Dancer2::Test apps => ['PrettyError'];
+my $app = Dancer2->runner->server->psgi_app;
+is( ref $app, 'CODE', 'Got app' );
 
-subtest "/error" => sub {
-    my $r = dancer_response GET => '/error';
+test_psgi $app, sub {
+    my $cb = shift;
 
-    is $r->status, 505, 'send_error sets the status to 505';
-    like $r->content, qr{Template selected}, 'Error message looks good';
-    like $r->content, qr{message: oh my};
-    like $r->content, qr{status: 505};
+    subtest "/error" => sub {
+        my $r = $cb->( GET '/error' );
+
+        is $r->code, 505, 'send_error sets the status to 505';
+        like $r->content, qr{Template selected}, 'Error message looks good';
+        like $r->content, qr{message: oh my};
+        like $r->content, qr{status: 505};
+    };
+
+    subtest "/public" => sub {
+        my $r = $cb->( GET '/public' );
+
+        is $r->code,    510,             'send_error sets the status to 510';
+        like $r->content, qr{Static page}, 'Error message looks good';
+    };
+
+    subtest "/no_template" => sub {
+        my $r = $cb->( GET '/no_template' );
+
+        is $r->code, 404, 'send_error sets the status to 404';
+        like $r->content, qr{<h1>Error 404 - Not Found</h1>},
+          'Error message looks good';
+    };
+
+    subtest '404 with static template' => sub {
+        my $r = $cb->( GET '/middle/of/nowhere' );
+
+        is $r->code, 404, 'unknown route => 404';
+        like $r->content, qr{you're lost}i, 'Error message looks good';
+    };
 };
-
-subtest "/public" => sub {
-    my $r = dancer_response GET => '/public';
-
-    is $r->status,    510,             'send_error sets the status to 510';
-    like $r->content, qr{Static page}, 'Error message looks good';
-};
-
-subtest "/no_template" => sub {
-    my $r = dancer_response GET => '/no_template';
-
-    is $r->status, 404, 'send_error sets the status to 404';
-    like $r->content, qr{<h1>Error 404 - Not Found</h1>},
-      'Error message looks good';
-};
-
-subtest '404 with static template' => sub {
-    my $r = dancer_response GET => '/middle/of/nowhere';
-
-    is $r->status, 404, 'unknown route => 404';
-    like $r->content, qr{you're lost}i, 'Error message looks good';
-};
-
 
 done_testing;

--- a/t/forward.t
+++ b/t/forward.t
@@ -1,9 +1,10 @@
 use strict;
 use warnings;
 use Test::More import => ['!pass'];
+use Plack::Test;
+use HTTP::Request::Common;
 
 use Dancer2;
-use Dancer2::Test;
 
 get '/' => sub {
     'home:' . join( ',', params );
@@ -32,47 +33,136 @@ get '/go_to_post/' => sub {
 # get '/b' => sub { vars->{test} = 1;  forward '/a'; };
 # get '/a' => sub { return "test is " . var('test'); };
 
-response_status_is  [ GET => '/' ] => 200;
-response_content_is [ GET => '/' ] => 'home:';
+my $app = Dancer2->runner->server->psgi_app;
+is( ref $app, 'CODE', 'Got app' );
 
-response_status_is  [ GET => '/bounce/' ] => 200;
-response_content_is [ GET => '/bounce/' ] => 'home:';
+test_psgi $app, sub {
+    my $cb = shift;
+    is( $cb->( GET '/' )->code, 200, '[GET /] Correct code' );
+    is( $cb->( GET '/' )->content, 'home:', '[GET /] Correct content' );
 
-response_status_is [ GET => '/bounce/thesethings/' ] => 200;
-response_content_is [ GET => '/bounce/thesethings/' ] =>
-  'home:withparams,thesethings';
+    is( $cb->( GET '/bounce/' )->code, 200, '[GET /bounce] Correct code' );
+    is(
+        $cb->( GET '/bounce/' )->content,
+        'home:',
+        '[GET /bounce] Correct content',
+    );
 
-response_status_is [ GET => '/bounce2/adding_params/' ] => 200;
-response_content_is [ GET => '/bounce2/adding_params/' ] =>
-  'home:withparams,foo';
+    is(
+        $cb->( GET '/bounce/thesethings/' )->code,
+        200,
+        '[GET /bounce/thesethings/] Correct code',
+    );
 
-response_status_is  [ GET => '/go_to_post/' ] => 200;
-response_content_is [ GET => '/go_to_post/' ] => 'post:foo,bar';
+    is(
+        $cb->( GET '/bounce/thesethings/' )->content,
+        'home:withparams,thesethings',
+        '[GET /bounce/thesethings/] Correct content',
+    );
 
-# NOT SUPPORTED
-# response_status_is  [ GET => '/b' ] => 200;
-# response_content_is [ GET => '/b' ] => 'test is 1';
+    is(
+        $cb->( GET '/bounce2/adding_params/' )->code,
+        200,
+        '[GET /bounce2/adding_params/] Correct code',
+    );
 
-my $expected_headers = [
-    'Content-Length' => 5,
-    'Content-Type'   => 'text/html; charset=UTF-8',
-    'Server'         => "Perl Dancer2 $Dancer2::VERSION",
-];
+    is(
+        $cb->( GET '/bounce2/adding_params/' )->content,
+        'home:withparams,foo',
+        '[GET /bounce2/adding_params/] Correct content',
+    );
 
-response_headers_are_deeply [ GET => '/bounce/' ], $expected_headers;
+    is(
+        $cb->( GET '/go_to_post/' )->code,
+        200,
+        '[GET /go_to_post/] Correct code',
+    );
 
-# checking post
+    is(
+        $cb->( GET '/go_to_post/' )->content,
+        'post:foo,bar',
+        '[GET /go_to_post/] Correct content',
+    );
 
-post '/'        => sub {'post-home'};
-post '/bounce/' => sub { forward('/') };
+    # NOT SUPPORTED
+    # response_status_is  [ GET => '/b' ] => 200;
+    # response_content_is [ GET => '/b' ] => 'test is 1';
 
-response_status_is  [ POST => '/' ] => 200;
-response_content_is [ POST => '/' ] => 'post-home';
+    {
+        my $res = $cb->( GET '/bounce/' );
 
-response_status_is  [ POST => '/bounce/' ] => 200;
-response_content_is [ POST => '/bounce/' ] => 'post-home';
+        is(
+            $res->headers->content_length,
+            5,
+            '[GET /bounce/] Correct content length',
+        );
 
-$expected_headers->[1] = 9;
-response_headers_are_deeply [ POST => '/bounce/' ], $expected_headers;
+        is(
+            $res->headers->content_type,
+            'text/html',
+            '[GET /bounce/] Correct content type',
+        );
+
+        is(
+            $res->headers->content_type_charset,
+            'UTF-8',
+            '[GET /bounce/] Correct content type charset',
+        );
+
+        is(
+            $res->headers->server,
+            "Perl Dancer2 $Dancer2::VERSION",
+            '[GET /bounce/] Correct Server',
+        );
+
+    }
+
+    # checking post
+    post '/'        => sub {'post-home'};
+    post '/bounce/' => sub { forward('/') };
+
+    is( $cb->( POST '/' )->code, 200, '[POST /] Correct code' );
+    is( $cb->( POST '/' )->content, 'post-home', '[POST /] Correct content' );
+
+    is(
+        $cb->( POST '/bounce/' )->code,
+        200,
+        '[POST /bounce/] Correct code',
+    );
+
+    is(
+        $cb->( POST '/bounce/' )->content,
+        'post-home',
+        '[POSt /bounce/] Correct content',
+    );
+
+    {
+        my $res = $cb->( POST '/bounce/' );
+
+        is(
+            $res->headers->content_length,
+            9,
+            '[POST /bounce/] Correct content length',
+        );
+
+        is(
+            $res->headers->content_type,
+            'text/html',
+            '[POST /bounce/] Correct content type',
+        );
+
+        is(
+            $res->headers->content_type_charset,
+            'UTF-8',
+            '[POST /bounce/] Correct content type charset',
+        );
+
+        is(
+            $res->headers->server,
+            "Perl Dancer2 $Dancer2::VERSION",
+            '[POST /bounce/] Correct Server',
+        );
+    }
+};
 
 done_testing;

--- a/t/hooks.t
+++ b/t/hooks.t
@@ -3,6 +3,8 @@ use warnings;
 use Test::More import => ['!pass'];
 use File::Spec;
 use Carp;
+use Plack::Test;
+use HTTP::Request::Common;
 
 use Class::Load 'try_load_class';
 use Capture::Tiny 0.12 'capture_stderr';
@@ -114,65 +116,72 @@ my $tests_flags = {};
 
 }
 
-use Dancer2::Test;
+$_->finish for @{ Dancer2->runner->server->apps };
+my $app = Dancer2->runner->server->psgi_app;
+is( ref $app, 'CODE', 'Got app' );
 
-subtest 'request hooks' => sub {
-    my $r = dancer_response get => '/';
-    is $tests_flags->{before_request},     1,     "before_request was called";
-    is $tests_flags->{after_request},      1,     "after_request was called";
-    is $tests_flags->{before_serializer},  undef, "before_serializer undef";
-    is $tests_flags->{after_serializer},   undef, "after_serializer undef";
-    is $tests_flags->{before_file_render}, undef, "before_file_render undef";
-};
+test_psgi $app, sub {
+    my $cb = shift;
 
-subtest 'after hook called once per request' => sub {
-    # Get current value of the 'after_request' tests flag.
-    my $current = $tests_flags->{after_request};
+    subtest 'request hooks' => sub {
+        $cb->( GET '/' );
+        is $tests_flags->{before_request},     1,     "before_request was called";
+        is $tests_flags->{after_request},      1,     "after_request was called";
+        is $tests_flags->{before_serializer},  undef, "before_serializer undef";
+        is $tests_flags->{after_serializer},   undef, "after_serializer undef";
+        is $tests_flags->{before_file_render}, undef, "before_file_render undef";
+    };
 
-    my $r = dancer_response get => '/redirect';
-    is $tests_flags->{after_request}, ++$current,
-        "after_request called after redirect";
+    subtest 'after hook called once per request' => sub {
+        # Get current value of the 'after_request' tests flag.
+        my $current = $tests_flags->{after_request};
 
-    $r = dancer_response get => '/forward';
-    is $tests_flags->{after_request}, ++$current,
-        "after_request called only once after forward";
-};
+        $cb->( GET '/redirect' );
+        is $tests_flags->{after_request}, ++$current,
+            "after_request called after redirect";
 
-subtest 'serializer hooks' => sub {
-    require 'JSON.pm';
-    my $r = dancer_response get => '/json';
-    my $json = JSON::to_json( [ foo => 42, added_in_hook => 1 ] );
-    is $r->content, $json, 'response is serialized';
-    is $tests_flags->{before_serializer}, 1, 'before_serializer was called';
-    is $tests_flags->{after_serializer},  1, 'after_serializer was called';
-    is $tests_flags->{before_file_render}, undef, "before_file_render undef";
-};
+        $cb->( GET '/forward' );
+        is $tests_flags->{after_request}, ++$current,
+            "after_request called only once after forward";
+    };
 
-subtest 'file render hooks' => sub {
-    my $resp = dancer_response get => '/send_file';
-    is $tests_flags->{before_file_render}, 1, "before_file_render was called";
-    is $tests_flags->{after_file_render},  1, "after_file_render was called";
+    subtest 'serializer hooks' => sub {
+        require 'JSON.pm';
+        my $r = $cb->( GET '/json' );
+        my $json = JSON::to_json( [ foo => 42, added_in_hook => 1 ] );
+        is $r->content, $json, 'response is serialized';
+        is $tests_flags->{before_serializer}, 1, 'before_serializer was called';
+        is $tests_flags->{after_serializer},  1, 'after_serializer was called';
+        is $tests_flags->{before_file_render}, undef, "before_file_render undef";
+    };
 
-    $resp = dancer_response get => '/file.txt';
-    is $tests_flags->{before_file_render}, 2, "before_file_render was called";
-    is $tests_flags->{after_file_render},  2, "after_file_render was called";
-};
+    subtest 'file render hooks' => sub {
+        $cb->( GET '/send_file' );
+        is $tests_flags->{before_file_render}, 1, "before_file_render was called";
+        is $tests_flags->{after_file_render},  1, "after_file_render was called";
 
-subtest 'template render hook' => sub {
-    my $resp = dancer_response get => '/template';
-    is $tests_flags->{before_template_render}, 1,
-      "before_template_render was called";
-    is $tests_flags->{after_template_render}, 1,
-      "after_template_render was called";
-};
+        $cb->( GET '/file.txt' );
 
-subtest 'before can halt' => sub {
-    my $resp = dancer_response get => '/intercepted';
-    is join( "\n", @{ $resp->[2] } ) => 'halted by before';
-};
+        is $tests_flags->{before_file_render}, 2, "before_file_render was called";
+        is $tests_flags->{after_file_render},  2, "after_file_render was called";
+    };
 
-subtest 'route_exception' => sub {
-    capture_stderr { dancer_response get => '/route_exception' };
+    subtest 'template render hook' => sub {
+        $cb->( GET '/template' );
+        is $tests_flags->{before_template_render}, 1,
+          "before_template_render was called";
+        is $tests_flags->{after_template_render}, 1,
+          "after_template_render was called";
+    };
+
+    subtest 'before can halt' => sub {
+        my $resp = $cb->( GET '/intercepted' );
+        is( $resp->content, 'halted by before' );
+    };
+
+    subtest 'route_exception' => sub {
+        capture_stderr { $cb->( GET '/route_exception' ) };
+    };
 };
 
 done_testing;

--- a/t/plugin_import.t
+++ b/t/plugin_import.t
@@ -3,6 +3,8 @@
 use strict;
 use warnings;
 use Test::More;
+use Plack::Test;
+use HTTP::Request::Common;
 
 {
     use Dancer2;
@@ -13,10 +15,18 @@ use Test::More;
     };
 }
 
-use Dancer2::Test;
+my $app = Dancer2->runner->server->psgi_app;
+is( ref $app, 'CODE', 'Got app' );
 
-response_content_is '/test', 'dancer_plugin_with_import_keyword',
-  "the plugin exported its keyword";
+test_psgi $app, sub {
+    my $cb = shift;
+
+    is(
+        $cb->( GET '/test' )->content,
+        'dancer_plugin_with_import_keyword',
+        'the plugin exported its keyword',
+    );
+};
 
 is_deeply(
     t::lib::PluginWithImport->stuff,

--- a/t/plugin_multiple_apps.t
+++ b/t/plugin_multiple_apps.t
@@ -3,6 +3,8 @@
 use strict;
 use warnings;
 use Test::More;
+use Plack::Test;
+use HTTP::Request::Common;
 
 {
 
@@ -18,10 +20,14 @@ use Test::More;
     use t::lib::SubApp2 with => { session => engine('session') };
 }
 
-use Dancer2::Test apps => [ 'App', 't::lib::SubApp1', 't::lib::SubApp2' ];
+my $app = Dancer2->runner->server->psgi_app;
+is( ref $app, 'CODE', 'Got app' );
 
-# make sure both apps works as epxected
-response_content_is '/subapp1', 1;
-response_content_is '/subapp2', 2;
+test_psgi $app, sub {
+    my $cb = shift;
+
+    is( $cb->( GET '/subapp1' )->content, 1, '/subapp1' );
+    is( $cb->( GET '/subapp2' )->content, 2, '/subapp2' );
+};
 
 done_testing;

--- a/t/plugin_register.t
+++ b/t/plugin_register.t
@@ -2,7 +2,6 @@ use strict;
 use warnings;
 
 use Test::More import => ['!pass'];
-use Dancer2::Test;
 use Test::Fatal;
 
 subtest 'reserved keywords' => sub {

--- a/t/plugin_syntax.t
+++ b/t/plugin_syntax.t
@@ -1,7 +1,8 @@
 use strict;
 use warnings;
 use Test::More import => ['!pass'];
-use Dancer2::Test;
+use Plack::Test;
+use HTTP::Request::Common;
 use JSON;
 
 subtest 'global and route keywords' => sub {
@@ -22,20 +23,36 @@ subtest 'global and route keywords' => sub {
         foo_route;
     }
 
-    my $r = dancer_response( GET => '/' );
-    is( $r->content, '/', 'route defined by a plugin' );
+    my $app = Dancer2->runner->server->psgi_app;
+    is( ref $app, 'CODE', 'Got app' );
 
-    $r = dancer_response( GET => '/foo' );
-    is( $r->content, 'foo', 'DSL keyword wrapped by a plugin' );
+    test_psgi $app, sub {
+        my $cb = shift;
 
-    $r = dancer_response( GET => '/plugin_setting' );
-    is( $r->content,
-        encode_json( { plugin => "42" } ),
-        'plugin_setting returned the expected config'
-    );
+        is(
+            $cb->( GET '/' )->content,
+            '/',
+            'route defined by a plugin',
+        );
 
-    $r = dancer_response( GET => '/app' );
-    is( $r->content, 'main', 'app name is correct' );
+        is(
+            $cb->( GET '/foo' )->content,
+            'foo',
+            'DSL keyword wrapped by a plugin',
+        );
+
+        is(
+            $cb->( GET '/plugin_setting' )->content,
+            encode_json( { plugin => "42" } ),
+            'plugin_setting returned the expected config'
+        );
+
+        is(
+            $cb->( GET '/app' )->content,
+            'main',
+            'app name is correct',
+        );
+    };
 };
 
 subtest 'plugin old syntax' => sub {
@@ -46,8 +63,18 @@ subtest 'plugin old syntax' => sub {
         around_get;
     }
 
-    my $r = dancer_response GET => '/foo/plugin';
-    is $r->content, 'foo plugin';
+    my $app = Dancer2->runner->server->psgi_app;
+    is( ref $app, 'CODE', 'Got app' );
+
+    test_psgi $app, sub {
+        my $cb = shift;
+
+        is(
+            $cb->( GET '/foo/plugin' )->content,
+            'foo plugin',
+            'foo plugin',
+        );
+    };
 };
 
 subtest caller_dsl => sub {
@@ -56,9 +83,18 @@ subtest caller_dsl => sub {
         use t::lib::DancerPlugin;
     }
 
-    my $r = dancer_response GET => '/sitemap';
-    is $r->content,
-      '^\/$, ^\/app$, ^\/foo$, ^\/foo\/plugin$, ^\/plugin_setting$, ^\/sitemap$';
+    my $app = Dancer2->runner->server->psgi_app;
+    is( ref $app, 'CODE', 'Got app' );
+
+    test_psgi $app, sub {
+        my $cb = shift;
+
+        is(
+            $cb->( GET '/sitemap' )->content,
+            '^\/$, ^\/app$, ^\/foo$, ^\/foo\/plugin$, ^\/plugin_setting$, ^\/sitemap$',
+            'Correct content',
+        );
+    };
 };
 
 subtest 'hooks in plugins' => sub {
@@ -88,12 +124,25 @@ subtest 'hooks in plugins' => sub {
 
     }
 
-    is $counter, 0, "the hook has not been executed";
-    my $r = dancer_response( GET => '/hooks_plugin' );
-    is( $r->content, 'hook for plugin', '... route is rendered' );
-    is $counter, 1, "... and the hook has been executed exactly once";
+    my $app = Dancer2->runner->server->psgi_app;
+    is( ref $app, 'CODE', 'Got app' );
 
-    dancer_response( GET => '/hook_with_var' );
+    test_psgi $app, sub {
+        my $cb = shift;
+
+        is( $counter, 0, 'the hook has not been executed' );
+
+        is(
+            $cb->( GET '/hooks_plugin' )->content,
+            'hook for plugin',
+            '... route is rendered',
+        );
+
+        is( $counter, 1, '... and the hook has been executed exactly once' );
+
+        # call the route that has an additional test
+        $cb->( GET '/hook_with_var' );
+    };
 };
 
 

--- a/t/splat.t
+++ b/t/splat.t
@@ -1,25 +1,35 @@
 use strict;
 use warnings;
 use Test::More import => ['!pass'];
-
-use Dancer2::Test;
+use Plack::Test;
+use HTTP::Request::Common;
 
 my @splat;
 
 {
     use Dancer2;
     get '/*/*/*' => sub {
+        my $params = params();
+        ::is_deeply(
+            $params,
+            { splat => [ qw<foo bar baz> ], foo => 42 },
+            'Correct params',
+        );
+
         @splat = splat;
     };
 }
 
-my $resp = dancer_response(
-    get => '/foo/bar/baz',
-    { params => { foo => 42 }, }
-);
+my $app = Dancer2->runner->server->psgi_app;
+is( ref $app, 'CODE', 'Got app' );
 
-is_deeply [@splat], [qw(foo bar baz)], "splat behaves as expected";
-is $resp->status,         200, "got a 200";
-is_deeply $resp->content, 3,   "got expected response";
+test_psgi $app, sub {
+    my $cb  = shift;
+    my $res = $cb->( GET '/foo/bar/baz?foo=42' );
+
+    is_deeply( [@splat], [qw(foo bar baz)], 'splat behaves as expected' );
+    is( $res->code, 200, 'got a 200' );
+    is_deeply( $res->content, 3, 'got expected response' );
+};
 
 done_testing;

--- a/t/template_name.t
+++ b/t/template_name.t
@@ -3,6 +3,8 @@ use warnings;
 use File::Spec;
 use File::Basename 'dirname';
 use Test::More;
+use Plack::Test;
+use HTTP::Request::Common;
 
 {
 
@@ -15,8 +17,12 @@ use Test::More;
     };
 }
 
-use Dancer2::Test apps => ['Foo'];
+my $app = Dancer2->runner->server->psgi_app;
+is( ref $app, 'CODE', 'Got app' );
 
-response_content_is "/template_name", 'Tiny', "template name";
+test_psgi $app, sub {
+    my $cb = shift;
+    is( $cb->( GET '/template_name' )->content, 'Tiny', 'template name' );
+};
 
 done_testing;

--- a/t/uri_for.t
+++ b/t/uri_for.t
@@ -1,6 +1,8 @@
-use Test::More import => ['!pass'];
 use strict;
 use warnings;
+use Test::More import => ['!pass'];
+use Plack::Test;
+use HTTP::Request::Common;
 
 {
     use Dancer2;
@@ -9,11 +11,18 @@ use warnings;
     };
 }
 
-use Dancer2::Test;
-response_status_is [ GET => '/foo' ], 200;
+my $app = Dancer2->runner->server->psgi_app;
+is( ref $app, 'CODE', 'Got app' );
 
-response_content_is [ GET => '/foo' ],
-  'http://localhost/foo',
-  "uri_for works as expected";
+test_psgi $app, sub {
+    my $cb = shift;
+
+    is( $cb->( GET '/foo' )->code, 200, '/foo code okay' );
+    is(
+        $cb->( GET '/foo' )->content,
+        'http://localhost/foo',
+        'uri_for works as expected',
+    );
+};
 
 done_testing;

--- a/t/vars.t
+++ b/t/vars.t
@@ -1,10 +1,10 @@
 use strict;
 use warnings;
 use Test::More import => ['!pass'];
+use Plack::Test;
+use HTTP::Request::Common;
 
-plan tests => 2;
-
-use Dancer2::Test;
+plan tests => 3;
 
 {
     use Dancer2;
@@ -23,5 +23,13 @@ use Dancer2::Test;
     };
 }
 
-response_content_is [ GET => '/bar' ], 'foo';
-response_content_is [ GET => '/baz' ], 'ugh';
+my $app = Dancer2->runner->server->psgi_app;
+is( ref $app, 'CODE', 'Got app' );
+ 
+test_psgi $app, sub {
+    my $cb = shift;
+
+    is( $cb->( GET '/bar' )->content, 'foo', 'foo' );
+    is( $cb->( GET '/baz' )->content, 'ugh', 'ugh' );
+};
+


### PR DESCRIPTION
Finally.

Dancer2::Test is 864 lines of code, including documentation. It tries to fake
whatever is necessary to run a request against the Dancer2 code.

It is long, exhaustive, and hairy. It has subtle edge cases that required work
on both D1 and D2. It has been the bane of much testing code in Dancer. It also
has at least one bug (GH #544).

More than all of these, it simply isn't required. At least not the way it works
now. Plack::Test covers everything it does, except for checking POD coverage of
routes - which could be kept.

For now I've changed all the code that uses it to use Plack::Test instead. The
code is clearer and more maintainable.

Dancer2::Test will move to a relaxed deprecation cycle. We will add
documentation that shows a more preferred approach, including how to rewrite
existing tests.

An additional process requires having a simple method for fetching the PSGI app,
that will also call the "finish" methods on each Dancer application - tasks
that are more verbose without Dancer2::Test and expose more of the backend than
should be exposed (because it might actually change).
