### PR TITLE
Fix: Additional HTTP methods for Ajax plugin #543

### DIFF
--- a/lib/Dancer2/Plugin/Ajax.pm
+++ b/lib/Dancer2/Plugin/Ajax.pm
@@ -15,7 +15,13 @@ use Dancer2::Plugin;
     use Dancer2;
     use Dancer2::Plugin::Ajax;
 
+    # For GET / POST
     ajax '/check_for_update' => sub {
+        # ... some Ajax code
+    };
+
+    # For all valid HTTP methods
+    ajax ['get', 'post', ... ] => '/check_for_more' =>sub {
         # ... some Ajax code
     };
 
@@ -40,7 +46,7 @@ Disable the layout
 
 =item *
 
-The action built matches POST / GET requests.
+The action built matches POST / GET requests by default. This can be extended by passing it an ArrayRef of allowed HTTP methods.
 
 =back
 
@@ -61,6 +67,16 @@ Here is example to use JSON:
 
 register 'ajax' => sub {
     my ( $dsl, $pattern, @rest ) = @_;
+
+    my $default_methods = [ 'get', 'post' ];
+
+    # BugFix for #543
+    # If the given pattern is an ArrayRef, we override the defaults
+    # and pass these onto to SDL->any()
+    if( ref($pattern) eq "ARRAY" ) {
+        $default_methods = $pattern;
+        $pattern = shift(@rest);
+    }
 
     my $code;
     for my $e (@rest) { $code = $e if ( ref($e) eq 'CODE' ) }
@@ -87,7 +103,7 @@ register 'ajax' => sub {
         return $response;
     };
 
-    $dsl->any( [ 'get', 'post' ] => $pattern, $ajax_route );
+    $dsl->any( $default_methods => $pattern, $ajax_route );
 };
 
 register_plugin;

--- a/t/ajax_plugin.t
+++ b/t/ajax_plugin.t
@@ -2,7 +2,7 @@ use strict;
 use warnings;
 use Test::More import => ['!pass'];
 use Plack::Test;
-use HTTP::Request::Common;
+use HTTP::Request::Common qw(GET HEAD PUT POST DELETE);
 
 {
     package AjaxApp;
@@ -21,6 +21,10 @@ use HTTP::Request::Common;
 
     ajax '/another/test' => sub {
         "{more: 'json'}";
+    };
+
+    ajax ['put', 'del', 'get'] => "/more/test" => sub {
+        "{some: 'json'}";
     };
 }
 
@@ -42,6 +46,26 @@ test_psgi $app, sub {
     {
         my $res = $cb->( GET '/test', 'X-Requested-With' => 'XMLHttpRequest' );
         is( $res->content, q({some: 'json'}), 'ajax works with GET' );
+    }
+
+    {
+        my $res = $cb->( GET '/more/test', 'X-Requested-With' => 'XMLHttpRequest' );
+        is( $res->content, q({some: 'json'}), 'ajax works with GET on multi-method route' );
+    }
+
+    {
+        my $res = $cb->( PUT '/more/test', 'X-Requested-With' => 'XMLHttpRequest' );
+        is( $res->content, q({some: 'json'}), 'ajax works with PUT on multi-method route' );
+    }
+
+    {
+        my $res = $cb->( DELETE '/more/test', 'X-Requested-With' => 'XMLHttpRequest' );
+        is( $res->content, q({some: 'json'}), 'ajax works with DELETE on multi-method route' );
+    }
+
+    {
+        my $res = $cb->( POST '/more/test', 'X-Requested-With' => 'XMLHttpRequest' );
+        is( $res->code, 404, 'ajax multi-method route only valid for the defined routes' );
     }
 
     {


### PR DESCRIPTION
Same as https://github.com/PerlDancer/Dancer2/pull/549 but with fixed/new tests - I cant unlink/trash the first PR, so this is the real one. Fixes #543.

RFC
