### PR TITLE
put HTTP_REQUEST_BASE support back from Dancer 1

### DIFF
--- a/lib/Dancer2/Cookbook.pod
+++ b/lib/Dancer2/Cookbook.pod
@@ -1288,6 +1288,12 @@ under a specified dir:
 
     ProxyPass /mywebapp/ http://localhost:3000/
     ProxyPassReverse /mywebapp/ http://localhost:3000/
+    <Location /mywebapp/>
+        RequestHeader set Request-Base /mywebapp
+    </Location>
+
+HTTP header C<Request-Base> is taken into account by Dancer, only when
+C<behind_proxy> setting is set to true.
 
 It is important for you to note that the Apache2 modules C<mod_proxy> and C<mod_proxy_http>
 must be enabled.

--- a/lib/Dancer2/Core/Request.pm
+++ b/lib/Dancer2/Core/Request.pm
@@ -679,7 +679,13 @@ sub _common_uri {
     my $uri = URI->new;
     $uri->scheme($scheme);
     $uri->authority( $host || "$server:$port" );
-    $uri->path( $path      || '/' );
+    if (setting('behind_proxy')) {
+        my $request_base = $self->env->{REQUEST_BASE} || $self->env->{HTTP_REQUEST_BASE} || '';
+        $uri->path($request_base . $path || '/');
+    }
+    else {
+        $uri->path($path || '/');
+    }
 
     return $uri;
 }

--- a/lib/Dancer2/Core/Request.pm
+++ b/lib/Dancer2/Core/Request.pm
@@ -73,6 +73,8 @@ supported:
 
 =item C<remote_address>
 
+=item C<request_base>
+
 =item C<user_agent>
 
 =item C<x_requested_with>
@@ -415,6 +417,7 @@ sub protocol              { $_[0]->env->{SERVER_PROTOCOL} }
 sub port                  { $_[0]->env->{SERVER_PORT} }
 sub request_uri           { $_[0]->env->{REQUEST_URI} }
 sub user                  { $_[0]->env->{REMOTE_USER} }
+sub request_base          { $_[0]->env->{REQUEST_BASE} || $_[0]->env->{HTTP_REQUEST_BASE} }
 sub script_name           { $_[0]->env->{SCRIPT_NAME} }
 
 =method scheme()


### PR DESCRIPTION
I think it is still needed in Dancer2 when tested in our server.

the code is copied from Dancer::Request.

Thanks