### PR TITLE
Remove is_daemon flag after change to HTTP::Server::PSGI.

### DIFF
--- a/lib/Dancer2/Config.pod
+++ b/lib/Dancer2/Config.pod
@@ -125,11 +125,6 @@ The port Dancer2 will listen to.
 Default value is 3000. This setting can be changed on the command-line with the
 B<--port> switch.
 
-=head3 daemon (boolean)
-
-If set to true, runs the standalone webserver in the background.
-This setting can be changed on the command-line with the B<--daemon> flag.
-
 =head3 behind_proxy (boolean)
 
 If set to true, Dancer2 will look to C<X-Forwarded-Protocol> and

--- a/lib/Dancer2/Core/Runner.pm
+++ b/lib/Dancer2/Core/Runner.pm
@@ -148,7 +148,6 @@ sub _build_default_config {
         logger       => ( $ENV{DANCER_LOGGER}       || 'console' ),
         host         => ( $ENV{DANCER_SERVER}       || '0.0.0.0' ),
         port         => ( $ENV{DANCER_PORT}         || '3000' ),
-        is_daemon    => ( $ENV{DANCER_DAEMON}       || 0 ),
         views        => ( $ENV{DANCER_VIEWS}
               || path( $self->config_location, 'views' ) ),
         appdir        => $self->location,
@@ -248,7 +247,7 @@ sub psgi_app {
 
 sub print_banner {
     my $self = shift;
-    my $pid  = $$; # TODO: how to get background pid?
+    my $pid  = $$;
 
     # we only print the info if we need to
     # FIXME: go to the configuration


### PR DESCRIPTION
As HTTP::Server::PSGI does not daemonize (run in background), the
standalone server can't either (a good thing IMHO).

If anyone needs the previous behaviour, they can always use
  plackup -s HTTP::Server::Simple --daemonize bin/app.pl
