### PR TITLE
Bugfix for (multiple) cookie extraction within a Request.

### DIFF
--- a/lib/Dancer2/Core/Request.pm
+++ b/lib/Dancer2/Core/Request.pm
@@ -12,6 +12,7 @@ use URI::Escape;
 
 use Dancer2::Core::Types;
 use Dancer2::Core::Request::Upload;
+use Dancer2::Core::Cookie;
 
 with 'Dancer2::Core::Role::Headers';
 
@@ -1105,7 +1106,10 @@ sub _build_cookies {
     my $self    = shift;
     my $cookies = {};
 
-    foreach my $cookie ( $self->header('COOKIE') ) {
+    my $http_cookie = $self->header('Cookie');
+    return $cookies unless defined $http_cookie; # nothing to do
+
+    foreach my $cookie ( split( /[,;]\s/, $http_cookie ) ) {
 
         # here, we don't want more than the 2 first elements
         # a cookie string can contains something like:

--- a/t/request.t
+++ b/t/request.t
@@ -27,6 +27,7 @@ sub run_test {
         REMOTE_HOST          => 'localhost',
         HTTP_USER_AGENT      => 'Mozilla',
         REMOTE_USER          => 'sukria',
+        HTTP_COOKIE          => 'cookie.a=foo=bar; cookie.b=1234abcd',
     };
 
     my $req = Dancer2::Core::Request->new( env => $env );
@@ -62,6 +63,9 @@ sub run_test {
 
     note "tests params";
     is_deeply { $req->params }, { foo => 42, bar => [ 12, 13, 14 ] };
+
+    note "tests cookies";
+    is( keys %{ $req->cookies }, 2, "multiple cookies extracted" );
 
     my $forward = $req->make_forward_to('/somewhere');
     is $forward->path_info, '/somewhere';


### PR DESCRIPTION
As part of improving cookie handling within Dancer2::Test, I misread the HTTP::Headers docs and assumed it was doing the split when called in array context. Oops, sorry!

Add tests and the split erroneously removed.
