### PR TITLE
GH #585: Adding a pre-dispatch sanity check for supported HTTP method:

### DIFF
--- a/lib/Dancer2/Core/Request.pm
+++ b/lib/Dancer2/Core/Request.pm
@@ -1126,7 +1126,6 @@ sub _build_cookies {
     return $cookies;
 }
 
-
 1;
 
 =head1 SEE ALSO

--- a/lib/Dancer2/Core/Runner.pm
+++ b/lib/Dancer2/Core/Runner.pm
@@ -226,6 +226,15 @@ sub psgi_app {
         my $env = shift;
         my $response;
 
+        # pre-request sanity check
+        my $method = uc $env->{'REQUEST_METHOD'};
+        $Dancer2::Core::Types::supported_http_methods{$method}
+            or return [
+                405,
+                [ 'Content-Type' => 'text/plain' ],
+                [ "Method Not Allowed\n\n$method is not supported." ]
+            ];
+
         eval {
             $response = $self->dispatcher->dispatch($env)->to_psgi;
             1;

--- a/lib/Dancer2/Core/Types.pm
+++ b/lib/Dancer2/Core/Types.pm
@@ -12,6 +12,10 @@ use Exporter 'import';
 our @EXPORT;
 our @EXPORT_OK;
 
+our %supported_http_methods = map +( $_ => 1 ), qw<
+    GET HEAD POST PUT DELETE OPTIONS PATCH
+>;
+
 
 =head1 DESCRIPTION
 
@@ -116,7 +120,7 @@ my $definitions = [
         subtype_of => 'Str',
         from       => 'MooX::Types::MooseLike::Base',
         test       => sub {
-            grep {/^$_[0]$/} qw(get head post put delete options patch);
+            grep {/^$_[0]$/} map +( lc ), keys %supported_http_methods
         },
         message =>
           sub { return exception_message( $_[0], 'a Dancer2Method' ) },
@@ -126,7 +130,7 @@ my $definitions = [
         subtype_of => 'Str',
         from       => 'MooX::Types::MooseLike::Base',
         test       => sub {
-            grep {/^$_[0]$/} qw(GET HEAD POST PUT DELETE OPTIONS PATCH);
+            grep {/^$_[0]$/} keys %supported_http_methods
         },
         message =>
           sub { return exception_message( $_[0], 'a Dancer2HTTPMethod' ) },

--- a/t/http_methods.t
+++ b/t/http_methods.t
@@ -1,7 +1,7 @@
 use strict;
 use warnings;
 
-use Test::More tests => 9;
+use Test::More tests => 12;
 use Plack::Test;
 use HTTP::Request;
 
@@ -36,5 +36,14 @@ test_psgi $app, sub {
     my $res = $cb->( HTTP::Request->new( HEAD => '/head' ) );
     is( $res->content, '', 'HEAD /' ); # HEAD requests have no content
     is( $res->headers->content_length, 4, 'Content-Length for HEAD' );
+
+    # Testing invalid HTTP methods.
+    {
+        my $req = HTTP::Request->new( "ILLEGAL" => '/' );
+        my $res = $cb->( $req );
+        ok( !$res->is_success, "Response->is_success is false when using illegal HTTP method" );
+        is( $res->code, 405, "Illegal method should return 405 code" );
+        like( $res->content, qr<Method Not Allowed>, q<Illegal method should have "Method Not Allowed" in the content> );
+    }
 };
 


### PR DESCRIPTION
It should not be possible to cause an internal server error by sending
an invalid HTTP method. Dancer 2 should return a 405 "Method Not Allowed"
instead.

We now inspect the environment hash to know whether it is possible to
build a request from the given parameters. The issue that spawned this
was being passed an unsupported method.

We keep a hash of supported methods in Dancer2::Core::Types available from
everywhere.
