### PR TITLE
unify empty return statements

### DIFF
--- a/lib/Dancer2/Core/App.pm
+++ b/lib/Dancer2/Core/App.pm
@@ -163,7 +163,7 @@ sub _build_template_engine {
     defined $config or $config = $self->config;
     defined $value  or $value  = $config->{'template'};
 
-    defined $value or return undef;
+    defined $value or return;
     ref $value    and return $value;
 
     is_module_name($value)
@@ -192,7 +192,7 @@ sub _build_serializer_engine {
     defined $config or $config = $self->config;
     defined $value  or $value  = $config->{serializer};
 
-    defined $value or return undef;
+    defined $value or return;
     ref $value    and return $value;
 
     my $engine_options =
@@ -413,7 +413,7 @@ has prefix => (
     predicate => 1,
     coerce    => sub {
         my $prefix = shift;
-        defined($prefix) and $prefix eq "/" and return undef;
+        defined($prefix) and $prefix eq "/" and return;
         return $prefix;
     },
 );

--- a/lib/Dancer2/Core/Error.pm
+++ b/lib/Dancer2/Core/Error.pm
@@ -123,7 +123,7 @@ sub _build_error_template {
       if -f $self->app->engine('template')
           ->view_pathname( $self->status );
 
-    return undef;
+    return;
 }
 
 has static_page => (
@@ -142,7 +142,7 @@ sub _build_static_page {
 
     my $filename = sprintf "%s/%d.html", $public_dir, $self->status;
 
-    open my $fh, $filename or return undef;
+    open my $fh, $filename or return;
 
     local $/ = undef;    # slurp time
 

--- a/lib/Dancer2/Core/HTTP.pm
+++ b/lib/Dancer2/Core/HTTP.pm
@@ -123,7 +123,7 @@ sub status {
     if ( exists $HTTP_CODES->{$status} ) {
         return $HTTP_CODES->{$status};
     }
-    return undef;
+    return;
 }
 
 =func status_message(status_code)

--- a/lib/Dancer2/Template/Implementation/ForkedTiny.pm
+++ b/lib/Dancer2/Template/Implementation/ForkedTiny.pm
@@ -190,7 +190,7 @@ sub _expression {
     foreach (@path) {
 
         # Support for private keys
-        return undef if substr( $_, 0, 1 ) eq '_';
+        return if substr( $_, 0, 1 ) eq '_';
 
         # Split by data type
         my $type = ref $cursor;


### PR DESCRIPTION
use simple `return;` instead of `return undef;`

closes #607
