### PR TITLE
Avoid needless sub indirection from DSL keywords.

### DIFF
--- a/lib/Dancer2/Core/DSL.pm
+++ b/lib/Dancer2/Core/DSL.pm
@@ -12,10 +12,10 @@ use Dancer2::FileUtils;
 with 'Dancer2::Core::Role::DSL';
 
 sub dsl_keywords {
-
-    # the flag means : 1 = is global, 0 = is not global. global means can be
-    # called from anywhere. not global means must be called from within a route
-    # handler
+    # is_global
+    #  0 - false, can only be called from within a route.
+    #  1 - true, can be called from anywhere.
+    #  2 - as above but additionally doesn't recieve $self as $_[0].
     {   any                  => { is_global => 1 },
         app                  => { is_global => 1 },
         captures             => { is_global => 0 },
@@ -26,15 +26,15 @@ sub dsl_keywords {
         cookies              => { is_global => 0 },
         dance                => { is_global => 1 },
         dancer_app           => { is_global => 1 },
-        dancer_version       => { is_global => 1 },
-        dancer_major_version => { is_global => 1 },
+        dancer_version       => { is_global => 2 },
+        dancer_major_version => { is_global => 2 },
         debug                => { is_global => 1 },
         del                  => { is_global => 1 },
-        dirname              => { is_global => 1 },
+        dirname              => { is_global => 2 },
         dsl                  => { is_global => 1 },
         engine               => { is_global => 1 },
         error                => { is_global => 1 },
-        false                => { is_global => 1 },
+        false                => { is_global => 2 },
         forward              => { is_global => 0 },
         from_dumper          => { is_global => 1 },
         from_json            => { is_global => 1 },
@@ -52,7 +52,7 @@ sub dsl_keywords {
         params               => { is_global => 0 },
         pass                 => { is_global => 0 },
         patch                => { is_global => 1 },
-        path                 => { is_global => 1 },
+        path                 => { is_global => 2 },
         post                 => { is_global => 1 },
         prefix               => { is_global => 1 },
         psgi_app             => { is_global => 1 },
@@ -74,7 +74,7 @@ sub dsl_keywords {
         to_dumper            => { is_global => 1 },
         to_json              => { is_global => 1 },
         to_yaml              => { is_global => 1 },
-        true                 => { is_global => 1 },
+        true                 => { is_global => 2 },
         upload               => { is_global => 0 },
         uri_for              => { is_global => 0 },
         var                  => { is_global => 0 },
@@ -83,23 +83,21 @@ sub dsl_keywords {
     };
 }
 
-sub dancer_app     { shift->app }
-sub dancer_version { Dancer2->VERSION }
+*dancer_app = \&app;
 
-sub dancer_major_version {
-    return ( split /\./, dancer_version )[0];
-}
+sub dancer_version       {     Dancer2->VERSION }
+sub dancer_major_version { int Dancer2->VERSION }
 
 sub debug   { shift->log( debug   => @_ ) }
 sub info    { shift->log( info    => @_ ) }
 sub warning { shift->log( warning => @_ ) }
 sub error   { shift->log( error   => @_ ) }
 
-sub true  {1}
-sub false {0}
+sub true  () {1}
+sub false () {0}
 
-sub dirname { shift and Dancer2::FileUtils::dirname(@_) }
-sub path    { shift and Dancer2::FileUtils::path(@_) }
+*dirname = \&Dancer2::FileUtils::dirname;
+*path    = \&Dancer2::FileUtils::path;
 
 sub config { shift->app->settings }
 
@@ -126,7 +124,7 @@ alias for L<setting>:
 
 =cut
 
-sub set { shift->setting(@_) }
+*set = \&setting;
 
 sub template { shift->app->template(@_) }
 
@@ -291,7 +289,7 @@ sub runner { Dancer2->runner }
 # start the server
 sub start { shift->runner->start }
 
-sub dance { shift->start(@_) }
+*dance = \&start;
 
 sub psgi_app {
     my $self = shift;
@@ -306,9 +304,10 @@ sub psgi_app {
 sub status       { shift->response->status(@_) }
 sub push_header  { shift->response->push_header(@_) }
 sub header       { shift->response->header(@_) }
-sub headers      { shift->response->header(@_) }
 sub content_type { shift->response->content_type(@_) }
 sub pass         { shift->app->pass }
+
+*headers = \&header;
 
 #
 # Route handler helpers

--- a/lib/Dancer2/Core/Request.pm
+++ b/lib/Dancer2/Core/Request.pm
@@ -441,8 +441,6 @@ Return script_name from the environment.
 =cut
 
 # aliases, kept for backward compat
-sub agent                 { $_[0]->user_agent }
-sub remote_address        { $_[0]->address }
 sub forwarded_for_address { $_[0]->env->{HTTP_X_FORWARDED_FOR} }
 sub address               { $_[0]->env->{REMOTE_ADDR} }
 sub remote_host           { $_[0]->env->{REMOTE_HOST} }
@@ -451,6 +449,9 @@ sub port                  { $_[0]->env->{SERVER_PORT} }
 sub request_uri           { $_[0]->env->{REQUEST_URI} }
 sub user                  { $_[0]->env->{REMOTE_USER} }
 sub script_name           { $_[0]->env->{SCRIPT_NAME} }
+
+*agent          = \&user_agent;
+*remote_address = \&address;
 
 =method scheme()
 

--- a/lib/Dancer2/Core/Role/DSL.pm
+++ b/lib/Dancer2/Core/Role/DSL.pm
@@ -47,49 +47,27 @@ sub dsl { $_[0] }
 # exports new symbol to caller
 sub export_symbols_to {
     my ( $self, $caller, $args ) = @_;
-    my $exports = $self->_construct_export_map($args);
 
-    foreach my $export ( keys %{$exports} ) {
+    while ( my ( $keyword, $opts ) = each %{ $self->keywords } ) {
+        # Skip if the keyword was excluded from importation.
+        next if $args->{"!$keyword"};
+
+        my $name = "${caller}::$keyword";
+
         no strict 'refs';
-        my $existing = *{"${caller}::${export}"}{CODE};
 
-        next if defined $existing;
+        # Skip if they already have this symbol.
+        next if defined *{$name}{CODE};
 
-        *{"${caller}::${export}"} = $exports->{$export};
-    }
+        *$name = $opts->{is_global} == 2 ? $self->can($keyword)
+               : $opts->{is_global}      ? sub { $self->$keyword(@_) }
+               : sub {
+            croak "Function '$keyword' must be called from a route handler"
+                unless defined $self->app->has_request;
 
-    return keys %{$exports};
-}
-
-# private
-
-sub _compile_keyword {
-    my ( $self, $keyword, $is_global ) = @_;
-
-    my $compiled_code = sub { $self->$keyword(@_); };
-
-    if ( !$is_global ) {
-        my $code = $compiled_code;
-        $compiled_code = sub {
-            $self->app->has_request or
-                croak "Function '$keyword' must be called from a route handler";
-            $code->(@_);
+            $self->$keyword(@_);
         };
     }
-
-    return $compiled_code;
-}
-
-sub _construct_export_map {
-    my ( $self, $args ) = @_;
-    my $keywords = $self->keywords;
-    my %map;
-    foreach my $keyword ( keys %$keywords ) {
-        # check if the keyword were excluded from importation
-        $args->{ '!' . $keyword } and next;
-        $map{$keyword} = $self->_compile_keyword( $keyword, $keywords->{$keyword}{is_global} );
-    }
-    return \%map;
 }
 
 1;

--- a/lib/Dancer2/FileUtils.pm
+++ b/lib/Dancer2/FileUtils.pm
@@ -102,7 +102,7 @@ L<File::Basename> for details.
 
 =cut
 
-sub dirname { File::Basename::dirname(@_) }
+*dirname = \&File::Basename::dirname;
 
 =func set_file_mode($fh);
 


### PR DESCRIPTION
This is more a RFC as there is an unanswered question on how to identify
functional keywords, POD changes need to be made, and a few more tests of our
DSL would be nice too :-P

So basically, who likes or dislikes this? Is it worth finishing up? What follows is the
commit message as it's rather informative.

---

When importing the DSL keywords into the caller they are currently wrapped in
subs that close over $self like so:

*caller::foo = sub { $self->foo(@_) }

This allows simple calling conventions for the caller. If the keyword has
restrictions on where is can be called from (is_global=0) then this sub is
additionally wrapped like so:

my $code = sub { $self->foo(@_) };

*caller::foo = sub {
    croak 'Not from here buddy' unless $self->app->has_request;

```
$code->(@_);
```

};

This is wasteful as it creates another layer of indirection. This commit changes
how those DSL keywords are imported like so:

*caller::foo = sub {
    croak 'Not from here buddy' unless $self->app->has_request;

```
$self->foo(@_);
```

};

There is also a third type of keyword that doesn't need $self at all, these
purely functional keywords can be better imported as:

*caller::foo = $self->can('foo');

This avoids the redirection all together. To identify these keywords is_global
has been set to 2 for those keywords. I'm open to suggestions on this point, I
did toy with the idea of an additional flag, is_functional perhaps?

Another benefit on inlining functional DSL keywords is that by adding prototypes
we can have constant folding applied at compile time like so:

$ perl -Mlib=lib -MDancer2 -MO=Deparse -e 'print dancer_version, true, false'
sub Stream::Buffered::rewind;
sub Stream::Buffered::size;
sub Stream::Buffered::print;
use warnings;
use strict;
print dancer_version(), 1, 0;
-e syntax OK

The calls to true and false have been completely inlined whereas the call to
dancer_version can't be as Dancer2->VERSION is not a constant.

Furthermore this commit tweaks how subs are aliased in Dancer2, preferring the
more efficient "*alias = &sub" form wherever possible.

One point of note is that export_symbols_to no longer returns a list of what it
has imported, the two and only calls to this don't seem to make use of this so I
can't see it being a huge issue but it could be made to work if needed.
