### PR TITLE
The default is documented as JSON, so honor that

### DIFF
--- a/lib/Dancer2/Serializer/Mutable.pm
+++ b/lib/Dancer2/Serializer/Mutable.pm
@@ -1,4 +1,5 @@
 package Dancer2::Serializer::Mutable;
+
 # ABSTRACT: Serialize and deserialize content based on HTTP header
 
 use Moo;
@@ -6,9 +7,7 @@ use Carp 'croak';
 use Encode;
 with 'Dancer2::Core::Role::Serializer';
 
-has '+content_type' => (
-    default => 'application/json',
-);
+has '+content_type' => ( default => 'application/json', );
 
 my $formats = {
     'text/x-yaml'        => 'YAML',
@@ -19,32 +18,25 @@ my $formats = {
 };
 
 my $serializer = {
-    'YAML'   => {
-        to      => sub { Dancer2::Core::DSL::to_yaml(@_)   },
-        from    => sub { Dancer2::Core::DSL::from_yaml(@_) },
+    'YAML' => {
+        to   => sub { Dancer2::Core::DSL::to_yaml(@_) },
+        from => sub { Dancer2::Core::DSL::from_yaml(@_) },
     },
     'Dumper' => {
-        to      => sub { Dancer2::Core::DSL::to_dumper(@_)   },
-        from    => sub { Dancer2::Core::DSL::from_dumper(@_) },
+        to   => sub { Dancer2::Core::DSL::to_dumper(@_) },
+        from => sub { Dancer2::Core::DSL::from_dumper(@_) },
     },
-    'JSON'   => {
-        to      => sub { Dancer2::Core::DSL::to_json(@_)   },
-        from    => sub { Dancer2::Core::DSL::from_json(@_) },
+    'JSON' => {
+        to   => sub { Dancer2::Core::DSL::to_json(@_) },
+        from => sub { Dancer2::Core::DSL::from_json(@_) },
     },
 };
 
 sub support_content_type {
     my ( $self, $ct ) = @_;
 
-    # FIXME: are we getting full content type?
-
-    if ( $ct && grep +( $_ eq $ct ), keys %{$formats} ) {
-        $self->set_content_type($ct);
-
-        return 1;
-    }
-
-    return 0;
+ #We support everything. If we don't support it explicitly, we default to json
+    return 1;
 }
 
 sub serialize {
@@ -54,9 +46,7 @@ sub serialize {
     my $format = $self->_get_content_type();
 
     # Match format with a serializer and return
-    $format and return $serializer->{$format}{'to'}->(
-        $self, $entity
-    );
+    $format and return $serializer->{$format}{'to'}->( $self, $entity );
 
     # If none is found then just return the entity without change
     return $entity;
@@ -66,8 +56,7 @@ sub deserialize {
     my ( $self, $content ) = @_;
 
     # The right content type should already be set
-    my $format = $formats->{$self->content_type};
-
+    my $format = $formats->{ $self->content_type };
     $format and return $serializer->{$format}{'from'}->( $self, $content );
 
     return $content;
@@ -79,7 +68,7 @@ sub _get_content_type {
 
     # Search for the first HTTP header variable which
     # specifies supported content.
-    foreach my $method ( qw<content_type accept> ) {
+    foreach my $method ( qw<content_type accept accept_type> ) {
         if ( my $value = $self->request->header($method) ) {
             if ( exists $formats->{$value} ) {
                 $self->set_content_type($value);
@@ -89,6 +78,7 @@ sub _get_content_type {
     }
 
     # If none if found, return the default, 'JSON'.
+    $self->set_content_type('application/json');
     return 'JSON';
 }
 

--- a/t/serializer_mutable.t
+++ b/t/serializer_mutable.t
@@ -1,7 +1,7 @@
 use strict;
 use warnings;
 
-use Test::More tests => 41;
+use Test::More tests => 81;
 use Dancer2::Serializer::Mutable;
 use Plack::Test;
 use HTTP::Request::Common;
@@ -32,6 +32,30 @@ is( ref $app, 'CODE', 'Got app' );
 test_psgi $app, sub {
     my $cb = shift;
 
+    #Check if the application state does not influence the returned header
+    {
+        my $res = $cb->( GET '/serialize' );
+        is(
+            $res->headers->content_type,
+            'application/json',
+            "Correct content-type headers",
+        );
+
+        $res = $cb->( GET '/serialize', 'Content-Type' => 'text/x-data-dumper' );
+        is(
+            $res->headers->content_type,
+            'text/x-data-dumper',
+            "Correct content-type headers",
+        );
+        $res = $cb->( GET '/serialize' );
+        is(
+            $res->headers->content_type,
+            'application/json',
+            "Correct content-type headers",
+        );
+
+    }
+
     # Configure all test cases
     my $d = {
         yaml    => {
@@ -45,6 +69,11 @@ test_psgi $app, sub {
         json    => {
                 types       => [ qw(text/x-json application/json) ],
                 value       => JSON::to_json({ bar => 'baz' }),
+            },
+        default => {
+                types               => [ '*/*', '' ],
+                value               => JSON::to_json( { bar => 'baz' } ),
+                return_content_type => 'application/json',
             },
     };
 
@@ -65,7 +94,7 @@ test_psgi $app, sub {
                     is( $res->content, $s->{value}, "[/$format] Correct content" );
                     is(
                         $res->headers->content_type,
-                        $content_type,
+                        $s->{return_content_type} || $content_type,
                         "[/$format] Correct content-type headers",
                     );
                 }
@@ -73,8 +102,8 @@ test_psgi $app, sub {
                 # Test sending the value serialized in the correct format
                 # needs to be de-serialized and returned
                 my $req = $cb->( POST '/deserialize',
-                                 'Content-Type' => $content_type,
-                                 content        => $s->{value} );
+                                'Content-Type' => $content_type,
+                                content        => $s->{value} );
 
                 is( $req->code, 200, "[/$format] Correct status" );
                 is( $req->content, 'baz', "[/$format] Correct content" );


### PR DESCRIPTION
Serializer::Mutable documents the default return type as being JSON. In practice, it doesn't serialize the output at all without an explicit request. On top of that it exhibits a bug where it returns the content_type header of a previous request. This branch corrects both and adds a test to check.
