### PR TITLE
Added serialize/deserialize DSL keywords

### DIFF
--- a/lib/Dancer2/Core/DSL.pm
+++ b/lib/Dancer2/Core/DSL.pm
@@ -30,6 +30,7 @@ sub dsl_keywords {
         dancer_major_version => { is_global => 1 },
         debug                => { is_global => 1 },
         del                  => { is_global => 1 },
+        deserialize          => { is_global => 1 },
         dirname              => { is_global => 1 },
         dsl                  => { is_global => 1 },
         engine               => { is_global => 1 },
@@ -64,6 +65,7 @@ sub dsl_keywords {
         runner               => { is_global => 1 },
         send_error           => { is_global => 0 },
         send_file            => { is_global => 0 },
+        serialize            => { is_global => 1 },
         session              => { is_global => 0 },
         set                  => { is_global => 1 },
         setting              => { is_global => 1 },
@@ -413,6 +415,30 @@ sub to_dumper {
     shift; # remove first element
     require 'Dancer2/Serializer/Dumper.pm';
     Dancer2::Serializer::Dumper::to_dumper(@_);
+}
+
+sub serialize {
+    my $self = shift;
+
+    my $serializer = $self->app->engine('serializer');
+
+    if ($serializer) {
+        return $serializer->serialize(@_);
+    } else {
+        carp 'Please set a serializer first!';
+    }
+}
+
+sub deserialize {
+    my $self = shift;
+
+    my $serializer = $self->app->engine('serializer');
+
+    if ($serializer) {
+        return $serializer->deserialize(@_);
+    } else {
+        carp 'Please set a serializer first!';
+    }
 }
 
 sub log { shift->app->log(@_) }


### PR DESCRIPTION
These keywords would use the serializer engine, which is set on the app. That way, the Dispatcher can identify possible serialization/deserialization errors.

Current to_json, to_yaml, from_json etc methods all create a new object, which will then be used for the serialization job. But the error checking is done only on the $app->engine('serializer')

These keywords would also use the serializer, which is configured in the app (json, yaml, dumper whatever).