### PR TITLE
Allow to/from_json to throw

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -110,7 +110,6 @@ HTTP::Body = 0
 Test::TCP = 0
 Test::MockTime = 0
 Test::Script = 0
-Test::Trap = 0
 LWP::Protocol::PSGI = 0.06
 
 ; ; for maintainers, see with mst how to avoid these

--- a/dist.ini
+++ b/dist.ini
@@ -110,6 +110,7 @@ HTTP::Body = 0
 Test::TCP = 0
 Test::MockTime = 0
 Test::Script = 0
+Test::Trap = 0
 LWP::Protocol::PSGI = 0.06
 
 ; ; for maintainers, see with mst how to avoid these

--- a/lib/Dancer2/Serializer/JSON.pm
+++ b/lib/Dancer2/Serializer/JSON.pm
@@ -9,21 +9,26 @@ with 'Dancer2::Core::Role::Serializer';
 has '+content_type' => (default => 'application/json');
 
 # helpers
+# Do not use (de)serialize(), since they are wrapped to trap exceptions
 sub from_json {
+    my ( $entity, $options ) = @_;
+
     my $s = Dancer2::Serializer::JSON->new;
-    $s->deserialize(@_);
+    JSON::from_json( $entity, $s->_merge_options($options) );
 }
 
 sub to_json {
+    my ( $entity, $options ) = @_;
+
     my $s = Dancer2::Serializer::JSON->new;
-    $s->serialize(@_);
+    JSON::to_json( $entity, $s->_merge_options($options) );
 }
 
 # class definition
 sub loaded {1}
 
-sub serialize {
-    my ( $self, $entity, $options ) = @_;
+sub _merge_options {
+    my ( $self, $options ) = @_;
 
     my $config = $self->config;
 
@@ -33,14 +38,19 @@ sub serialize {
 
     $options->{utf8} = 1 if !defined $options->{utf8};
 
-    JSON::to_json( $entity, $options );
+    $options;
+}
+
+sub serialize {
+    my ( $self, $entity, $options ) = @_;
+
+    JSON::to_json( $entity, $self->_merge_options($options) );
 }
 
 sub deserialize {
     my ( $self, $entity, $options ) = @_;
 
-    $options->{utf8} = 1 if !defined $options->{utf8};
-    JSON::from_json( $entity, $options );
+    JSON::from_json( $entity, $self->_merge_options($options) );
 }
 
 1;

--- a/t/serializer_json.t
+++ b/t/serializer_json.t
@@ -2,6 +2,7 @@ use strict;
 use warnings;
 
 use Test::More;
+use Test::Trap;
 use Plack::Test;
 use HTTP::Request::Common;
 
@@ -37,22 +38,32 @@ my @tests = (
           { c => [ { d => 3, e => { f => 4, g => 'word', } } ], h => 6 },
         options => { pretty => 1 },
         name    => "nested",
+    },
+    {   entity  => { error => bless({}, 'invalid') },
+        options => {},
+        name    => "exception propagates",
     }
 );
 
 my $app = Dancer2->runner->psgi_app;
 
 for my $test (@tests) {
-    my $expected = JSON::to_json( $test->{entity}, $test->{options} );
+    my $expected;
+    trap { $expected = JSON::to_json( $test->{entity}, $test->{options} ); };
+    my $expected_left = $trap->leaveby();
 
     # Helpers pass options
-    my $actual =
-      Dancer2::Serializer::JSON::to_json( $test->{entity}, $test->{options} );
-    is( $actual, $expected, "to_json: $test->{name}" );
+    my $actual;
+    trap { $actual = Dancer2::Serializer::JSON::to_json( $test->{entity}, $test->{options} ); };
+    my $actual_left = $trap->leaveby();
+    is( $actual,      $expected,      "to_json: $test->{name}" );
+    is( $actual_left, $expected_left, "to_json: $test->{name} lives/dies" );
 
     # Options from config
     my $serializer = Dancer2::Serializer::JSON->new(config => $test->{options});
-    my $output = $serializer->serialize( $test->{entity} );
+    my $output;
+    trap { $output = $serializer->serialize( $test->{entity} ); };
+    $trap->did_return(); # Serializer not expected to die
     is( $output, $expected, "serialize: $test->{name}" );
 
     $MyApp::entity = $test->{entity};
@@ -60,11 +71,17 @@ for my $test (@tests) {
         my $cb = shift;
 
         my $res = $cb->( GET '/serialize' );
-        is($res->content, $expected,
-          "serialized content in response: $test->{name}");
+        if($expected_left eq 'return') {
+            is($res->content, $expected,
+              "serialized content in response: $test->{name}");
+        } else {
+            is($res->code, 500,
+              "response code for failed serialize: $test->{name}");
+            # TODO Add appropriate content test; at the moment this actually
+            #      errors out about an undefined variable
+        }
     };
 
 }
-
 
 done_testing();


### PR DESCRIPTION
```
Do not implement to/from_json in terms of the (de)serialize()
methods of a temporary Serializer instance, since the error
generated is lost and they will just return undef. Let them throw
instead so that the route code can handle the exception, or propagate
to general "route died" handling. Configuration options are still
merged in using a temporary instance.

Add test dependency on Test::Trap for testing exceptions.

Add unit tests for unserializable data for the JSON serializer.
```
Some considerations for review:
 * Addresses issue #644 for the case where you are using to/from_json without it being set as your serializer (e.g. because you want to respect the configuration, but do not want to blanket handle complex returns from routes).
 * The refactoring to `_merge_options` means that configuration can now affect *de*serialization as well. I'm not sure if this is desirable.
 * I am not clear on what the *intended* behaviour is if you set up a serializer then return unserializable data from your route, so the test for this case is quite loose (and has a TODO). At the moment Dancer seems to be choking on an undef internally in this case, but fixing that seems like material for a separate commit.
 * Should possibly do the same for YAML etc. if this is deemed to be an appropriate change.
 * (First time I've done the pull request workflow, so I hope I've got this right!)