### PR TITLE
Fixed typo of with_return clearer method

### DIFF
--- a/lib/Dancer2/Core/App.pm
+++ b/lib/Dancer2/Core/App.pm
@@ -277,7 +277,7 @@ has with_return => (
     is        => 'ro',
     predicate => 1,
     writer    => 'set_with_return',
-    clearer   => 'clear_with_response',
+    clearer   => 'clear_with_return',
 );
 
 

--- a/lib/Dancer2/Core/Dispatcher.pm
+++ b/lib/Dancer2/Core/Dispatcher.pm
@@ -62,7 +62,7 @@ DISPATCH:
             };
 
             # Ensure we clear the with_return handler
-            $app->clear_with_response;
+            $app->clear_with_return;
 
             # handle forward requests
             if ( ref $response eq 'Dancer2::Core::Request' ) {


### PR DESCRIPTION
Changed the with return clearer name from 'clear_with_response' to 'clear_with_return'
