### PR TITLE
Added test for settings.environment in views

### DIFF
--- a/t/template_environment.t
+++ b/t/template_environment.t
@@ -1,0 +1,42 @@
+#!/usr/bin/env perl
+
+use strict;
+use warnings;
+
+use Test::More;
+use Plack::Test;
+use HTTP::Request::Common;
+
+{
+    package MyApp;
+
+    use Dancer2;
+
+    set template => 'template_toolkit';
+
+    get '/foo' => sub {
+        template 'environment_setting'
+    };
+    get '/bar' => sub {
+        set environment => 'development';
+        template 'environment_setting'
+    };
+}
+
+my $app = Dancer2->psgi_app;
+is( ref $app, 'CODE', 'Got app' );
+
+test_psgi $app, sub {
+    my $cb = shift;
+    my $res;
+
+    $res = $cb->(GET '/foo');
+    is $res->code, 200;
+    like $res->content, qr/development/;
+
+    $res = $cb->(GET '/bar');
+    is $res->code, 200;
+    like $res->content, qr/development/;
+};
+
+done_testing();

--- a/t/views/environment_setting.tt
+++ b/t/views/environment_setting.tt
@@ -1,0 +1,1 @@
+[% settings.environment %]


### PR DESCRIPTION
Adding a test to prove issue https://github.com/PerlDancer/Dancer2/issues/650 . If the environment config setting is not set explicitly in the config or inside the app (via the 'set' keyword'), the 'settings.environment' variable inside the view is empty (no default value is set apparently). However, if the environment variable is set explicitly, the 'settings.environment' value is accessible in the view.
