### PR TITLE
Major architectural change: Apps now dispatch independently as full-fledged PSGI apps

### DIFF
--- a/lib/Dancer2/Core/DSL.pm
+++ b/lib/Dancer2/Core/DSL.pm
@@ -71,6 +71,7 @@ sub dsl_keywords {
         start                => { is_global => 1 },
         status               => { is_global => 0 },
         template             => { is_global => 0 },
+        to_app               => { is_global => 1 },
         to_dumper            => { is_global => 1 },
         to_json              => { is_global => 1 },
         to_yaml              => { is_global => 1 },
@@ -298,6 +299,8 @@ sub psgi_app {
 
     $self->runner->psgi_app( [ $self->app ] );
 }
+
+sub to_app { shift->app->to_app }
 
 #
 # Response alterations

--- a/lib/Dancer2/Core/Dispatcher.pm
+++ b/lib/Dancer2/Core/Dispatcher.pm
@@ -2,9 +2,6 @@ package Dancer2::Core::Dispatcher;
 # ABSTRACT: Class for dispatching request to the appropriate route handler
 
 use Moo;
-use Encode;
-use Safe::Isa;
-use Return::MultiLevel qw(with_return);
 
 use Dancer2::Core::Types;
 use Dancer2::Core::Request;
@@ -16,214 +13,42 @@ has apps => (
     default => sub { [] },
 );
 
-# take the list of applications and an $env hash, return a Response object.
+has apps_psgi => (
+    is      => 'ro',
+    isa     => ArrayRef,
+    lazy    => 1,
+    builder => '_build_apps_psgi',
+);
+
+sub _build_apps_psgi {
+    my $self = shift;
+    return [ map +( $_->name, $_->to_app ), @{ $self->apps } ];
+}
+
 sub dispatch {
-    my ( $self, $env, $request ) = @_;
+    my ( $self, $env ) = @_;
+    my @apps = @{ $self->apps_psgi };
 
-    my %preexisting_sessions;
-
-    # warn "dispatching ".$env->{PATH_INFO}
-    #    . " with ".join(", ", map { $_->name } @{$self->apps });
-
-DISPATCH:
     while (1) {
-    foreach my $app ( @{ $self->apps } ) {
-        # warn "walking through routes of ".$app->name;
+        for ( my $i = 0; $i < @apps; $i += 2 ) {
+            my ( $app_name, $app ) = @apps[ $i, $i + 1 ];
 
-        # create request if we didn't get any
-        $request ||= $self->build_request( $env, $app );
+            my $response = $app->($env);
 
-        my $cname       = $app->engine('session')->cookie_name;
-        my $http_method = lc $request->method;
-        my $path_info   =    $request->path_info;
-
-        $app->log( core => "looking for $http_method $path_info" );
-
-      ROUTE:
-        foreach my $route ( @{ $app->routes->{$http_method} } ) {
-            # warn "testing route ".$route->regexp;
-
-            # TODO store in route cache
-
-            # go to the next route if no match
-            my $match = $route->match($request)
-                or next ROUTE;
-
-            $request->_set_route_params($match);
-            $app->set_request($request);
-            # Add session to app *if* we have a session and the request
-            # has the appropriate cookie header for _this_ app.
-
-            $preexisting_sessions{$cname}
-                and $app->set_session( $preexisting_sessions{$cname} );
-
-            my $response = with_return {
-                my ($return) = @_;
-
-                # stash the multilevel return coderef in the app
-                $app->has_with_return
-                    or $app->set_with_return($return);
-
-                return $self->_dispatch_route($route, $app);
-            };
-
-            # Ensure we clear the with_return handler
-            $app->clear_with_return;
-
-            # handle forward requests
-            if ( ref $response eq 'Dancer2::Core::Request' ) {
-                # this is actually a request, not response
-                $request = $response;
-
-                # Get the session object from the app before we clean up
-                # the request context, so we can propogate this to the
-                # next dispatch cycle (if required).
-                $app->_has_session
-                    and $preexisting_sessions{$cname} = $app->session;
-
-                $app->cleanup;
-
-                next DISPATCH;
-            }
-
-            # from here we assume the response is a Dancer2::Core::Response
-
-            # No further processing of this response if its halted
-            if ( $response->is_halted ) {
-                $app->cleanup;
-                return $response;
-            }
-
-            # pass the baton if the response says so...
-            if ( $response->has_passed ) {
-                ## A previous route might have used splat, failed
-                ## this needs to be cleaned from the request.
-                exists $request->{_params}{splat}
-                    and delete $request->{_params}{splat};
-
-                $response->has_passed(0); # clear for the next round
-                next ROUTE;
-            }
-
-            $app->execute_hook( 'core.app.after_request', $response );
-            $app->cleanup;
-
-            return $response;
+            # the app raised a flag saying it couldn't match anything
+            # which is different than "I matched and it's a 404"
+            delete Dancer2->runner->{'internal_404'}
+                or return $response;
         }
 
-        # Get current session object to allow propogation to next app.
-        $app->_has_session
-            and $preexisting_sessions{$cname} = $app->session;
-        $app->cleanup;
-    }
-
+        # don't run anymore
         last;
     } # while
 
-    # Assume there was at least one app to the request object was instantiated..
-    return $self->response_not_found( $request );
-}
-
-# the dispatcher can build requests now :)
-sub build_request {
-    my ( $self, $env, $app ) = @_;
-
-    # If we have an app, send the serialization engine
-    my $engine  = $app->engine('serializer');
-    my $request = Dancer2::Core::Request->new(
-          env             => $env,
-          is_behind_proxy => Dancer2->runner->config->{'behind_proxy'} || 0,
-        ( serializer      => $engine )x!! $engine,
-    );
-
-    # if it's a mutable serializer, we add more headers
-    # so it can be set properly
-    # I don't like doing this... -- Sawyer
-    if ( $engine->$_isa('Dancer2::Serializer::Mutable') ) {
-        $engine->{'extra_headers'} = {
-            map +( $_ => $request->$_ ), qw<content_type accept accept_type>
-        }
-    }
-
-    # Log deserialization errors
-    if ($engine) {
-        $engine->has_error and $app->log(
-            core => "Failed to deserialize the request : " .
-                    $engine->error
-        );
-    }
-
-    return $request;
-}
-
-# Call any before hooks then the matched route.
-sub _dispatch_route {
-    my ($self, $route, $app) = @_;
-
-    $app->execute_hook( 'core.app.before_request', $app );
-    my $response = $app->response;
-
-    my $content;
-    if ( $response->is_halted ) {
-        # if halted, it comes from the 'before' hook. Take its content
-        $content = $response->content;
-    }
-    else {
-        $content = eval { $route->execute($app) };
-        my $error = $@;
-        if ($error) {
-            $app->log( error => "Route exception: $error" );
-            $app->execute_hook( 'core.app.route_exception', $app, $error );
-            return $self->response_internal_error( $app, $error );
-        }
-    }
-
-    if ( ref $content eq 'Dancer2::Core::Response' ) {
-        $response = $app->set_response($content);
-    }
-    elsif ( defined $content ) {
-        # The response object has no back references to the content or app
-        # Update the default_content_type of the response if any value set in
-        # config so it can be applied when the response is encoded/returned.
-        if ( exists $app->config->{content_type}
-          && $app->config->{content_type} ) {
-            $response->default_content_type($app->config->{content_type});
-        }
-
-        $response->content($content);
-        $response->encode_content;
-    }
-
-    return $response;
-}
-
-sub response_internal_error {
-    my ( $self, $app, $error ) = @_;
-
-    # warn "got error: $error";
-
-    return Dancer2::Core::Error->new(
-        app       => $app,
-        status    => 500,
-        exception => $error,
-    )->throw;
-}
-
-sub response_not_found {
-    my ( $self, $request ) = @_;
-
-    # Use first defined app (for now)
-    my $app = $self->apps->[0];
-    $app->set_request($request);
-
-    my $response = Dancer2::Core::Error->new(
-        app    => $app,
-        status  => 404,
-        message => $request->path,
-    )->throw;
-
-    $app->cleanup;
-    return $response;
+    # a 404 on all apps, using the first app
+    my $default_app = $self->apps->[0];
+    my $request     = $default_app->build_request($env);
+    return $default_app->response_not_found($request)->to_psgi;
 }
 
 1;

--- a/lib/Dancer2/Core/Runner.pm
+++ b/lib/Dancer2/Core/Runner.pm
@@ -196,43 +196,18 @@ sub psgi_app {
         $apps = $self->apps;
     }
 
-    foreach my $app ( @{$apps} ) {
-        $app->finish;
-    }
-
     my $dispatcher = Dancer2::Core::Dispatcher->new( apps => $apps );
 
-    # eval entire request to catch any internal errors
-    my $psgi = sub {
+    # initialize psgi_apps
+    # (calls ->finish on the apps and create their PSGI apps)
+    # the dispatcher caches that in the attribute
+    # so ->finish isn't actually called again if you run this method
+    $dispatcher->apps_psgi;
+
+    return sub {
         my $env = shift;
-        my $response;
-
-        # pre-request sanity check
-        my $method = uc $env->{'REQUEST_METHOD'};
-        $Dancer2::Core::Types::supported_http_methods{$method}
-            or return [
-                405,
-                [ 'Content-Type' => 'text/plain' ],
-                [ "Method Not Allowed\n\n$method is not supported." ]
-            ];
-
-        eval {
-            $response = $dispatcher->dispatch($env)->to_psgi;
-            1;
-        } or do {
-            return [
-                500,
-                [ 'Content-Type' => 'text/plain' ],
-                [ "Internal Server Error\n\n$@"  ],
-            ];
-        };
-
-        return $response;
+        return $dispatcher->dispatch($env);
     };
-
-    my $builder = Plack::Builder->new;
-    $builder->add_middleware('Head');
-    return $builder->wrap($psgi);
 }
 
 sub print_banner {

--- a/lib/Dancer2/Manual.pod
+++ b/lib/Dancer2/Manual.pod
@@ -1556,13 +1556,22 @@ choices).
 This keyword should be called at the very end of the script, once all routes
 are defined.  At this point, Dancer takes over control.
 
+=head2 to_app
+
+Returns the PSGI coderef for the current (and only the current) application.
+
+You can call it as a method on the class or as a DSL:
+
+    my $app = MyApp->to_app;
+
+    # or
+
+    my $app = to_app;
+
 =head2 psgi_app
 
-Returns the PSGI coderef for the current (and only the current) application
-
-This keyword will typically be used as a method to get the psgi coderef for
-testing, or building a larger application via L<Plack::Builder> from
-independent parts.
+Provides the same functionality as C<to_app> but uses the deprecated
+Dispatcher engine. You should use C<to_app>.
 
 =head2 status
 

--- a/t/ajax_plugin.t
+++ b/t/ajax_plugin.t
@@ -28,7 +28,7 @@ use HTTP::Request::Common qw(GET HEAD PUT POST DELETE);
     };
 }
 
-my $app = Dancer2->psgi_app;
+my $app = AjaxApp->to_app;
 is( ref $app, 'CODE', 'Got app' );
 
 test_psgi $app, sub {

--- a/t/any.t
+++ b/t/any.t
@@ -18,7 +18,7 @@ use HTTP::Request::Common;
     };
 }
 
-my $app = Dancer2->psgi_app;
+my $app = App->to_app;
 is( ref $app, 'CODE', 'Got app' );
 
 test_psgi $app, sub {

--- a/t/app.t
+++ b/t/app.t
@@ -54,7 +54,7 @@ for my $path ( '/', '/blog', '/mywebsite', '/mywebsite/blog', ) {
         '/mywebsite/blog' => '/blog',
     };
 
-    my $resp = $dispatcher->dispatch($env)->to_psgi;
+    my $resp = $dispatcher->dispatch($env);
     is $resp->[0], 200, 'got a 200';
     is $resp->[2][0], $expected->{$path}, 'got expected route';
 }
@@ -123,7 +123,7 @@ for
         PATH_INFO      => $path,
     };
 
-    my $resp = $dispatcher->dispatch($env)->to_psgi;
+    my $resp = $dispatcher->dispatch($env);
     is $resp->[0], 200, 'got a 200';
     is $resp->[2][0], $path, 'got expected route';
 }
@@ -158,7 +158,7 @@ my $env = {
 };
 
 like(
-    exception { my $resp = $dispatcher->dispatch($env)->to_psgi },
+    $dispatcher->dispatch($env)->[2][0],
     qr{Exception caught in 'core.app.before_request' filter: Hook error: Can't locate object method "failure"},
     'before filter nonexistent method failure',
 );
@@ -169,10 +169,6 @@ $env = {
     REQUEST_METHOD => 'GET',
     PATH_INFO      => '/',
 };
-
-is( exception { my $resp = $dispatcher->dispatch($env)->to_psgi },
-    undef, 'Successful to_psgi of response',
-);
 
 # test duplicate routes when the path is a regex
 $app = Dancer2::Core::App->new( name => 'main' );

--- a/t/app_alone.t
+++ b/t/app_alone.t
@@ -1,0 +1,25 @@
+#!perl
+
+use strict;
+use warnings;
+
+use Test::More tests => 3;
+use Plack::Test;
+use HTTP::Request::Common;
+
+{
+    package MyApp;
+    use Dancer2;
+
+    get '/' => sub {'OK'};
+}
+
+my $app = MyApp->to_app;
+isa_ok( $app, 'CODE' );
+
+test_psgi $app, sub {
+    my $cb = shift;
+    is( $cb->( GET '/' )->code,    200,  '[GET /] Correct status'  );
+    is( $cb->( GET '/' )->content, 'OK', '[GET /] Correct content' );
+};
+

--- a/t/auto_page.t
+++ b/t/auto_page.t
@@ -16,7 +16,7 @@ use HTTP::Request::Common;
     engine('template')->layout('main');
 }
 
-my $app = Dancer2->psgi_app;
+my $app = AutoPageTest->to_app;
 is( ref $app, 'CODE', 'Got app' );
 
 test_psgi $app, sub {

--- a/t/caller.t
+++ b/t/caller.t
@@ -15,7 +15,7 @@ use HTTP::Request::Common;
 
 }
 
-my $app = Dancer2->psgi_app;
+my $app = App->to_app;
 test_psgi $app, sub {
     my $cb  = shift;
     my $res = $cb->( GET '/' );

--- a/t/context-in-before.t
+++ b/t/context-in-before.t
@@ -41,7 +41,7 @@ my $before;
     get '/' => sub {'OK'};
 }
 
-my $app = Dancer2->psgi_app;
+my $app = OurApp->to_app;
 isa_ok( $app, 'CODE', 'Got app' );
 
 test_psgi $app, sub {

--- a/t/custom_dsl.t
+++ b/t/custom_dsl.t
@@ -16,7 +16,7 @@ prend '/' => sub {
     request->method;
 };
 
-my $app = Dancer2->psgi_app;
+my $app = __PACKAGE__->to_app;
 is( ref $app, 'CODE', 'Got app' );
 
 test_psgi $app, sub {

--- a/t/deserialize.t
+++ b/t/deserialize.t
@@ -35,7 +35,7 @@ use HTTP::Request::Common;
     };
 }
 
-my $app = Dancer2->psgi_app;
+my $app = MyApp->to_app;
 is( ref $app, 'CODE', 'Got app' );
 
 test_psgi $app, sub {

--- a/t/dispatcher.t
+++ b/t/dispatcher.t
@@ -8,6 +8,7 @@ use Dancer2::Core::App;
 use Dancer2::Core::Route;
 use Dancer2::Core::Dispatcher;
 use Dancer2::Core::Hook;
+use Dancer2::Core::Response;
 
 set logger => 'Null';
 
@@ -151,7 +152,7 @@ foreach my $test (@tests) {
     my $expected = $test->{expected};
     my $path     = $env->{'PATH_INFO'};
 
-    my $resp = $dispatcher->dispatch($env)->to_psgi;
+    my $resp = $dispatcher->dispatch($env);
 
     is( $resp->[0], $expected->[0], "[$path] Return code ok" );
 
@@ -188,7 +189,12 @@ foreach my $test (
     my $env      = $test->{env};
     my $expected = $test->{expected};
 
-    my $resp = $dispatcher->dispatch($env);
+    my $psgi_response = $dispatcher->dispatch($env);
+    my $resp          = Dancer2::Core::Response->new(
+        status  => $psgi_response->[0],
+        headers => $psgi_response->[1],
+        content => $psgi_response->[2][0],
+    );
 
     is $resp->status => $expected->[0], "Return code ok.";
     ok( $resp->header('Content-Length') >= 140, "Length ok." );

--- a/t/dsl.t
+++ b/t/dsl.t
@@ -10,7 +10,7 @@ any [ 'get', 'post' ], '/' => sub {
     request->method;
 };
 
-my $app = Dancer2->psgi_app;
+my $app = __PACKAGE__->to_app;
 is( ref $app, 'CODE', 'Got app' );
 
 test_psgi $app, sub {

--- a/t/dsl/halt.t
+++ b/t/dsl/halt.t
@@ -23,7 +23,7 @@ subtest 'halt within routes' => sub {
         };
     }
 
-    my $app = Dancer2->psgi_app;
+    my $app = App->to_app;
     is( ref $app, 'CODE', 'Got app' );
 
     test_psgi $app, sub {
@@ -67,7 +67,7 @@ subtest 'halt in before hook' => sub {
 
     }
 
-    my $app = Dancer2->psgi_app;
+    my $app = App->to_app;
     is( ref $app, 'CODE', 'Got app' );
 
     test_psgi $app, sub {

--- a/t/dsl/pass.t
+++ b/t/dsl/pass.t
@@ -22,7 +22,7 @@ subtest 'pass within routes' => sub {
         };
     }
 
-    my $app = Dancer2->psgi_app;
+    my $app = App->to_app;
     is( ref $app, 'CODE', 'Got app' );
 
     test_psgi $app, sub {

--- a/t/dsl/to_app.t
+++ b/t/dsl/to_app.t
@@ -1,0 +1,32 @@
+#!perl
+use strict;
+use warnings;
+use Plack::Test;
+use HTTP::Request::Common;
+use Test::More tests => 2;
+
+{
+    package App1;
+    use Dancer2;
+    get '/' => sub {'App1'};
+
+    my $app = to_app;
+    ::test_psgi $app, sub {
+        my $cb = shift;
+        ::is( $cb->( ::GET '/' )->content, 'App1', 'Got first App' );
+    };
+}
+
+{
+    package App2;
+    use Dancer2;
+    get '/' => sub {'App2'};
+
+    my $app = to_app;
+    ::test_psgi $app, sub {
+        my $cb = shift;
+        ::is( $cb->( ::GET '/' )->content, 'App2', 'Got second App' );
+    };
+}
+
+

--- a/t/error.t
+++ b/t/error.t
@@ -30,17 +30,17 @@ my $env = {
     REMOTE_USER     => 'sukria',
 };
 
-my $a = Dancer2::Core::App->new( name => 'main' );
-my $request = Dancer2::Core::Dispatcher->build_request( $env, $a );
+my $app     = Dancer2::Core::App->new( name => 'main' );
+my $request = $app->build_request($env);
 
-$a->set_request($request);
+$app->set_request($request);
 
 subtest 'basic defaults of Error object' => sub {
-    my $e = Dancer2::Core::Error->new( app => $a );
-    is $e->status,  500,                                 'code';
-    is $e->title,   'Error 500 - Internal Server Error', 'title';
-    is $e->message, '',                               'message';
-    like $e->content, qr!http://localhost:5000/foo/css!,
+    my $err = Dancer2::Core::Error->new( app => $app );
+    is $err->status,  500,                                 'code';
+    is $err->title,   'Error 500 - Internal Server Error', 'title';
+    is $err->message, '',                               'message';
+    like $err->content, qr!http://localhost:5000/foo/css!,
         "error content contains css path relative to uri_base";
 };
 
@@ -58,7 +58,7 @@ subtest "send_error in route" => sub {
         };
     }
 
-    my $app = Dancer2->psgi_app;
+    my $app = App->to_app;
     is( ref $app, 'CODE', 'Got app' );
 
     test_psgi $app, sub {
@@ -92,7 +92,7 @@ subtest "send_error with custom stuff" => sub {
         };
     }
 
-    my $app = Dancer2->psgi_app;
+    my $app = App->to_app;
     is( ref $app, 'CODE', 'Got app' );
 
     test_psgi $app, sub {
@@ -143,7 +143,7 @@ subtest 'App dies with serialized error' => sub {
         };
     }
 
-    my $app = Dancer2->psgi_app;
+    my $app = AppDies->to_app;
     isa_ok( $app, 'CODE', 'Got app' );
 
     test_psgi $app, sub {

--- a/t/error_template.t
+++ b/t/error_template.t
@@ -30,7 +30,7 @@ use HTTP::Request::Common;
 
 }
 
-my $app = Dancer2->psgi_app;
+my $app = PrettyError->to_app;
 is( ref $app, 'CODE', 'Got app' );
 
 test_psgi $app, sub {

--- a/t/forward.t
+++ b/t/forward.t
@@ -33,7 +33,7 @@ get '/go_to_post/' => sub {
 # get '/b' => sub { vars->{test} = 1;  forward '/a'; };
 # get '/a' => sub { return "test is " . var('test'); };
 
-my $app = Dancer2->psgi_app;
+my $app = __PACKAGE__->to_app;
 is( ref $app, 'CODE', 'Got app' );
 
 test_psgi $app, sub {
@@ -133,7 +133,7 @@ test_psgi $app, sub {
     is(
         $cb->( POST '/bounce/' )->content,
         'post-home',
-        '[POSt /bounce/] Correct content',
+        '[POST /bounce/] Correct content',
     );
 
     {

--- a/t/forward_before_hook.t
+++ b/t/forward_before_hook.t
@@ -31,7 +31,7 @@ hook before => sub {
     forward '/default';
 };
 
-my $app = Dancer2->psgi_app;
+my $app = __PACKAGE__->to_app;
 is( ref $app, 'CODE', 'Got app' );
 
 test_psgi $app, sub {

--- a/t/handler_file.t
+++ b/t/handler_file.t
@@ -34,7 +34,7 @@ use File::Temp;
     };
 }
 
-my $app = Dancer2->psgi_app;
+my $app = StaticContent->to_app;
 is( ref $app, 'CODE', 'Got app' );
 
 test_psgi $app, sub {

--- a/t/hooks.t
+++ b/t/hooks.t
@@ -116,7 +116,7 @@ my $tests_flags = {};
 
 }
 
-my $app = Dancer2->psgi_app;
+my $app = __PACKAGE__->to_app;
 is( ref $app, 'CODE', 'Got app' );
 
 test_psgi $app, sub {

--- a/t/http_methods.t
+++ b/t/http_methods.t
@@ -16,7 +16,7 @@ my %method = (
     options => 'OPTIONS',
 );
 
-my $app = Dancer2->psgi_app;
+my $app = __PACKAGE__->to_app;
 is( ref $app, 'CODE', 'Got app' );
 
 test_psgi $app, sub {

--- a/t/log_die_before_hook.t
+++ b/t/log_die_before_hook.t
@@ -21,7 +21,7 @@ use Capture::Tiny 'capture_stderr';
     };
 }
 
-my $app = Dancer2->psgi_app;
+my $app = App->to_app;
 is( ref $app, 'CODE', 'Got app' );
 
 test_psgi $app, sub {

--- a/t/log_levels.t
+++ b/t/log_levels.t
@@ -33,7 +33,7 @@ use HTTP::Request::Common;
     };
 }
 
-my $app = Dancer2->psgi_app;
+my $app = App->to_app;
 
 test_psgi $app, sub {
     my $cb  = shift;

--- a/t/multi_apps.t
+++ b/t/multi_apps.t
@@ -19,8 +19,8 @@ use HTTP::Request::Common;
 
 {
     my $app = builder {
-        mount '/wiki'  => MyTestWiki->psgi_app;
-        mount '/forum' => MyTestForum->psgi_app;
+        mount '/wiki'  => MyTestWiki->to_app;
+        mount '/forum' => MyTestForum->to_app;
     };
 
     isa_ok( $app, 'CODE', 'Got app' );

--- a/t/multiapp_template_hooks.t
+++ b/t/multiapp_template_hooks.t
@@ -98,7 +98,7 @@ note 'Check App1 only calls first hook, not both'; {
     # clear
     %called_hooks = ();
 
-    my $app = App1->psgi_app;
+    my $app = App1->to_app;
     isa_ok( $app, 'CODE', 'Got app for test' );
 
     test_psgi $app, sub {
@@ -125,7 +125,7 @@ note 'Check App2 only calls second hook, not both'; {
     # clear
     %called_hooks = ();
 
-    my $app = App2->psgi_app;
+    my $app = App2->to_app;
     isa_ok( $app, 'CODE', 'Got app for test' );
 
     test_psgi $app, sub {

--- a/t/named_apps.t
+++ b/t/named_apps.t
@@ -5,7 +5,6 @@ use Plack::Test;
 use HTTP::Request::Common;
 
 {
-
     package Foo;
     use Dancer2;
 
@@ -27,15 +26,19 @@ use HTTP::Request::Common;
     }
 }
 
-my $app = Dancer2->psgi_app;
+foreach my $class ( qw<Foo Bar> ) {
+    my $app = $class->to_app;
 
-test_psgi $app, sub {
-    my $cb  = shift;
-    for my $path ( qw/foo bar/ ) {
-        my $res = $cb->( POST "/$path" );
-        is $res->content, "foo${path}baz",
-            "Got app content path $path";
-    }
-};
+    test_psgi $app, sub {
+        my $cb   = shift;
+        my $path = lc $class;
+        my $res  = $cb->( POST "/$path" );
+        is(
+            $res->content,
+            "foo${path}baz",
+            "Got app content path $path",
+        );
+    };
+}
 
 done_testing;

--- a/t/plugin_import.t
+++ b/t/plugin_import.t
@@ -15,7 +15,7 @@ use HTTP::Request::Common;
     };
 }
 
-my $app = Dancer2->psgi_app;
+my $app = __PACKAGE__->to_app;
 is( ref $app, 'CODE', 'Got app' );
 
 test_psgi $app, sub {

--- a/t/plugin_multiple_apps.t
+++ b/t/plugin_multiple_apps.t
@@ -7,7 +7,6 @@ use Plack::Test;
 use HTTP::Request::Common;
 
 {
-
     package App;
 
     BEGIN {

--- a/t/plugin_syntax.t
+++ b/t/plugin_syntax.t
@@ -7,6 +7,7 @@ use JSON;
 
 subtest 'global and route keywords' => sub {
     {
+        package App1;
         use Dancer2;
         use t::lib::FooPlugin;
 
@@ -23,7 +24,7 @@ subtest 'global and route keywords' => sub {
         foo_route;
     }
 
-    my $app = Dancer2->psgi_app;
+    my $app = App1->to_app;
     is( ref $app, 'CODE', 'Got app' );
 
     test_psgi $app, sub {
@@ -49,7 +50,7 @@ subtest 'global and route keywords' => sub {
 
         is(
             $cb->( GET '/app' )->content,
-            'main',
+            'App1',
             'app name is correct',
         );
     };
@@ -57,13 +58,14 @@ subtest 'global and route keywords' => sub {
 
 subtest 'plugin old syntax' => sub {
     {
+        package App2;
         use Dancer2;
         use t::lib::DancerPlugin;
 
         around_get;
     }
 
-    my $app = Dancer2->psgi_app;
+    my $app = App2->to_app;
     is( ref $app, 'CODE', 'Got app' );
 
     test_psgi $app, sub {
@@ -78,12 +80,7 @@ subtest 'plugin old syntax' => sub {
 };
 
 subtest caller_dsl => sub {
-    {
-        use Dancer2;
-        use t::lib::DancerPlugin;
-    }
-
-    my $app = Dancer2->psgi_app;
+    my $app = App1->to_app;
     is( ref $app, 'CODE', 'Got app' );
 
     test_psgi $app, sub {
@@ -101,6 +98,7 @@ subtest 'hooks in plugins' => sub {
     my $counter = 0;
 
     {
+        package App3;
         use Dancer2;
         use t::lib::Hookee;
 
@@ -114,7 +112,7 @@ subtest 'hooks in plugins' => sub {
 
         get '/hook_with_var' => sub {
             some_other(); # executes 'third_hook'
-            is var('hook') => 'third hook', "Vars preserved from hooks";
+            ::is var('hook') => 'third hook', "Vars preserved from hooks";
         };
 
         get '/hooks_plugin' => sub {
@@ -129,7 +127,7 @@ subtest 'hooks in plugins' => sub {
 
     }
 
-    my $app = Dancer2->psgi_app;
+    my $app = App3->to_app;
     is( ref $app, 'CODE', 'Got app' );
 
     test_psgi $app, sub {

--- a/t/redirect.t
+++ b/t/redirect.t
@@ -7,7 +7,7 @@ use HTTP::Request::Common;
 
 subtest 'basic redirects' => sub {
     {
-        package App;
+        package App1;
         use Dancer2;
 
         get '/'         => sub {'home'};
@@ -16,7 +16,7 @@ subtest 'basic redirects' => sub {
         get '/redirect_querystring' => sub { redirect '/login?failed=1' };
     }
 
-    my $app = Dancer2->psgi_app;
+    my $app = App1->to_app;
     is( ref $app, 'CODE', 'Got app' );
 
     test_psgi $app, sub {
@@ -76,8 +76,7 @@ subtest 'basic redirects' => sub {
 # redirect absolute
 subtest 'absolute and relative redirects' => sub {
     {
-
-        package App;
+        package App2;
         use Dancer2;
 
         get '/absolute_with_host' =>
@@ -86,7 +85,7 @@ subtest 'absolute and relative redirects' => sub {
         get '/relative' => sub { redirect "somewhere/else"; };
     }
 
-    my $app = Dancer2->psgi_app;
+    my $app = App2->to_app;
     is( ref $app, 'CODE', 'Got app' );
 
     test_psgi $app, sub {
@@ -126,14 +125,14 @@ subtest 'absolute and relative redirects' => sub {
 
 subtest 'redirect behind a proxy' => sub {
     {
-        package App;
+        package App3;
         use Dancer2;
         prefix '/test2';
         set behind_proxy => 1;
         get '/bounce' => sub { redirect '/test2' };
     }
 
-    my $app = Dancer2->psgi_app;
+    my $app = App3->to_app;
     is( ref $app, 'CODE', 'Got app' );
 
     test_psgi $app, sub {
@@ -191,14 +190,14 @@ subtest 'redirect behind a proxy' => sub {
 subtest 'redirect behind multiple proxies' => sub {
     {
 
-        package App;
+        package App4;
         use Dancer2;
         prefix '/test2';
         set behind_proxy => 1;
         get '/bounce' => sub { redirect '/test2' };
     }
 
-    my $app = Dancer2->psgi_app;
+    my $app = App4->to_app;
     is( ref $app, 'CODE', 'Got app' );
 
     test_psgi $app, sub {

--- a/t/serializer.t
+++ b/t/serializer.t
@@ -18,7 +18,7 @@ use HTTP::Request::Common;
     get '/to_json' => sub { to_json({bar => 'baz'}, {pretty => 1}) };
 }
 
-my $app = Dancer2->psgi_app;
+my $app = MyApp->to_app;
 is( ref $app, 'CODE', 'Got app' );
 
 test_psgi $app, sub {

--- a/t/serializer_json.t
+++ b/t/serializer_json.t
@@ -40,7 +40,7 @@ my @tests = (
     }
 );
 
-my $app = Dancer2->psgi_app;
+my $app = MyApp->to_app;
 
 for my $test (@tests) {
     my $expected = JSON::to_json( $test->{entity}, $test->{options} );

--- a/t/serializer_mutable.t
+++ b/t/serializer_mutable.t
@@ -26,7 +26,7 @@ use YAML;
     };
 }
 
-my $app = Dancer2->psgi_app;
+my $app = MyApp->to_app;
 is( ref $app, 'CODE', 'Got app' );
 
 test_psgi $app, sub {

--- a/t/splat.t
+++ b/t/splat.t
@@ -20,7 +20,7 @@ my @splat;
     };
 }
 
-my $app = Dancer2->psgi_app;
+my $app = __PACKAGE__->to_app;
 is( ref $app, 'CODE', 'Got app' );
 
 test_psgi $app, sub {

--- a/t/template.t
+++ b/t/template.t
@@ -77,7 +77,7 @@ $tt->add_hook(
     get '/' => sub { template index => { var => 42 } };
 }
 
-my $app    = Dancer2->psgi_app;
+my $app    = Bar->to_app;
 my $space  = " ";
 my $result = "layout top
 var = 42
@@ -118,7 +118,7 @@ test_psgi $app, sub {
     get '/get_views_via_settings' => sub { set 'views' };
 }
 
-$app = Dancer2->psgi_app;
+$app = Foo->to_app;
 is( ref $app, 'CODE', 'Got app' );
 
 test_psgi $app, sub {

--- a/t/template_default_tokens.t
+++ b/t/template_default_tokens.t
@@ -37,7 +37,7 @@ params.foo: 42
 session.foo in session
 vars.foo: in var";
 
-my $app = Dancer2->psgi_app;
+my $app = Foo->to_app;
 is( ref $app, 'CODE', 'Got app' );
 
 test_psgi $app, sub {

--- a/t/template_name.t
+++ b/t/template_name.t
@@ -17,7 +17,7 @@ use HTTP::Request::Common;
     };
 }
 
-my $app = Dancer2->psgi_app;
+my $app = Foo->to_app;
 is( ref $app, 'CODE', 'Got app' );
 
 test_psgi $app, sub {

--- a/t/uri_for.t
+++ b/t/uri_for.t
@@ -5,13 +5,14 @@ use Plack::Test;
 use HTTP::Request::Common;
 
 {
+    package App;
     use Dancer2;
     get '/foo' => sub {
         return uri_for('/foo');
     };
 }
 
-my $app = Dancer2->psgi_app;
+my $app = App->to_app;
 is( ref $app, 'CODE', 'Got app' );
 
 test_psgi $app, sub {

--- a/t/vars.t
+++ b/t/vars.t
@@ -23,7 +23,7 @@ plan tests => 3;
     };
 }
 
-my $app = Dancer2->psgi_app;
+my $app = __PACKAGE__->to_app;
 is( ref $app, 'CODE', 'Got app' );
 
 test_psgi $app, sub {


### PR DESCRIPTION
- Applications are now finalized to a full-fledged PSGI app:
  
  They can now be used independently without the Dispatcher itself.
  They can also be mixed independently without the Dispatcher.
  
  You can do this using either the 'to_app' method on the App class
  or the 'to_app' DSL.
  
  If you want to create multiple Apps, you can use the following
  mechanisms to control the flow:
  - Plack::App::URLMap: mounting them on different prefixes.
  - 'prefix' keyword: set different apps on different prefixes.
  - Registering under the same 'appname': thus providing them
    with the same engines.
  
  The 'prefix' and 'appname' can be used together to provide
  multiple Apps that share the same engines (sessions, for example)
  but still retain different paths.
- The Dispatcher only loops over the Apps:
  
  Since the Apps now contain the dispatching code, the Dispatcher
  now only calls each App separately.
- You can no longer forward or pass between Apps:
  
  Forwarding and passing between Applications is considered risky,
  fragile, and a source of possible security problems. Although we
  try to mitigate it, it shouldn't be done. Now it cannot be done.
  
  With the new architecture you cannnot forward or pass requests
  between Apps.

The way the current mechanism works is:
- The dispatching code has been moved to the App.
- If you decide to use the Dispatcher, it will simply loop over the
  Apps and call each one just like a normal PSGI app.
- The Dispatcher will then check if the response is a 404 that a
  user provided or a 404 generated because no route matched the
  request. It does that using a boolean the App sets in the Runner.
- If it's a 404 indicating no available route, it will simply try
  the next App.

Notes:
- We could now allow each App to have its own allowed HTTP methods.
- We could now allow each App to have its own custom 500 error.
- We could now allow each App to decide whether to add the 'Head'
  middleware or not.
- We could now control the middleware each App gets separately.
- We could now easily add pure PSGI responses.
- We could start working on a nice DSL for delayed PSGI responses.
