### PR TITLE
Fallback during search for config file. Site root is considered when no file is found

### DIFF
--- a/lib/Dancer2/Core/App.pm
+++ b/lib/Dancer2/Core/App.pm
@@ -727,6 +727,9 @@ sub BUILD {
     my $self = shift;
     $self->init_route_handlers();
     $self->_init_hooks();
+
+    #Siteroot is saved as fallback when no config file is found using App's path
+    Dancer2->runner->siteroot($self->location) if($self->name eq 'main');
 }
 
 sub finish {

--- a/lib/Dancer2/Core/App.pm
+++ b/lib/Dancer2/Core/App.pm
@@ -729,7 +729,7 @@ sub BUILD {
     $self->_init_hooks();
 
     #Siteroot is saved as fallback when no config file is found using App's path
-    Dancer2->runner->siteroot($self->location) if($self->name eq 'main');
+    Dancer2->runner->siteroot($self->location) if($self->name && $self->name eq 'main');
 }
 
 sub finish {

--- a/lib/Dancer2/Core/App.pm
+++ b/lib/Dancer2/Core/App.pm
@@ -729,7 +729,7 @@ sub BUILD {
     $self->_init_hooks();
 
     #Siteroot is saved as fallback when no config file is found using App's path
-    Dancer2->runner->siteroot($self->location) if($self->name && $self->name eq 'main');
+    Dancer2->runner->set_siteroot($self->location) if($self->name && $self->name eq 'main');
 }
 
 sub finish {

--- a/lib/Dancer2/Core/Role/ConfigReader.pm
+++ b/lib/Dancer2/Core/Role/ConfigReader.pm
@@ -124,6 +124,37 @@ sub _build_config_files {
             push @files, $path;
         }
     }
+    if(@files)
+    {
+        return [ sort @files ];
+    }
+    else
+    {
+        return $self->_build_config_files_from_siteroot();
+    }
+}
+
+sub _build_config_files_from_siteroot {
+    my ($self) = @_;
+
+    my $location = Dancer2->runner->siteroot;
+    # an undef location means no config files for the caller
+    return [] unless defined $location;
+
+    my $running_env = $self->environment;
+    my @exts = Config::Any->extensions;
+    my @files;
+
+    foreach my $ext (@exts) {
+        foreach my $file ( [ $location, "config.$ext" ],
+            [ $self->environments_location, "$running_env.$ext" ] )
+        {
+            my $path = path( @{$file} );
+            next if !-r $path;
+
+            push @files, $path;
+        }
+    }
 
     return [ sort @files ];
 }

--- a/lib/Dancer2/Core/Runner.pm
+++ b/lib/Dancer2/Core/Runner.pm
@@ -73,6 +73,11 @@ has timeout => (
     default => sub { $_[0]->config->{'timeout'} },
 );
 
+has siteroot => (
+    is      => 'rw',
+    lazy    => 1,
+);
+
 sub _build_server {
     my $self = shift;
 

--- a/lib/Dancer2/Core/Runner.pm
+++ b/lib/Dancer2/Core/Runner.pm
@@ -73,11 +73,6 @@ has timeout => (
     default => sub { $_[0]->config->{'timeout'} },
 );
 
-has siteroot => (
-    is      => 'rw',
-    lazy    => 1,
-);
-
 sub _build_server {
     my $self = shift;
 
@@ -109,6 +104,12 @@ sub _build_config {
                            $ENV{DANCER_STARTUP_INFO}         :
                            1 ),
     };
+}
+
+sub set_siteroot {
+    my $self = shift;
+    my $siteroot = shift;
+    $self->config->{'siteroot'} = $siteroot;
 }
 
 sub BUILD {


### PR DESCRIPTION
Every app look for configuration in config_location path. If no file is found there search is repeated in the siteroot.
As siteroot, is considered the config_location of the main app.

This will avoid problems with apps deployed through CPAN and not deployed in the lib directory of the Dancer2 project.
