### PR TITLE
Git guide markdown fixes

### DIFF
--- a/GitGuide.md
+++ b/GitGuide.md
@@ -157,7 +157,8 @@ running, you should install the dependencies required by Dancer2:
 
      $ dzil listdeps | cpanm -n
 
-When that is done, you're good to go! You can use dzil to build and test Dancer2:
+When that is done, you're good to go! You can use `dzil` to build and test
+Dancer2:
 
      $ dzil build
      $ dzil test


### PR DESCRIPTION
While reading the Git Guide I noticed a couple of grammatical, consistency and formatting issues.  These are fixed in a way which I believe fits within the relevant guidelines.  Any comments are welcome!
