### PR TITLE
Document serving static files using Plack::Middleware::Static

### DIFF
--- a/lib/Dancer2/Cookbook.pod
+++ b/lib/Dancer2/Cookbook.pod
@@ -1251,7 +1251,7 @@ Next, our bin/app.pl should look similar to this:
 
     #!/usr/bin/env perl
     use Plack::Builder;
-    use Dancer2;
+    use Dancer2::FileUtils qw[ path ];
     use MyApp;
 
     builder {


### PR DESCRIPTION
Documents an example of serving static files using Plack::Middleware::Static in the Dancer2::Cookbook. Also adds a note at [Sessions and logging in](https://metacpan.org/pod/distribution/Dancer2/lib/Dancer2/Cookbook.pod#Sessions-and-logging-in) example about it preventing static files to be served when the user is not logged in.
