### PR TITLE
Feature/handler file config option

### DIFF
--- a/lib/Dancer2/Config.pod
+++ b/lib/Dancer2/Config.pod
@@ -61,10 +61,12 @@ If you prefer YAML, a sample YAML based config file might look like this:
 
     appname: "Hello"
     charset: "UTF-8"
-    auto_page: 1
 
     session: "YAML"
     serializer: "JSON"
+
+    route_handlers:
+        AutoPage: 1
 
     plugins:
       DBIC:
@@ -77,9 +79,11 @@ If JSON is more your thing, your file might look more like this:
     {
         "appname": "Hello",
         "charset": "UTF-8",
-        "auto_page": "1",
         "session": "YAML",
         "serializer": "JSON",
+        "route_handlers": {
+            "AutoPage": 1
+        },
         "plugins": {
             "DBIC": {
                 "default": {
@@ -94,7 +98,6 @@ If you like Apache configuration files, try something similar to:
 
         appname = Hello
         charset = UTF-8
-        auto_page = 1
         session = YAML
         serializer = JSON
         <plugins>
@@ -229,6 +232,33 @@ This is the directory where your templates and layouts live.  It's the
 "view" part of MVC (model, view, controller).
 
 This defaults to $appdir/views.
+
+=head2 Route handlers
+
+This is the config option for enabling/disabling route handlers. The default values are:
+
+    route_handlers:
+        File: 1
+        AutoPage: 0
+
+=head3 AutoPage
+
+For simple pages where you're not doing anything dynamic, but still want to use the template engine to provide headers etc, you can use the AutoPage feature to avoid the need to create a route for each page.
+
+With AutoPage enabled, if the requested path does not match any specific route, Dancer2 will check in the views directory for a matching template, and use it to satisfy the request if found. If you request /foo/bar, Dancer2 will look in the views dir for /foo/bar.tt.
+
+Dancer2 will honor your before_template_render code, and all default variables. They will be accessible and interpolated on automatic served pages.
+
+AutoPage is disabled by default. To enable it, set its value to 1.
+
+=head3 File
+
+This route handler is a built in way of serving static files with Dancer2. It automatically adds
+a GET and HEAD route '/**' into the Dancer2 application matching every request. 
+If the file is present inside the public directory, it is served. Otherwise it passes the 
+request.
+
+For setting the public directory location, see the documentation of L<public|Dancer2::Config/public_(directory)>.
 
 =head2 Templating & layouts
 
@@ -424,6 +454,8 @@ will not be able to access to its value.
 
 
 =head2 auto_page (boolean)
+
+B<DEPRECATED!> The auto_page config option is deprecated. Please see the L<route handlers|Dancer2::Config/"Route_handlers"> documentation for more information.
 
 For simple pages where you're not doing anything dynamic, but still
 want to use the template engine to provide headers etc, you can use

--- a/lib/Dancer2/Cookbook.pod
+++ b/lib/Dancer2/Cookbook.pod
@@ -217,14 +217,14 @@ Then you can set up the template as such:
     Please try again or contact us at our email at <...>.
 
 
-=head2 Using the auto_page feature for automatic route creation
+=head2 Using the AutoPage route handler for automatic route creation
 
-For simple "static" pages, you can simply enable the C<auto_page> config
-setting; this means that you need not declare a route handler for those pages;
+For simple "static" pages, you can simply enable the C<AutoPage> feature;
+this means that you need not declare a route handler for those pages;
 if a request is for C</foo/bar>, Dancer2 will check for a matching view (e.g.
 C</foo/bar.tt> and render it with the default layout etc if found.  For full
 details, see the documentation for the
-L<auto_page setting|Dancer2::Config/"auto_page">.
+L<AutoPage setting|Dancer2::Config/"AutoPage">.
 
 
 

--- a/lib/Dancer2/Core/App.pm
+++ b/lib/Dancer2/Core/App.pm
@@ -510,10 +510,7 @@ sub _build_default_config {
                             || path( $self->location, 'public' ) ),
         route_handlers => [
             [
-                File => {
-                    public_dir => $ENV{DANCER_PUBLIC} ||
-                                  path( $self->location, 'public' )
-                }
+                File => 1
             ],
             [
                 AutoPage => 1

--- a/lib/Dancer2/Core/App.pm
+++ b/lib/Dancer2/Core/App.pm
@@ -508,14 +508,10 @@ sub _build_default_config {
         template       => 'Tiny',
         public         => ( $ENV{DANCER_PUBLIC}
                             || path( $self->location, 'public' ) ),
-        route_handlers => [
-            [
-                File => 1
-            ],
-            [
-                AutoPage => 1
-            ],
-        ],
+        route_handlers => {
+            File     => 1,
+            AutoPage => 1,
+        },
     };
 }
 
@@ -738,21 +734,21 @@ sub init_route_handlers {
     my $self = shift;
 
     my $handlers_config = $self->config->{route_handlers};
-    for my $handler_data ( @{$handlers_config} ) {
-        my ($handler_name, $config) = @{$handler_data};
-        $config = {} if !ref($config);
 
-        my $handler = Dancer2::Core::Factory->create(
-            Handler => $handler_name,
-            app     => $self,
-            %$config,
-            postponed_hooks => $self->postponed_hooks,
-        );
+    for my $handler_name (keys %$handlers_config) {
+        #Add the handler if the config value is true
+        if ($handlers_config->{ $handler_name }) {
+            my $handler = Dancer2::Core::Factory->create(
+                Handler         => $handler_name,
+                app             => $self,
+                postponed_hooks => $self->postponed_hooks,
+            );
 
-        push @{ $self->route_handlers }, {
-            name    => $handler_name,
-            handler => $handler,
-        };
+            push @{ $self->route_handlers }, {
+                name    => $handler_name,
+                handler => $handler,
+            };
+        }
     }
 }
 

--- a/lib/Dancer2/Core/App.pm
+++ b/lib/Dancer2/Core/App.pm
@@ -510,7 +510,7 @@ sub _build_default_config {
                             || path( $self->location, 'public' ) ),
         route_handlers => {
             File     => 1,
-            AutoPage => 1,
+            AutoPage => 0,
         },
     };
 }

--- a/lib/Dancer2/Core/App.pm
+++ b/lib/Dancer2/Core/App.pm
@@ -506,6 +506,8 @@ sub _build_default_config {
                             || path( $self->config_location, 'views' ) ),
         appdir         => $self->location,
         template       => 'Tiny',
+        public         => ( $ENV{DANCER_PUBLIC}
+                            || path( $self->location, 'public' ) ),
         route_handlers => [
             [
                 File => {

--- a/lib/Dancer2/Core/App.pm
+++ b/lib/Dancer2/Core/App.pm
@@ -2,7 +2,7 @@
 package Dancer2::Core::App;
 
 use Moo;
-use Carp            'croak';
+use Carp            qw[ croak carp ];
 use Scalar::Util    'blessed';
 use Module::Runtime 'is_module_name';
 use File::Spec;
@@ -734,6 +734,27 @@ sub init_route_handlers {
     my $self = shift;
 
     my $handlers_config = $self->config->{route_handlers};
+
+    # DEPRECATED
+    if (ref $handlers_config eq 'ARRAY') {
+        carp 'The use of route_handlers config as an arrayref is deprecated!'
+             .' Please check the updated manual in Dancer2::Config.';
+
+        my %hash_config = map { @$_ } @$handlers_config;
+
+        $handlers_config = {};
+
+        $handlers_config->{AutoPage} = $hash_config{AutoPage};
+        $handlers_config->{File}     = $hash_config{File};
+        $self->setting('public', $hash_config{File}->{public_dir});
+        $self->setting('handlers_config', $handlers_config);
+    }
+
+    # DEPRECATED
+    if (exists $self->config->{auto_page}) {
+        carp 'The auto_page config option is deprecated!';
+        $handlers_config->{AutoPage} = $self->config->{auto_page};
+    }
 
     for my $handler_name (keys %$handlers_config) {
         #Add the handler if the config value is true

--- a/lib/Dancer2/Core/App.pm
+++ b/lib/Dancer2/Core/App.pm
@@ -756,7 +756,7 @@ sub init_route_handlers {
         $handlers_config->{AutoPage} = $self->config->{auto_page};
     }
 
-    for my $handler_name (keys %$handlers_config) {
+    for my $handler_name (qw[ File AutoPage ]) {
         #Add the handler if the config value is true
         if ($handlers_config->{ $handler_name }) {
             my $handler = Dancer2::Core::Factory->create(

--- a/lib/Dancer2/Core/Error.pm
+++ b/lib/Dancer2/Core/Error.pm
@@ -137,8 +137,7 @@ sub _build_static_page {
 
     # TODO there must be a better way to get it
     my $public_dir = $ENV{DANCER_PUBLIC}
-      || ( $self->has_app
-        && path( $self->app->config_location, 'public' ) );
+      || ( $self->has_app && $self->app->config->{'public'} );
 
     my $filename = sprintf "%s/%d.html", $public_dir, $self->status;
 

--- a/lib/Dancer2/Handler/AutoPage.pm
+++ b/lib/Dancer2/Handler/AutoPage.pm
@@ -11,8 +11,6 @@ with 'Dancer2::Core::Role::StandardResponses';
 sub register {
     my ( $self, $app ) = @_;
 
-    return unless $app->config->{auto_page};
-
     $app->add_route(
         method => $_,
         regexp => $self->regexp,

--- a/lib/Dancer2/Handler/File.pm
+++ b/lib/Dancer2/Handler/File.pm
@@ -42,12 +42,7 @@ has regexp => (
     default => sub {'/**'},
 );
 
-sub _build_public_dir {
-    my $self = shift;
-    return $self->app->config->{public}
-        || $ENV{DANCER_PUBLIC}
-        || path( $self->app->location, 'public' );
-}
+sub _build_public_dir { shift->app->config->{public} }
 
 sub register {
     my ( $self, $app ) = @_;

--- a/t/auto_page.t
+++ b/t/auto_page.t
@@ -8,8 +8,9 @@ use HTTP::Request::Common;
 {
     package AutoPageTest;
     use Dancer2;
+    use Dancer2::Handler::AutoPage;
 
-    set auto_page => 1;
+    set route_handlers => { AutoPage => 1 };
     ## HACK HACK HACK
     Dancer2::Handler::AutoPage->register(app);
     engine('template')->views('t/views');

--- a/t/dancer-test/config.yml
+++ b/t/dancer-test/config.yml
@@ -1,1 +1,3 @@
-route_handlers: []
+route_handlers: 
+    File: 0
+    AutoPage: 0


### PR DESCRIPTION
This PR does a couple of thing (I wanted to separate those into their own PR, but they kinda depend on each other)

* The 'public' config option is added to D2::Core::App's default_config inside _build_default_config. It's value is $ENV{DANCER_PUBLIC} || path($app->location, 'public'). When the public dir is specified in the config, this value will be overwritten in the resulting merged $app->config.
The duplicated logic of building the public dir location is removed from D2::Handler::File and D2::Core::Error; they both use $app->config->{public} now.

* public_dir is removed from the File route handlers default config inside the same _build_default_config method. There is already a Dancer2-global 'public' config option, so why to duplicate, we can simply use that.

* the route_handlers config is changed. Instead of an arrayref, it is now a hashref, like this:
```yaml
route_handlers:
    File: 1
    AutoPage: 0
```
This way individual route handlers can be explicitly enabled/disabled, you no longer need to set 'route_handlers: []' to disable the File handler, you can now set it's value explicitly to 0.

* For now, I added deprecation warning for the old route_handlers config use. If it's value is an old-style arrayref, it is parsed into the new format, so it is working, but it now issues a warning, that it is deprecated.

* I deprecated the auto_page config option as well. There were two config options to enable/disable this feature; AutoPage => 1 inside route_handlers and auto_page itself. The old behavior was like this: the AutoPage handler was created and added to the app's route_handlers array, because the AutoPage config value inside _build_default_config was 0. But inside Handler::AutoPage->register the auto_page option was used to determine if we need to add any routes. 
Now there is only one config option for it; if it is 0, the handler is not even created.

* I updated Dancer2::Config and Dancer2::Cookbook according to these changes.