### PR TITLE
Fix typo in Dancer2::Logger::Capture POD + add more real-world example

### DIFF
--- a/lib/Dancer2/Logger/Capture.pm
+++ b/lib/Dancer2/Logger/Capture.pm
@@ -40,9 +40,50 @@ A worked-out real-world example:
 
 This is a logger class for L<Dancer2> which captures all logs to an object.
 
-It's primary purpose is for testing.
+It's primary purpose is for testing. Here is an example of a test:
 
-=method trap
+    use strict;
+    use warnings;
+    use Test::More;
+    use Plack::Test;
+    use HTTP::Request::Common;
+
+    {
+        package App;
+        use Dancer2;
+
+        set log       => 'debug';
+        set logger    => 'capture';
+
+        get '/' => sub {
+            log(debug => 'this is my debug message');
+            log(core  => 'this should not be logged');
+            log(info  => 'this is my info message');
+        };
+    }
+
+    my $app = Dancer2->psgi_app;
+    is( ref $app, 'CODE', 'Got app' );
+
+    test_psgi $app, sub {
+        my $cb = shift;
+
+        my $res = $cb->( GET '/' );
+
+        my $trap = App->dancer_app->logger_engine->trapper;
+
+        is_deeply $trap->read, [
+            { level => 'debug', message => 'this is my debug message' },
+            { level => 'info',  message => 'this is my info message' },
+        ];
+
+        is_deeply $trap->read, [];
+    };
+
+    done_testing;
+
+
+=method trapper
 
 Returns the L<Dancer2::Logger::Capture::Trap> object used to capture
 and read logs.


### PR DESCRIPTION
Dancer2::Logger::Capture has no method 'trap', it is 'trapper' (FIXED).

Added an example of a test using Test::PSGI involving
Dancer2::Logger::Capture (this one includes logging in routes, which is
more real-world example as the current one)
