### PR TITLE
Add irc link on metacpan page

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -32,6 +32,8 @@ autoprereqs_skip = ^t::lib::|^t::app::|XS$
 repository = https://github.com/PerlDancer/Dancer2
 bugtracker = https://github.com/PerlDancer/Dancer2/issues
 homepage   = http://perldancer.org/
+x_IRC      = irc://irc.perl.org/#dancer
+x_WebIRC   = https://chat.mibbit.com/#dancer@irc.perl.org
 
 [PruneFiles]
 match = ~$ ; emacs backup files


### PR DESCRIPTION
I _think_ this'll add the "Questions? Chat with us!"  link on metacpan.
It certainly adds the lines to META.json and META.yml

See https://metacpan.org/pod/DBIx::Class for an example of what I'm talking about.
