### PR TITLE
Adding __END__ statement in front of POD

### DIFF
--- a/lib/Dancer2/Template/TemplateToolkit.pm
+++ b/lib/Dancer2/Template/TemplateToolkit.pm
@@ -51,6 +51,8 @@ sub render {
 
 1;
 
+__END__
+
 =head1 SYNOPSIS
 
 To use this engine, you may configure L<Dancer2> via C<config.yaml>:


### PR DESCRIPTION
Ok, now the POD has been moved to be consistently after the `__END__` statement.  phew!
