### PR TITLE
Move send_error implementation to Core::App

### DIFF
--- a/lib/Dancer2/Core/DSL.pm
+++ b/lib/Dancer2/Core/DSL.pm
@@ -6,7 +6,6 @@ use Moo;
 use Carp;
 use Class::Load 'load_class';
 use Dancer2::Core::Hook;
-use Dancer2::Core::Error;
 use Dancer2::FileUtils;
 
 with 'Dancer2::Core::Role::DSL';
@@ -142,6 +141,8 @@ sub session {
         $session->delete($key);
     }
 }
+
+sub send_error { shift->app->send_error(@_) }
 
 sub send_file { shift->app->send_file(@_) }
 
@@ -341,24 +342,6 @@ sub mime {
         $runner->mime_type->reset_default;
         return $runner->mime_type;
     }
-}
-
-sub send_error {
-    my ( $self, $message, $status ) = @_;
-
-    my $serializer = $self->app->engine('serializer');
-    my $x = Dancer2::Core::Error->new(
-          message    => $message,
-          app        => $self->app,
-        ( status     => $status     )x!! $status,
-        ( serializer => $serializer )x!! $serializer,
-    )->throw;
-
-    # return if there is a with_return coderef
-    $self->app->with_return->($x)
-      if $self->app->has_with_return;
-
-    return $x;
 }
 
 #


### PR DESCRIPTION
The implementation of the 'send_error' keyword was previously within Core::DSL, but is flagged as being only to be used within a route. With apps doing their own dispatching, its "cleaner" to have send_error implemented within Core::App.   [Just shifting the deck chairs, but this is not the titanic :) ]
