### PR TITLE
update Migration doc to reflect absent keyword param_array

### DIFF
--- a/lib/Dancer2/Manual/Migration.pod
+++ b/lib/Dancer2/Manual/Migration.pod
@@ -255,3 +255,9 @@ Engines now receive a logger that consumes L<Dancer2::Core::Role::Logger> in
 order to log errors. The attribute is called C<logger>.
 
 The logger engine doesn't have the attribute since it is the logger itself.
+
+=head2 Keywords
+
+=head3 param_array
+
+This keyword doesn't exist in Dancer2.


### PR DESCRIPTION
related to #726.
