### PR TITLE
Move Content-Length calculation to D2::Core::Response->to_psgi

### DIFF
--- a/lib/Dancer2/Core/Response.pm
+++ b/lib/Dancer2/Core/Response.pm
@@ -68,15 +68,6 @@ has content => (
         my $value = shift;
         return "$value";
     },
-
-   # This trigger makes sure we have a good content-length whenever the content
-   # changes
-    trigger => sub {
-        my ( $self, $value ) = @_;
-        $self->has_passed or $self->header( 'Content-Length' => length($value) );
-        return $value;
-    },
-
     predicate => 'has_content',
     clearer   => 'clear_content',
 );
@@ -145,6 +136,10 @@ sub to_psgi {
     # e.g. if all routes 'pass'. Apply defaults here..
     $self->content_type or $self->content_type($self->default_content_type);
     $self->content('') if ! defined $self->content;
+
+    defined $self->header('Content-Length') or
+        $self->header('Content-Length' => length($self->content));
+
     return [ $self->status, $self->headers_to_array, [ $self->content ], ];
 }
 

--- a/t/response.t
+++ b/t/response.t
@@ -9,15 +9,18 @@ is $r->status,  200;
 is $r->content, 'hello';
 
 note "content_type";
+my $content_body = "foo";
+
 $r = Dancer2::Core::Response->new(
     headers => [ 'Content-Type' => 'text/html' ],
-    content => 'foo',
+    content => $content_body,
 );
 
 is_deeply $r->to_psgi,
   [ 200,
-    [   Server         => "Perl Dancer2 $Dancer2::VERSION",
-        'Content-Type' => 'text/html',
+    [   'Server'         => "Perl Dancer2 $Dancer2::VERSION",
+        'Content-Length' => length($content_body),
+        'Content-Type'   => 'text/html',
     ],
     ['foo']
   ];
@@ -47,20 +50,18 @@ $r->header( 'X-Bar' => 234 );
 is $r->header('X-Bar'),      '234';
 is $r->push_header('X-Bar'), '234';
 
-is scalar( @{ $r->headers_to_array } ), 10;
+is scalar( @{ $r->headers_to_array } ), 12;
 
 # check that we drop the content on 204
 $r = Dancer2::Core::Response->new( content => "foo" );
 $r->status(204);
 is $r->content, '';
-is $r->header('Content-Length'), 0;
 
 # stringify HTTP status
 $r = Dancer2::Core::Response->new( content => "foo", status => "Not Found" );
 is $r->status, 404;
 
-$r =
-  Dancer2::Core::Response->new( content => "foo", status => "not_modified" );
+$r = Dancer2::Core::Response->new( content => "foo", status => "not_modified" );
 is $r->status, 304;
 
 done_testing;


### PR DESCRIPTION
Instead calculating it every time the content is set, it is done only
when the response is serialized to PSGI format.
If the Content-Length header is already set by that time (by
Handler::File, Handler::AutoPage or else), it won't be
recalculated.

Some tests were failing because of this change. They got fixed too.
