### PR TITLE
Possible fix for issue #734

### DIFF
--- a/t/classes/Dancer2-Core-Role-HasLocation/with.t
+++ b/t/classes/Dancer2-Core-Role-HasLocation/with.t
@@ -47,7 +47,7 @@ note 'With lib/ and bin/:'; {
 
     like(
         $location,
-        qr{^[\\/]FakeDancerDir[\\/]$},
+        qr{^[\\/]FakeDancerDir[\\/]?$},
         'Got correct location with lib/ and bin/',
     );
 }
@@ -85,7 +85,7 @@ note 'blib/ ignored:'; {
 
     like(
         $location,
-        qr{^[\\/]FakeDancerDir[\\/]$},
+        qr{^[\\/]FakeDancerDir[\\/]?$},
         'blib/ dir is ignored',
     );
 }


### PR DESCRIPTION
Based on http://www.cpantesters.org/cpan/report/6fd6c508-714c-1014-84c7-d9e22d8cd431
i think that the '\' at the end of the path may not be present on
Windows systems, so I added a '?' regex modifier after that
