### PR TITLE
Docs/megasplat route param example

### DIFF
--- a/lib/Dancer2/Manual.pod
+++ b/lib/Dancer2/Manual.pod
@@ -175,6 +175,9 @@ ArrayRef:
         my @tags = @{$tags};
     };
 
+The splat keyword in the above example for the route '/entry/1/tags/one/two'
+would set $entry_id to 1 and $tags to ['one', 'two']
+
 =head3 Mixed named and wildcard matching
 
 A route can combine named (token) matching and wildcard matching.


### PR DESCRIPTION
This PR adds additional documentation for a mixed splat/megasplat route by showing what exactly the splat keyword returns on an example.
