### PR TITLE
Remove manual AutoPage registering in test

### DIFF
--- a/t/auto_page.t
+++ b/t/auto_page.t
@@ -10,8 +10,6 @@ use HTTP::Request::Common;
     use Dancer2;
 
     set auto_page => 1;
-    ## HACK HACK HACK
-    Dancer2::Handler::AutoPage->register(app);
     engine('template')->views('t/views');
     engine('template')->layout('main');
 }


### PR DESCRIPTION
That manual register call is redundant, as the auto_page => 1 setting causes the handler to register itself already.
