### PR TITLE
Enable UTF-8 in the source code of the skeleton app

### DIFF
--- a/share/skel/lib/AppFile.pm
+++ b/share/skel/lib/AppFile.pm
@@ -1,4 +1,5 @@
 package [% appname %];
+use utf8;
 use Dancer2;
 
 our $VERSION = '0.1';


### PR DESCRIPTION
Since the skeleton app generated by `dancer2 gen` is by default configured to
use UTF-8 (in config.yml), it makes sense to enable UTF-8 in the source code of
the main module (lib/${APP_NAME}.pm) as well. Thus Unicode string literals are
not double encoded and are rendered properly.

Consider this route:

    get '/' => sub { "щука\n" }; # stored in a file with UTF-8 encoding

Before change it would give:

    $ curl localhost:3000
    ÑÑÐºÐ°

After change:

    $ curl localhost:3000
    щука

♥