### PR TITLE
Use #!/usr/bin/env perl executable

### DIFF
--- a/lib/Dancer2/Cookbook.pod
+++ b/lib/Dancer2/Cookbook.pod
@@ -18,7 +18,7 @@ Dancer2 has been designed to be easy to work with - it's trivial to write a
 simple web app, but still has the power to work with larger projects. To
 start with, let's make an incredibly simple "Hello World" example:
 
-    #!/usr/bin/perl
+    #!/usr/bin/env perl
 
     use Dancer2;
 

--- a/script/dancer2
+++ b/script/dancer2
@@ -1,4 +1,4 @@
-#!/usr/bin/perl
+#!/usr/bin/env perl
 # PODNAME: dancer2
 # ABSTRACT: Dancer2 command line interface
 

--- a/t/classes/Dancer2-Core-Route/base.t
+++ b/t/classes/Dancer2-Core-Route/base.t
@@ -1,4 +1,4 @@
-#!/usr/bin/perl
+#!/usr/bin/env perl
 use strict;
 use warnings;
 

--- a/t/lwp-protocol-psgi.t
+++ b/t/lwp-protocol-psgi.t
@@ -1,4 +1,4 @@
-#!/usr/bin/perl
+#!/usr/bin/env perl
 use strict;
 use warnings;
 use Test::More;

--- a/t/psgi_app_forward_and_pass.t
+++ b/t/psgi_app_forward_and_pass.t
@@ -1,4 +1,4 @@
-#!/usr/bin/perl
+#!/usr/bin/env perl
 use strict;
 use warnings;
 

--- a/t/template_tiny/01_compile.t
+++ b/t/template_tiny/01_compile.t
@@ -1,4 +1,4 @@
-#!/usr/bin/perl
+#!/usr/bin/env perl
 
 use strict;
 

--- a/t/template_tiny/02_trivial.t
+++ b/t/template_tiny/02_trivial.t
@@ -1,4 +1,4 @@
-#!/usr/bin/perl
+#!/usr/bin/env perl
 
 use strict;
 

--- a/t/template_tiny/03_samples.t
+++ b/t/template_tiny/03_samples.t
@@ -1,4 +1,4 @@
-#!/usr/bin/perl
+#!/usr/bin/env perl
 
 use strict;
 

--- a/t/template_tiny/04_compat.t
+++ b/t/template_tiny/04_compat.t
@@ -1,4 +1,4 @@
-#!/usr/bin/perl
+#!/usr/bin/env perl
 
 use strict;
 

--- a/t/template_tiny/05_preparse.t
+++ b/t/template_tiny/05_preparse.t
@@ -1,4 +1,4 @@
-#!/usr/bin/perl
+#!/usr/bin/env perl
 
 use strict;
 


### PR DESCRIPTION
Hi!
I would suggest to use the "#!/usr/bin/env perl" shebang instead of the hardcoded "#!/usr/bin/perl" executable, so it would work nicely with perlbrew instances.

Without it, for example the following code would not run:

``` bash
cd /tmp
PERL5LIB="/home/davs/dancer2/lib:$PERL5LIB" DANCER2_SHARE_DIR="share" ~/dancer2/script/dancer2 -a testApp
```

Instead I need to run the dancer2 script like this (note the explicit perl command before dancer2):

``` bash
cd /tmp
PERL5LIB="/home/davs/dancer2/lib:$PERL5LIB" DANCER2_SHARE_DIR="share" perl ~/dancer2/script/dancer2 -a testApp
```

This patch would I think resolve the issue while keeping backwards compatibility.
