### PR TITLE
Fix more tests on Windows. Don't fail due to directory separator differences

### DIFF
--- a/t/app.t
+++ b/t/app.t
@@ -208,8 +208,8 @@ is_deeply(
 );
 
 is(
-    $app->caller,
-    't/app.t',
+    File::Spec->canonpath( $app->caller ),
+    File::Spec->catfile(t => 'app.t'),
     'Correct caller for app',
 );
 

--- a/t/caller.t
+++ b/t/caller.t
@@ -6,6 +6,7 @@ use warnings;
 use Test::More tests => 2;
 use Plack::Test;
 use HTTP::Request::Common;
+use File::Spec;
 
 {
     package App;
@@ -21,5 +22,9 @@ test_psgi $app, sub {
     my $res = $cb->( GET '/' );
 
     is( $res->code, 200, '[GET /] Successful' );
-    is( $res->content, 't/caller.t', 'Correct App name from caller' );
+    is(
+        File::Spec->canonpath( $res->content),
+        File::Spec->catfile(t => 'caller.t'),
+        'Correct App name from caller',
+    );
 };

--- a/t/dispatcher.t
+++ b/t/dispatcher.t
@@ -204,7 +204,7 @@ foreach my $test (
         expected => [
             500,
             [ 'Content-Length', "Content-Type", 'text/html' ],
-            qr{Internal Server Error.*Can't locate object method "fail" via package "Fail" \(perhaps you forgot to load "Fail"\?\) at t/dispatcher\.t line \d+.*$}ms
+            qr{Internal Server Error.*Can't locate object method "fail" via package "Fail" \(perhaps you forgot to load "Fail"\?\) at t[\\/]dispatcher\.t line \d+.*$}ms
         ]
     }
   )


### PR DESCRIPTION
I encountered the failures upon cloning from GitHub and running `dzil test`.

Specifically:

```
Failed test 'Correct caller for app'
at t\app.t line 210.
       got: 't\app.t'
  expected: 't/app.t'

Failed test 'Correct App name from caller'
at t\caller.t line 24.
       got: 't\caller.t'
  expected: 't/caller.t'

Failed test 'contents ok'
at t\dispatcher.t line 224.
...
```

So, I canonicalized the comparisons. Now, this will still cause failures if the test scripts are invoked in funny ways (e.g. `prove -b ../Dancer2\t/app.t`), but these changes should remove spurious test failures under usual build conditions.

I tried the new versions both with Strawberry Perl 5.20.1 64 bit, my custom build using MSVC, and they seem to work.
