### PR TITLE
Consistent prefixes: variables and leading forward slashes:

### DIFF
--- a/lib/Dancer2/Core/Request.pm
+++ b/lib/Dancer2/Core/Request.pm
@@ -1,9 +1,7 @@
 package Dancer2::Core::Request;
-
 # ABSTRACT: Interface for accessing incoming requests
 
 use Moo;
-
 use Carp;
 use Encode;
 use HTTP::Body;

--- a/lib/Dancer2/Core/Route.pm
+++ b/lib/Dancer2/Core/Route.pm
@@ -138,17 +138,10 @@ sub BUILDARGS {
     my $prefix = $args{prefix};
     my $regexp = $args{regexp};
 
-    # regexp must have a leading /
-    if ( ref($regexp) ne 'Regexp' ) {
-        index( $regexp, '/', 0 ) == 0
-            or die "regexp must begin with /\n";
-    }
-
     # init prefix
     if ( $prefix ) {
         $args{regexp} =
             ref($regexp) eq 'Regexp' ? qr{^\Q${prefix}\E${regexp}$} :
-            $regexp eq '/'           ? qr{^\Q${prefix}\E/?$} :
             $prefix . $regexp;
     }
 

--- a/t/app.t
+++ b/t/app.t
@@ -41,7 +41,7 @@ is $app->environment, 'development';
 my $routes_regexps = $app->routes_regexps_for('get');
 is( scalar(@$routes_regexps), 4, "route regexps are OK" );
 
-for my $path ( '/', '/blog', '/mywebsite', '/mywebsite/blog', ) {
+for my $path ( '/', '/blog', '/mywebsite/', '/mywebsite/blog', ) {
     my $env = {
         REQUEST_METHOD => 'GET',
         PATH_INFO      => $path
@@ -50,7 +50,7 @@ for my $path ( '/', '/blog', '/mywebsite', '/mywebsite/blog', ) {
     my $expected = {
         '/'               => '/',
         '/blog'           => '/blog',
-        '/mywebsite'      => '/',
+        '/mywebsite/'     => '/',
         '/mywebsite/blog' => '/blog',
     };
 
@@ -71,7 +71,7 @@ $app->lexical_prefix(
         $app->add_route(
             method => 'get',
             regexp => '/',
-            code   => sub {'/foo'}
+            code   => sub {'/foo/'}
         );
 
         $app->add_route(
@@ -116,7 +116,7 @@ $app->lexical_prefix(
 );
 
 for
-  my $path ( '/foo', '/foo/second', '/foo/bar/second', '/root', '/somewhere' )
+  my $path ( '/foo/', '/foo/second', '/foo/bar/second', '/root', '/somewhere' )
 {
     my $env = {
         REQUEST_METHOD => 'GET',

--- a/t/classes/Dancer2-Core-Route/base.t
+++ b/t/classes/Dancer2-Core-Route/base.t
@@ -4,10 +4,29 @@ use Test::More;
 use Test::Fatal;
 use Dancer2::Core::Route;
 
-plan tests => 1;
+plan tests => 2;
 
-like(
-    exception { Dancer2::Core::Route->new( regexp => 'no+leading+slash' ) },
-    qr/^regexp must begin with/,
-    'route pattern must start with a /',
+is(
+    exception {
+        Dancer2::Core::Route->new(
+            regexp => 'no+leading+slash',
+            method => 'get',
+            code   => sub {1},
+        )
+    },
+    undef,
+    'route pattern can start with a / or not',
 );
+
+is(
+    exception {
+        Dancer2::Core::Route->new(
+            regexp => '',
+            method => 'get',
+            code   => sub {1},
+        )
+    },
+    undef,
+    'route pattern can also be empty',
+);
+

--- a/t/classes/Dancer2-Core-Route/match.t
+++ b/t/classes/Dancer2-Core-Route/match.t
@@ -24,16 +24,20 @@ my @tests = (
 
     # prefix tests
     [   [ 'get', '/', sub {33}, '/forum' ],
-        '/forum',
-        [ { splat => [1] }, 33 ]
+        '/forum/',
+        [ {}, 33 ]
     ],
     [   [ 'get', '/', sub {33}, '/forum' ],
         '/forum/',
-        [ { splat => [1] }, 33 ]
+        [ {}, 33 ]
     ],
     [   [ 'get', '/mywebsite', sub {33}, '/forum' ],
         '/forum/mywebsite',
         [ {}, 33 ]
+    ],
+    [   [ 'get', '', sub {'concat'}, '/' ],
+        '/',
+        [ {}, 'concat' ]
     ],
 
     # splat test
@@ -68,7 +72,7 @@ my @tests = (
     ],
 );
 
-plan tests => 55;
+plan tests => 59;
 
 for my $t (@tests) {
     my ( $route, $path, $expected ) = @$t;


### PR DESCRIPTION
I couldn't break this down into multiple commits so instead a
single commit which fixes two issues. They are both tricky to
grasp and one might introduce breakage (while reducing breakage,
I guess), so they're important to understand.

The first relates to allowing variables in prefixes with a single
path request. If your route is simply '/', variables in the prefix
are simply ignored:

    prefix '/:board' => sub {
        get '/' => sub {...}
    };

Now the actual route registered is '/:board/', literally. That
means that it won't accept variables but only '/:board/'.

The second issue is accepting anything that does not start with
a leading forward slash. This would be an error:

    get '' => sub {...}; # breaks

If you have a prefix and you want to still grab the basic path
without the ending slash it would fail:

    prefix '/:board' => sub {
        get '' => sub {...}; # breaks
    };

This is now fixed too.

One thing to research and perhaps write a test for is the behavior
using path() or path_info(). path() is defined by
path_info() || '/', which might be a problem.

Another issue to recognize is that if someone had the following
code and we don't cover for it, they will receive a 404:

    prefix '/:board' => sub {
        get '/' => sub {
            # expecting to grab both /foo/ and /foo
        };
    };

This, if successful, closes GH #558 and possibly GH #793.