### PR TITLE
Use Import::Into for importing pragmas.

### DIFF
--- a/lib/Dancer2.pm
+++ b/lib/Dancer2.pm
@@ -5,6 +5,7 @@ use strict;
 use warnings;
 use List::Util  'first';
 use Class::Load 'load_class';
+use Import::Into;
 use Dancer2::Core;
 use Dancer2::Core::App;
 use Dancer2::Core::Runner;
@@ -26,9 +27,7 @@ sub import {
     my ( $class,  @args   ) = @_;
     my ( $caller, $script ) = caller;
 
-    strict->import;
-    warnings->import;
-    utf8->import;
+    $_->import::into($caller) for qw(strict warnings utf8);
 
     my @final_args;
     foreach my $arg (@args) {


### PR DESCRIPTION
We were calling $pragma->import which should "just work" to apply the
pragma to the caller. #782 hints that the utf8 pragma may not be
imported correctly. By using Import::Into we have a consistent way to
import pragmas (or anything else may wish to) into the caller.
