### PR TITLE
Rename show_errors to show_stacktrace

### DIFF
--- a/lib/Dancer2/Config.pod
+++ b/lib/Dancer2/Config.pod
@@ -308,7 +308,7 @@ to use them.
 Sessions are configured with a corresponding L</Session engine> section, as
 shown below.
 
-=head3 show_errors (boolean)
+=head3 show_stacktrace (boolean)
 
 If set to true, Dancer2 will render a detailed debug screen whenever an
 error is caught. If set to false, Dancer2 will render the default error
@@ -317,7 +317,7 @@ by the C<error_template> setting.
 
 The error screen attempts to sanitise sensitive looking information
 (passwords / card numbers in the request, etc) but you still should not have
-show_errors enabled whilst in production, as there is still a risk of
+show_stacktrace enabled whilst in production, as there is still a risk of
 divulging details.
 
 =head3 error_template (template path)

--- a/lib/Dancer2/Cookbook.pod
+++ b/lib/Dancer2/Cookbook.pod
@@ -664,14 +664,14 @@ file:
     # appdir/environments/development.yml
     log: 'debug'
     startup_info: 1
-    show_errors:  1
+    show_stacktrace:  1
 
 And in a production one:
 
     # appdir/environments/production.yml
     log: 'warning'
     startup_info: 0
-    show_errors:  0
+    show_stacktrace:  0
 
 =head2 Accessing configuration information
 

--- a/lib/Dancer2/Core/Error.pm
+++ b/lib/Dancer2/Core/Error.pm
@@ -14,14 +14,14 @@ has app => (
     predicate => 'has_app',
 );
 
-has show_errors => (
+has show_stacktrace => (
     is      => 'ro',
     isa     => Bool,
     default => sub {
         my $self = shift;
 
         $self->has_app
-            and return $self->app->setting('show_errors');
+            and return $self->app->setting('show_stacktrace');
     },
 );
 
@@ -105,7 +105,7 @@ sub default_error_page {
         $self->app->request->uri_base : '';
 
     my $message = $self->message;
-    if ( $self->show_errors && $self->exception) {
+    if ( $self->show_stacktrace && $self->exception) {
         $message .= "\n" . $self->exception;
     }
 
@@ -259,8 +259,8 @@ has content => (
             defined $content && return $content;
         }
 
-        # It doesn't make sense to return a static page if show_errors is on
-        if ( !$self->show_errors && (my $content = $self->static_page) ) {
+        # It doesn't make sense to return a static page if show_stacktrace is on
+        if ( !$self->show_stacktrace && (my $content = $self->static_page) ) {
             return $content;
         }
 
@@ -512,7 +512,7 @@ Create a new Dancer2::Core::Error object. For available arguments see ATTRIBUTES
 
 =method supported_hooks ();
 
-=attr show_errors
+=attr show_stacktrace
 
 =attr charset
 

--- a/lib/Dancer2/Manual.pod
+++ b/lib/Dancer2/Manual.pod
@@ -281,7 +281,7 @@ error page with the HTTP status code 500.
 It's possible either to display the content of the error message or to hide
 it with a generic error page.
 
-This is a choice left to the end-user and can be set with the B<show_errors>
+This is a choice left to the end-user and can be set with the B<show_stacktrace>
 setting.
 
 Note that you can also choose to consider all warnings in your route
@@ -509,14 +509,14 @@ file:
     # appdir/environments/development.yml
     log: 'debug'
     startup_info: 1
-    show_errors:  1
+    show_stacktrace:  1
 
 And in a production one:
 
     # appdir/environments/production.yml
     log: 'warning'
     startup_info: 0
-    show_errors:  0
+    show_stacktrace:  0
 
 Please note that you are not limited to writing configuration files in YAML.
 Dancer2 supports any file format that is supported by L<Config::Any>, such

--- a/lib/Dancer2/Tutorial.pod
+++ b/lib/Dancer2/Tutorial.pod
@@ -257,7 +257,7 @@ more options than just the session engine we want to set.
   set 'template'     => 'template_toolkit';
   set 'logger'       => 'console';
   set 'log'          => 'debug';
-  set 'show_errors'  => 1;
+  set 'show_stacktrace'  => 1;
   set 'startup_info' => 1;
   set 'warnings'     => 1;
 
@@ -468,7 +468,7 @@ Here's the complete 'dancr.pl' script from start to finish.
  set 'template'     => 'template_toolkit';
  set 'logger'       => 'console';
  set 'log'          => 'debug';
- set 'show_errors'  => 1;
+ set 'show_stacktrace'  => 1;
  set 'startup_info' => 1;
  set 'warnings'     => 1;
  set 'username'     => 'admin';

--- a/share/skel/environments/development.yml
+++ b/share/skel/environments/development.yml
@@ -17,7 +17,7 @@ warnings: 1
 # should Dancer2 show a stacktrace when an error is caught?
 # if set to yes, public/500.html will be ignored and either
 # views/500.tt or a default error template will be used.
-show_errors: 1
+show_stacktrace: 1
 
 # print the banner
 startup_info: 1

--- a/share/skel/environments/production.yml
+++ b/share/skel/environments/production.yml
@@ -10,7 +10,7 @@ logger: "file"
 warnings: 0
 
 # hide errors
-show_errors: 0
+show_stacktrace: 0
 
 # disable server tokens in production environments
 no_server_token: 1

--- a/t/config/config.yml
+++ b/t/config/config.yml
@@ -1,6 +1,6 @@
 main: 1
 charset: 'UTF-8'
-show_errors: 1
+show_stacktrace: 1
 
 application:
    some_feature: foo

--- a/t/config/environments/production.yml
+++ b/t/config/environments/production.yml
@@ -1,2 +1,2 @@
-show_errors: 0
+show_stacktrace: 0
 logger: "console"

--- a/t/config/environments/staging.json
+++ b/t/config/environments/staging.json
@@ -1,5 +1,5 @@
 {
     "main": "1",
     "charset": 'UTF-8',
-    "show_errors": "1"
+    "show_stacktrace": "1"
 }

--- a/t/config_reader.t
+++ b/t/config_reader.t
@@ -110,7 +110,7 @@ is_deeply $m->config->{application},
 
 note "config parsing";
 
-is $f->config->{show_errors}, 0;
+is $f->config->{show_stacktrace}, 0;
 is $f->config->{main},        1;
 is $f->config->{charset},     'utf-8', "normalized UTF-8 to utf-8";
 

--- a/t/dispatcher.t
+++ b/t/dispatcher.t
@@ -17,7 +17,7 @@ my $buffer = {};
 my $app = Dancer2::Core::App->new( name => 'main' );
 
 $app->setting( logger      => engine('logger') );
-$app->setting( show_errors => 1 );
+$app->setting( show_stacktrace => 1 );
 
 # a simple / route
 $app->add_route(

--- a/t/error.t
+++ b/t/error.t
@@ -116,18 +116,18 @@ subtest 'Response->error()' => sub {
     ok $resp->is_halted, 'response is halted';
 };
 
-subtest 'Error with show_errors: 0' => sub {
+subtest 'Error with show_stacktrace: 0' => sub {
     my $err = Dancer2::Core::Error->new(
-        exception   => 'our exception',
-        show_errors => 0
+        exception       => 'our exception',
+        show_stacktrace => 0
     )->throw;
     unlike $err->content => qr/our exception/;
 };
 
-subtest 'Error with show_errors: 1' => sub {
+subtest 'Error with show_stacktrace: 1' => sub {
     my $err = Dancer2::Core::Error->new(
-        exception   => 'our exception',
-        show_errors => 1
+        exception       => 'our exception',
+        show_stacktrace => 1
     )->throw;
     like $err->content => qr/our exception/;
 };
@@ -163,8 +163,8 @@ subtest 'Error with exception object' => sub {
     local $@;
     eval { MyTestException->throw('a test exception object') };
     my $err = Dancer2::Core::Error->new(
-        exception   => $@,
-        show_errors => 1,
+        exception       => $@,
+        show_stacktrace => 1,
     )->throw;
 
     like $err->content, qr/a test exception object/, 'Error content contains exception message';

--- a/t/session_engines.t
+++ b/t/session_engines.t
@@ -42,8 +42,8 @@ my $SESSION_DIR;
     setting session => 'Simple';
 
     set(
-        show_errors  => 1,
-        environment  => 'production',
+        show_stacktrace  => 1,
+        environment      => 'production',
     );
 }
 

--- a/t/session_hooks.t
+++ b/t/session_hooks.t
@@ -27,8 +27,8 @@ my $test_flags = {};
     use Dancer2;
 
     set(
-        show_errors => 1,
-        envoriment  => 'production'
+        show_stacktrace => 1,
+        envoriment      => 'production'
     );
 
     setting( session => 'Simple' );

--- a/t/session_lifecycle.t
+++ b/t/session_lifecycle.t
@@ -9,8 +9,8 @@ use HTTP::Cookies;
     package App;
     use Dancer2;
 
-    set session     => 'Simple';
-    set show_errors => 1;
+    set session         => 'Simple';
+    set show_stacktrace => 1;
 
     get '/no_session_data' => sub {
         return "session not modified";


### PR DESCRIPTION
This plainly renames show_errors to show_stacktrace, regarding issue PerlDancer/Dancer2#769
