### PR TITLE
fix broken link in documentation #831

### DIFF
--- a/lib/Dancer2/Session/YAML.pm
+++ b/lib/Dancer2/Session/YAML.pm
@@ -65,6 +65,6 @@ This module depends on L<YAML>.
 
 =head1 SEE ALSO
 
-See L<Dancer2::Session> for details about session usage in route handlers.
+See L<Dancer2::Core::Session> for details about session usage in route handlers.
 
 =cut


### PR DESCRIPTION
I took the liberty to assume that the link should point to the Session documentation of Dancer2