### PR TITLE
Improve scoping of app cleanup after dispatch (#762)

### DIFF
--- a/lib/Dancer2/Core/App.pm
+++ b/lib/Dancer2/Core/App.pm
@@ -1198,9 +1198,8 @@ DISPATCH:
         last;
     }
 
-    $self->cleanup;
 
-    # make sure Core::Dispatcher recognizes this failure
+    # No response! ensure Core::Dispatcher recognizes this failure
     # so it can try the next Core::App
     # and set the created request so we don't create it again
     # (this is important so we don't ignore the previous body)
@@ -1209,7 +1208,10 @@ DISPATCH:
         Dancer2->runner->{'internal_request'} = $request;
     }
 
-    return $self->response_not_found($request);
+    # Render 404 response, cleanup, and return the response.
+    my $response = $self->response_not_found($request);
+    $self->cleanup;
+    return $response;
 }
 
 sub build_request {

--- a/t/issues/gh-762.t
+++ b/t/issues/gh-762.t
@@ -1,0 +1,41 @@
+use Test::More;
+use Plack::Test;
+use HTTP::Request::Common;
+
+{
+    package FourOhFour;
+
+    use Dancer2;
+
+    set views      => 't/issues/gh-762/views';
+
+    get '/error' => sub {
+        send_error "oh my", 404;
+    };
+
+}
+
+my $fourohfour_app = FourOhFour->to_app;
+my $fourohfour_test   = Plack::Test->create($fourohfour_app);
+
+subtest "/error" => sub {
+    my $res = $fourohfour_test->request( GET '/error' );
+
+    is $res->code, 404, 'send_error sets the status to 404';
+    like $res->content, qr{Template selected}, 'Error message looks good';
+    like $res->content, qr{message: oh my};
+    like $res->content, qr{status: 404};
+};
+
+subtest 'FourOhFour with views template' => sub {
+    my $path = "/middle/of/nowhere";
+    my $res = $fourohfour_test->request( GET $path );
+
+    is $res->code, 404, 'unknown route => 404';
+    like $res->content, qr{Template selected}, 'Error message looks good';
+    like $res->content, qr{message: $path};
+    like $res->content, qr{status: 404};
+};
+
+done_testing();
+

--- a/t/issues/gh-762/views/404.tt
+++ b/t/issues/gh-762/views/404.tt
@@ -1,0 +1,4 @@
+Template selected.
+
+message: [% content %]
+status: [% status %]


### PR DESCRIPTION
If the request dispatch fails to match any route, render any error template before cleaning up the app context, then immediately return the rendered (error) response.

This is as close to using 'local' vars for scoping as we can get, without actually using localized vars.

Resolves #762.