### PR TITLE
added some extra needed parentheses in check for request in logger.

### DIFF
--- a/lib/Dancer2/Core/Role/Logger.pm
+++ b/lib/Dancer2/Core/Role/Logger.pm
@@ -118,7 +118,7 @@ sub format_message {
         f => sub { $stack[1] || '-' },
         l => sub { $stack[2] || '-' },
         h => sub {
-            ( $request && $request->remote_host || $request->address ) || '-'
+            ( $request && ($request->remote_host || $request->address) ) || '-'
         },
         i => sub { ( $request && $request->id ) || '-' },
     };


### PR DESCRIPTION
Completion of earlier fix in commit 17e950ff828adff95b1b9e1b0e2c048331d54dce. Without this fix Dancer2 may still bork in case of undefined $request.
