### PR TITLE
Snigdha

### DIFF
--- a/lib/Dancer2/Cookbook.pod
+++ b/lib/Dancer2/Cookbook.pod
@@ -444,6 +444,55 @@ We can now add the B<POST> method for verifying that username and password:
          # let's render instead of redirect...
          template login => { error => 'Invalid username or password' };
      };
+     
+=head2 Accessing configuration information from a separate script
+
+You may want to access your webapp's configuration from outside your
+webapp. You could, of course, use the YAML module of your choice and load
+your webapps's C<config.yml>, but chances are that this is not convenient.
+
+Use Dancer2 instead. You can simply use
+the values from C<config.yml> and some additional default values:
+
+    # bin/show_app_config.pl
+    use Dancer2;
+    print "template:".config->{template}."\n"; # simple
+    print "log:".config->{log}."\n"; # undef
+
+Note that C<< config->{log} >> should result in an uninitialized warning
+on a default scaffold since the environment isn't loaded and
+log is defined in the environment and not in C<config.yml>. Hence C<undef>.
+
+Dancer2 will load your C<config.yml> configuration file along with the
+correct environment file located in your C<environments> directory.
+
+The environment is determined by two environment variables in the following
+order:
+
+=over 4
+
+=item * DANCER_ENVIRONMENT
+
+=item * PLACK_ENV
+
+=back
+
+If neither of those is set, it will default to loading the development
+environment (typically C<$webapp/environment/development.yml>).
+
+If you wish to load a different environment, you need to override these
+variables.
+
+You can call your script with the environment changed:
+
+    $ PLACK_ENV=production perl bin/show_app_config.pl
+
+Or you can override them directly in the script (less recommended):
+
+    BEGIN { $ENV{'DANCER_ENVIRONMENT'} = 'production' }
+    use Dancer2;
+
+    ...
 
 =head2 Template Toolkit's WRAPPER directive in Dancer2
 

--- a/lib/Dancer2/Cookbook.pod
+++ b/lib/Dancer2/Cookbook.pod
@@ -655,6 +655,8 @@ Our bookstore lookup application can now be started using the built-in server:
 
     # start the web application
     bookstore/bin/app.pl
+    
+=back
 
 =head2 Authentication
 

--- a/lib/Dancer2/Cookbook.pod
+++ b/lib/Dancer2/Cookbook.pod
@@ -47,6 +47,7 @@ If you I<really> do not want the C<warnings> pragma (for example, due to an
 undesired warning about use of undef values), add a C<no warnings> pragma to
 the appropriate block in your module or psgi file.
 
+
 =head2 Starting a Dancer2 project
 
 The first simple example is fine for trivial projects, but for anything more
@@ -93,6 +94,7 @@ will live), an environments directory (where environment-specific settings
 live), a module containing the actual guts of your application, a script to
 start it - or to run your web app via Plack/PSGI - more on that later.
 
+
 =head2 Default Route
 
 In case you want to avoid a I<404 error>, or handle multiple routes in the
@@ -115,6 +117,7 @@ Then you can set up the template like so:
 
     Please try again or contact us at <contact@example.com>.
 
+
 =head2 Using the C<auto_page> feature for automatic route creation
 
 For simple "static" pages you can simply enable the C<auto_page> config
@@ -123,6 +126,7 @@ pages; if a request is for C</foo/bar>, Dancer2 will check for a matching
 view (e.g. C</foo/bar.tt> and render it with the default layout etc. if
 found. For full details, see the documentation for the L<auto_page
 setting|Dancer2::Config/"auto_page">.
+
 
 =head2 Simplifying AJAX queries with the Ajax plugin
 
@@ -220,6 +224,7 @@ care of the JSON encapsulation.
 For more serious AJAX interaction, there's also L<Dancer2::Plugin::Ajax> 
 that adds an I<ajax> route handler to the mix.
 
+
 =head2 Using the prefix feature to split your application
 
 For better maintainability, you may want to separate some of your application
@@ -261,6 +266,7 @@ When using multiple applications please ensure that your path definitions do
 not overlap. For example, if using a default route as described above, once
 a request is matched to the default route then no further routes (or
 applications) would be reached.
+
 
 =head2 Delivering custom error pages
 
@@ -344,6 +350,97 @@ And if total control is needed:
 
          ...;
      };
+
+
+=head2 Template Toolkit's WRAPPER directive in Dancer2
+
+Dancer2 already provides a WRAPPER-like ability, which we call a "layout".
+The reason we don't use Template Toolkit's WRAPPER (which also makes us incompatible with
+it) is because not all template systems support it. Actually, most don't.
+
+However, you might want to use it, and be able to define META variables and
+regular L<Template::Toolkit> variables.
+
+These few steps will get you there:
+
+=over 4
+
+=item * Disable the layout in Dancer2
+
+You can do this by simply commenting (or removing) the C<layout>
+configuration in the config file.
+
+=item * Use the Template Toolkit template engine
+
+Change the configuration of the template to Template Toolkit:
+
+    # in config.yml
+    template: "template_toolkit"
+
+=item * Tell the Template Toolkit engine which wrapper to use
+
+    # in config.yml
+    # ...
+    engines:
+        template:
+            template_toolkit:
+                WRAPPER: layouts/main.tt
+
+=back
+
+Done! Everything will work fine out of the box, including variables and META
+variables.
+
+
+=head2 Accessing configuration information from a separate script
+
+You may want to access your webapp's configuration from outside your
+webapp. You could, of course, use the YAML module of your choice and load
+your webapps's C<config.yml>, but chances are that this is not convenient.
+
+Use Dancer2 instead. You can simply use
+the values from C<config.yml> and some additional default values:
+
+    # bin/show_app_config.pl
+    use Dancer2;
+    print "template:".config->{template}."\n"; # simple
+    print "log:".config->{log}."\n"; # undef
+
+Note that C<< config->{log} >> should result in an uninitialized warning
+on a default scaffold since the environment isn't loaded and
+log is defined in the environment and not in C<config.yml>. Hence C<undef>.
+
+Dancer2 will load your C<config.yml> configuration file along with the
+correct environment file located in your C<environments> directory.
+
+The environment is determined by two environment variables in the following
+order:
+
+=over 4
+
+=item * DANCER_ENVIRONMENT
+
+=item * PLACK_ENV
+
+=back
+
+If neither of those is set, it will default to loading the development
+environment (typically C<$webapp/environment/development.yml>).
+
+If you wish to load a different environment, you need to override these
+variables.
+
+You can call your script with the environment changed:
+
+    $ PLACK_ENV=production perl bin/show_app_config.pl
+
+Or you can override them directly in the script (less recommended):
+
+    BEGIN { $ENV{'DANCER_ENVIRONMENT'} = 'production' }
+    use Dancer2;
+
+    ...
+
 
 =head2 Authentication
 
@@ -445,296 +542,6 @@ We can now add the B<POST> method for verifying that username and password:
          template login => { error => 'Invalid username or password' };
      };
      
-=head2 Accessing configuration information from a separate script
-
-You may want to access your webapp's configuration from outside your
-webapp. You could, of course, use the YAML module of your choice and load
-your webapps's C<config.yml>, but chances are that this is not convenient.
-
-Use Dancer2 instead. You can simply use
-the values from C<config.yml> and some additional default values:
-
-    # bin/show_app_config.pl
-    use Dancer2;
-    print "template:".config->{template}."\n"; # simple
-    print "log:".config->{log}."\n"; # undef
-
-Note that C<< config->{log} >> should result in an uninitialized warning
-on a default scaffold since the environment isn't loaded and
-log is defined in the environment and not in C<config.yml>. Hence C<undef>.
-
-Dancer2 will load your C<config.yml> configuration file along with the
-correct environment file located in your C<environments> directory.
-
-The environment is determined by two environment variables in the following
-order:
-
-=over 4
-
-=item * DANCER_ENVIRONMENT
-
-=item * PLACK_ENV
-
-=back
-
-If neither of those is set, it will default to loading the development
-environment (typically C<$webapp/environment/development.yml>).
-
-If you wish to load a different environment, you need to override these
-variables.
-
-You can call your script with the environment changed:
-
-    $ PLACK_ENV=production perl bin/show_app_config.pl
-
-Or you can override them directly in the script (less recommended):
-
-    BEGIN { $ENV{'DANCER_ENVIRONMENT'} = 'production' }
-    use Dancer2;
-
-    ...
-
-=head2 Template Toolkit's WRAPPER directive in Dancer2
-
-Dancer2 already provides a WRAPPER-like ability, which we call a "layout".
-The reason we don't use Template Toolkit's WRAPPER (which also makes us incompatible with
-it) is because not all template systems support it. Actually, most don't.
-
-However, you might want to use it, and be able to define META variables and
-regular L<Template::Toolkit> variables.
-
-These few steps will get you there:
-
-=over 4
-
-=item * Disable the layout in Dancer2
-
-You can do this by simply commenting (or removing) the C<layout>
-configuration in the config file.
-
-=item * Use the Template Toolkit template engine
-
-Change the configuration of the template to Template Toolkit:
-
-    # in config.yml
-    template: "template_toolkit"
-
-=item * Tell the Template Toolkit engine which wrapper to use
-
-    # in config.yml
-    # ...
-    engines:
-        template:
-            template_toolkit:
-                WRAPPER: layouts/main.tt
-
-=back
-
-Done! Everything will work fine out of the box, including variables and META
-variables.
-
-=head2 Creating a service
-
-You can turn your app into a proper service running in the background using one of
-the following examples.
-
-=head3 Using Ubic
-
-L<Ubic> is an extensible perlish service manager. You can use it to start
-and stop any services, automatically start them on reboots or daemon
-failures, and implement custom status checks.
-
-A basic PSGI service description (usually in C</etc/ubic/service/application>):
-
-    use parent qw(Ubic::Service::Plack);
-
-    # if your application is not installed in @INC path:
-    sub start {
-        my $self = shift;
-        $ENV{PERL5LIB} = '/path/to/your/application/lib';
-        $self->SUPER::start(@_);
-    }
-
-    __PACKAGE__->new(
-        server => 'Starman',
-        app => '/path/to/your/application/app.psgi',
-        port => 5000,
-        user => 'www-data',
-    );
-
-Run C<ubic start application> to start the service.
-
-=head3 Using daemontools
-
-daemontools is a collection of tools for managing UNIX services. You can use
-it to easily start/restart/stop services.
-
-A basic script to start an application: (in C</service/application/run>)
-
-    #!/bin/sh
-
-    # if your application is not installed in @INC path:
-    export PERL5LIB='/path/to/your/application/lib'
-
-    exec 2>&1 \
-    /usr/local/bin/plackup -s Starman -a /path/to/your/application/app.psgi -p 5000
-
-=head2 Running stand-alone behind a proxy / load balancer
-
-Another option would be to run your app stand-alone as described above, but
-then use a proxy or load balancer to accept incoming requests (on the
-standard port 80, say) and feed them to your Dancer2 app.
-
-This could be achieved using various software; examples would include:
-
-=head3 Using Apache's C<mod_proxy>
-
-You could set up a C<VirtualHost> for your web app, and proxy all requests
-through to it:
-
-    <VirtualHost mywebapp.example.com:80>
-    ProxyPass / http://localhost:3000/
-    ProxyPassReverse / http://localhost:3000/
-    </VirtualHost>
-
-Or, if you want your webapp to share an existing VirtualHost, you could have
-it under a specified dir:
-
-    ProxyPass /mywebapp/ http://localhost:3000/
-    ProxyPassReverse /mywebapp/ http://localhost:3000/
-
-It is important for you to note that the Apache2 modules C<mod_proxy> and
-C<mod_proxy_http> must be enabled:
-
-    $ a2enmod proxy
-    $ a2enmod proxy_http
-
-It is also important to set permissions for proxying for security purposes,
-below is an example.
-
-    <Proxy *>
-      Order allow,deny
-      Allow from all
-    </Proxy>
-
-=head3 Using perlbal
-
-C<perlbal> is a single-threaded event-based server written in Perl
-supporting HTTP load balancing, web serving, and a mix of the two, available
-from L<http://www.danga.com/perlbal/>.
-
-It processes hundreds of millions of requests a day just for LiveJournal,
-Vox and TypePad and dozens of other "Web 2.0" applications.
-
-It can also provide a management interface to let you see various
-information on requests handled etc.
-
-It could easily be used to handle requests for your Dancer2 apps, too.
-
-It can be easily installed from CPAN:
-
-    perl -MCPAN -e 'install Perlbal'
-
-Once installed, you'll need to write a configuration file. See the examples
-provided with perlbal, but you'll probably want something like:
-
-    CREATE POOL my_dancers
-    POOL my_dancers ADD 10.0.0.10:3030
-    POOL my_dancers ADD 10.0.0.11:3030
-    POOL my_dancers ADD 10.0.0.12:3030
-    POOL my_dancers ADD 10.0.0.13:3030
-
-    CREATE SERVICE my_webapp
-    SET listen          = 0.0.0.0:80
-    SET role            = reverse_proxy
-    SET pool            = my_dancers
-    SET persist_client  = on
-    SET persist_backend = on
-    SET verify_backend  = on
-    ENABLE my_webapp
-
-=head3 Using balance
-
-C<balance> is a simple load-balancer from Inlab Software, available from
-L<http://www.inlab.de/balance.html>.
-
-It could be used simply to hand requests to a standalone Dancer2 app. You
-could even run several instances of your Dancer2 app, on the same machine or
-on several machines, and use a machine running C<balance> to distribute the
-requests between them, for some serious heavy traffic handling!
-
-To listen on port 80, and send requests to a Dancer2 app on port 3000:
-
-    balance http localhost:3000
-
-To listen on a specified IP only on port 80, and distribute requests between
-multiple Dancer2 apps on multiple other machines:
-
-    balance -b 10.0.0.1 80 10.0.0.2:3000 10.0.0.3:3000 10.0.0.4:3000
-
-=head3 Using lighttpd
-
-You can use lighttp's C<mod_proxy>:
-
-    $HTTP["url"] =~ "/application" {
-        proxy.server = (
-            "/" => (
-                "application" => ( "host" => "127.0.0.1", "port" => 3000 )
-            )
-        )
-    }
-
-This configuration will proxy all requests to the C</application> path to the
-path C</> on localhost:3000.
-
-=head3 Using Nginx
-
-with Nginx:
-
-    upstream backendurl {
-        server unix:THE_PATH_OF_YOUR_PLACKUP_SOCKET_HERE.sock;
-    }
-
-    server {
-      listen       80;
-      server_name YOUR_HOST_HERE;
-
-      access_log /var/log/YOUR_ACCESS_LOG_HERE.log;
-      error_log  /var/log/YOUR_ERROR_LOG_HERE.log info;
-
-      root YOUR_ROOT_PROJECT/public;
-      location / {
-        try_files $uri @proxy;
-        access_log off;
-        expires max;
-      }
-
-      location @proxy {
-            proxy_set_header Host $http_host;
-            proxy_set_header X-Forwarded-Host $host;
-            proxy_set_header X-Real-IP $remote_addr;
-            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-            proxy_pass       http://backendurl;
-      }
-
-    }
-
-You will need plackup to start a worker listening on a socket :
-
-    cd YOUR_PROJECT_PATH
-    sudo -u www plackup -E production -s Starman --workers=2 \
-        -l THE_PATH_OF_YOUR_PLACKUP_SOCKET_HERE.sock -a bin/app.psgi
-
-A good way to start this is to use C<daemontools> and place this line with
-all environments variables in the "run" file.
-
-=head2 Turning off warnings
-
-The C<warnings> pragma is already used when one loads Dancer2. However, if
-you I<really> do not want the C<warnings> pragma (for example, due to an
-undesired warning about use of undef values), add a C<no warnings> pragma to
-the appropriate block in your module or psgi file.
-
 =head2 Writing a REST application
 
 With Dancer2, it's easy to write REST applications. Dancer2 provides helpers
@@ -970,3 +777,206 @@ will filter it for only the simple keys in the retrieved data:
 All that is left now is to render it:
 
      template index => { metrics => $metrics };
+
+     
+=head2 Creating a service
+
+You can turn your app into a proper service running in the background using one of
+the following examples.
+
+=head3 Using Ubic
+
+L<Ubic> is an extensible perlish service manager. You can use it to start
+and stop any services, automatically start them on reboots or daemon
+failures, and implement custom status checks.
+
+A basic PSGI service description (usually in C</etc/ubic/service/application>):
+
+    use parent qw(Ubic::Service::Plack);
+
+    # if your application is not installed in @INC path:
+    sub start {
+        my $self = shift;
+        $ENV{PERL5LIB} = '/path/to/your/application/lib';
+        $self->SUPER::start(@_);
+    }
+
+    __PACKAGE__->new(
+        server => 'Starman',
+        app => '/path/to/your/application/app.psgi',
+        port => 5000,
+        user => 'www-data',
+    );
+
+Run C<ubic start application> to start the service.
+
+=head3 Using daemontools
+
+daemontools is a collection of tools for managing UNIX services. You can use
+it to easily start/restart/stop services.
+
+A basic script to start an application: (in C</service/application/run>)
+
+    #!/bin/sh
+
+    # if your application is not installed in @INC path:
+    export PERL5LIB='/path/to/your/application/lib'
+
+    exec 2>&1 \
+    /usr/local/bin/plackup -s Starman -a /path/to/your/application/app.psgi -p 5000
+
+=head2 Running stand-alone behind a proxy / load balancer
+
+Another option would be to run your app stand-alone as described above, but
+then use a proxy or load balancer to accept incoming requests (on the
+standard port 80, say) and feed them to your Dancer2 app.
+
+This could be achieved using various software; examples would include:
+
+=head3 Using Apache's C<mod_proxy>
+
+You could set up a C<VirtualHost> for your web app, and proxy all requests
+through to it:
+
+    <VirtualHost mywebapp.example.com:80>
+    ProxyPass / http://localhost:3000/
+    ProxyPassReverse / http://localhost:3000/
+    </VirtualHost>
+
+Or, if you want your webapp to share an existing VirtualHost, you could have
+it under a specified dir:
+
+    ProxyPass /mywebapp/ http://localhost:3000/
+    ProxyPassReverse /mywebapp/ http://localhost:3000/
+
+It is important for you to note that the Apache2 modules C<mod_proxy> and
+C<mod_proxy_http> must be enabled:
+
+    $ a2enmod proxy
+    $ a2enmod proxy_http
+
+It is also important to set permissions for proxying for security purposes,
+below is an example.
+
+    <Proxy *>
+      Order allow,deny
+      Allow from all
+    </Proxy>
+
+=head3 Using perlbal
+
+C<perlbal> is a single-threaded event-based server written in Perl
+supporting HTTP load balancing, web serving, and a mix of the two, available
+from L<http://www.danga.com/perlbal/>.
+
+It processes hundreds of millions of requests a day just for LiveJournal,
+Vox and TypePad and dozens of other "Web 2.0" applications.
+
+It can also provide a management interface to let you see various
+information on requests handled etc.
+
+It could easily be used to handle requests for your Dancer2 apps, too.
+
+It can be easily installed from CPAN:
+
+    perl -MCPAN -e 'install Perlbal'
+
+Once installed, you'll need to write a configuration file. See the examples
+provided with perlbal, but you'll probably want something like:
+
+    CREATE POOL my_dancers
+    POOL my_dancers ADD 10.0.0.10:3030
+    POOL my_dancers ADD 10.0.0.11:3030
+    POOL my_dancers ADD 10.0.0.12:3030
+    POOL my_dancers ADD 10.0.0.13:3030
+
+    CREATE SERVICE my_webapp
+    SET listen          = 0.0.0.0:80
+    SET role            = reverse_proxy
+    SET pool            = my_dancers
+    SET persist_client  = on
+    SET persist_backend = on
+    SET verify_backend  = on
+    ENABLE my_webapp
+
+=head3 Using balance
+
+C<balance> is a simple load-balancer from Inlab Software, available from
+L<http://www.inlab.de/balance.html>.
+
+It could be used simply to hand requests to a standalone Dancer2 app. You
+could even run several instances of your Dancer2 app, on the same machine or
+on several machines, and use a machine running C<balance> to distribute the
+requests between them, for some serious heavy traffic handling!
+
+To listen on port 80, and send requests to a Dancer2 app on port 3000:
+
+    balance http localhost:3000
+
+To listen on a specified IP only on port 80, and distribute requests between
+multiple Dancer2 apps on multiple other machines:
+
+    balance -b 10.0.0.1 80 10.0.0.2:3000 10.0.0.3:3000 10.0.0.4:3000
+
+=head3 Using lighttpd
+
+You can use lighttp's C<mod_proxy>:
+
+    $HTTP["url"] =~ "/application" {
+        proxy.server = (
+            "/" => (
+                "application" => ( "host" => "127.0.0.1", "port" => 3000 )
+            )
+        )
+    }
+
+This configuration will proxy all requests to the C</application> path to the
+path C</> on localhost:3000.
+
+=head3 Using Nginx
+
+with Nginx:
+
+    upstream backendurl {
+        server unix:THE_PATH_OF_YOUR_PLACKUP_SOCKET_HERE.sock;
+    }
+
+    server {
+      listen       80;
+      server_name YOUR_HOST_HERE;
+
+      access_log /var/log/YOUR_ACCESS_LOG_HERE.log;
+      error_log  /var/log/YOUR_ERROR_LOG_HERE.log info;
+
+      root YOUR_ROOT_PROJECT/public;
+      location / {
+        try_files $uri @proxy;
+        access_log off;
+        expires max;
+      }
+
+      location @proxy {
+            proxy_set_header Host $http_host;
+            proxy_set_header X-Forwarded-Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_pass       http://backendurl;
+      }
+
+    }
+
+You will need plackup to start a worker listening on a socket :
+
+    cd YOUR_PROJECT_PATH
+    sudo -u www plackup -E production -s Starman --workers=2 \
+        -l THE_PATH_OF_YOUR_PLACKUP_SOCKET_HERE.sock -a bin/app.psgi
+
+A good way to start this is to use C<daemontools> and place this line with
+all environments variables in the "run" file.
+
+=head2 Turning off warnings
+
+The C<warnings> pragma is already used when one loads Dancer2. However, if
+you I<really> do not want the C<warnings> pragma (for example, due to an
+undesired warning about use of undef values), add a C<no warnings> pragma to
+the appropriate block in your module or psgi file.

--- a/lib/Dancer2/Cookbook.pod
+++ b/lib/Dancer2/Cookbook.pod
@@ -442,6 +442,220 @@ Or you can override them directly in the script (less recommended):
     ...
 
 
+=head2 Using DBIx::Class
+
+L<DBIx::Class>, also known as DBIC, is one of the many Perl ORM 
+(I<Object Relational Mapper>). It is easy to use DBIC in Dancer using the
+L<Dancer2::Plugin::DBIC>.
+
+=head3 An example
+
+This example demonstrates a simple Dancer application that allows to search 
+for authors or books. The application is connected to a database, that contains 
+authors, and their books. The website will have one single page with a form, 
+that allows to query books or authors, and display the results.
+
+=head4 Creating the application
+
+    $> dancer -a bookstore
+    
+To use the Template Toolkit as the template engine, we specify it in the 
+congiguration file:
+
+    # add in bookstore/config.yml
+    template: template_toolkit
+    
+=head4 Creating the view
+
+We need a view to display the search form, and below, the results, if any. The 
+results will be fed by the route to the view as an arrayref of results. Each 
+result is a I<hashref>, with a author key containing the name of the author, and 
+a books key containing an I<arrayref> of strings : the books names.
+
+    # example of a list of results
+    [ { author => 'author 1',
+        books => [ 'book 1', 'book 2' ],
+      },
+      { author => 'author 2',
+        books => [ 'book 3', 'book 4' ],
+      }
+    ]
+    
+# bookstore/views/search.tt
+<p>
+<form action="/search">
+Search query: <input type="text" name="query" />
+</form>
+</p>
+<br>  
+
+An example of the view, displaying the search form, and the results, if any:
+
+    <% IF query.length %>
+      <p>Search query was : <% query %>.</p>
+      <% IF results.size %>
+        Results:
+        <ul>
+        <% FOREACH result IN results %>
+          <li>Author: <% result.author.replace("((?i)$query)", '<b>$1</b>') %>
+          <ul>
+          <% FOREACH book IN result.books %>
+            <li><% book.replace("((?i)$query)", '<b>$1</b>') %>
+          <% END %>
+          </ul>
+        <% END %>
+      <% ELSE %>
+        No result
+      <% END %>
+    <% END %>
+    
+=head4 Creating a Route
+
+A simple route, to be added in the I<bookstore.pm> module:
+
+    # add in bookstore/lib/bookstore.pm
+    get '/search' => sub {
+        my $query = params->{query};
+        my @results = ();
+        if (length $query) {
+            @results = _perform_search($query);
+        }
+        template 'search', { query => $query,
+                             results => \@results,
+                           };
+    };
+    
+=head4 Creating a database
+
+We create a SQLite file database:
+    
+    $> sqlite3 bookstore.db
+    CREATE TABLE author( 
+      id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, 
+      firstname text default '' not null, 
+      lastname text not null);
+    
+    CREATE TABLE book(
+      id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, 
+      author INTEGER REFERENCES author (id), 
+      title text default '' not null );
+      
+Now, to populate the database with some data, we use L<DBIx::Class>:
+
+    # populate_database.pl
+    package My::Bookstore::Schema;
+    use base qw(DBIx::Class::Schema::Loader);
+    package main;
+    my $schema = My::Bookstore::Schema->connect('dbi:SQLite:dbname=bookstore.db');
+    $schema->populate('Author', [
+      [ 'firstname', 'lastname'],
+      [ 'Ian M.',    'Banks'   ],
+      [ 'Richard',   'Matheson'],
+      [ 'Frank',     'Herbert' ],
+    ]);
+    my @books_list = (
+      [ 'Consider Phlebas',    'Banks'    ],
+      [ 'The Player of Games', 'Banks'    ],
+      [ 'Use of Weapons',      'Banks'    ],
+      [ 'Dune',                'Herbert'  ],
+      [ 'Dune Messiah',        'Herbert'  ],
+      [ 'Children of Dune',    'Herbert'  ],
+      [ 'The Night Stalker',   'Matheson' ],
+      [ 'The Night Strangler', 'Matheson' ],
+    );
+    # transform author names into ids
+    $_->[1] = $schema->resultset('Author')->find({ lastname => $_->[1] })->id
+      foreach (@books_list);
+    $schema->populate('Book', [
+      [ 'title', 'author' ],
+      @books_list,
+    ]);
+    
+Then run it in the directory where I<bookstore.db> sits:
+
+    perl populate_database.db
+    
+=head4 Using Dancer::Plugin::DBIC
+
+There are 2 ways of configuring DBIC to understand how the data is organized
+in your database:
+
+=over 4
+
+=item Use auto-detection
+
+The configuration file needs to be updated to indicate the use of the 
+Dancer::Plugin::DBIC plugin, define a new DBIC schema called I<bookstore> and
+to indicate that this schema is connected to the SQLite database we created.
+
+    # add in bookstore/config.yml
+    plugins:
+      DBIC:
+        bookstore:
+          dsn:  "dbi:SQLite:dbname=bookstore.db"
+          
+Now, C<_perform_search> can be implemented using L<Dancer::Plugin::DBIC>. The 
+plugin gives you access to an additional keyword called B<schema>, which you 
+give the name of schema you want to retrieve. It returns a C<DBIx::Class::Schema::Loader> 
+which can be used to get a resultset and perform searches, as per standard 
+usage of DBIX::Class.
+
+    # add in bookstore/lib/bookstore.pm
+    sub _perform_search {
+        my ($query) = @_;
+        my $bookstore_schema = schema 'bookstore';
+        my @results;
+        # search in authors
+        my @authors = $bookstore_schema->resultset('Author')->search({
+          -or => [
+            firstname => { like => "%$query%" },
+            lastname  => { like => "%$query%" },
+          ]
+        });
+        push @results, map {
+            { author => join(' ', $_->firstname, $_->lastname),
+              books => [],
+            }
+        } @authors;
+        my %book_results;
+        # search in books
+        my @books = $bookstore_schema->resultset('Book')->search({
+            title => { like => "%$query%" },
+        });
+        foreach my $book (@books) {
+            my $author_name = join(' ', $book->author->firstname, $book->author->lastname);
+            push @{$book_results{$author_name}}, $book->title;
+        }
+        push @results, map {
+            { author => $_,
+              books => $book_results{$_},
+            }
+        } keys %book_results;
+        return @results;
+    }
+
+=item Use home made schema classes
+
+The L<DBIx::Class::MooseColumns> lets you write the DBIC schema classes 
+using L<Moose>. The schema classes should be put in a place that Dancer 
+will find. A good place is in I<bookstore/lib/>.
+
+Once your schema classes are in place, all you need to do is modify I<config.yml> 
+to specify that you want to use them, instead of the default auto-detection method:
+
+    # change in bookstore/config.yml
+    plugins:
+      DBIC:
+        bookstore:
+          schema_class: My::Bookstore::Schema
+          dsn: "dbi:SQLite:dbname=bookstore.db"
+          
+B<Starting the application>:
+Our bookstore lookup application can now be started using the built-in server:
+
+    # start the web application
+    bookstore/bin/app.pl
+
 =head2 Authentication
 
 Writing a form for authentication is simple: we check the user credentials 

--- a/lib/Dancer2/Cookbook.pod
+++ b/lib/Dancer2/Cookbook.pod
@@ -93,112 +93,11 @@ will live), an environments directory (where environment-specific settings
 live), a module containing the actual guts of your application, a script to
 start it - or to run your web app via Plack/PSGI - more on that later.
 
+=head2 Default Route
 
-
-=head1 DANCE ROUTINES: ROUTES
-
-=head2 Declaring routes
-
-To control what happens when a web request is received by your webapp, you'll
-need to declare C<routes>.  A route declaration indicates which HTTP method(s)
-it is valid for, the path it matches (e.g. /foo/bar), and a coderef to execute,
-which returns the response.
-
-    get '/hello/:name' => sub {
-        return "Hi there " . params->{name};
-    };
-
-The above route specifies that, for GET requests to '/hello/...', the code block
-provided should be executed.
-
-=head2 Handling multiple HTTP request methods
-
-Routes can use C<any> to match all, or a specified list of HTTP methods.
-
-The following will match any HTTP request to the path /myaction:
-
-    any '/myaction' => sub {
-        # code
-    }
-
-The following will match GET or POST requests to /myaction:
-
-    any ['get', 'post'] => '/myaction' => sub {
-        # code
-    };
-
-For convenience, any route which matches GET requests will also match HEAD
-requests.
-
-
-
-=head2 Retrieving request parameters
-
-The L<params|Dancer2/params> keyword returns a hashref of request parameters;
-these will be parameters supplied on the query string, within the path itself
-(with named placeholders), and, for HTTTP POST requests, the content of the
-POST body.
-
-
-
-=head2 Named parameters in route path declarations
-
-As seen above, you can use C<:somename> in a route's path to capture part of the
-path; this will become available by calling L<params|Dancer2/params>.
-
-So, for a web app where you want to display information on a company, you might
-use something like:
-
-    get '/company/view/:companyid' => sub {
-        my $company_id = params->{companyid};
-        # Look up the company and return appropriate page
-    };
-
-
-
-=head2 Wildcard path matching and splat
-
-You can also declare wildcards in a path, and retrieve the values they matched
-with the L<splat|Dancer2/splat> keyword:
-
-    get '/*/*' => sub {
-        my ($action, $id) = splat;
-        if (my $action eq 'view') {
-            return display_item($id);
-        } elsif ($action eq 'delete') {
-            return delete_item($id);
-        } else {
-            status 'not_found';
-            return "What?";
-        }
-    };
-
-
-
-=head2 Before filters - processed before a request
-
-A L<before|Dancer2/before> filter declares code which should be handled before
-a request is passed to the appropriate route.
-
-    hook before => sub {
-        forward '/foo/oversee', { note => 'Hi there' };
-    };
-
-    get '/foo/*' => sub {
-        my ($match) = splat; # 'oversee';
-        params->{note};      # 'Hi there'
-    };
-
-The above declares a before filter which uses C<forward> to do an internal
-redirect to C</foo/oversee> with an additional parameter C<note>.
-
-See also the L<hook|Dancer2/hook> hook keyword.
-
-=head2 Default route
-
-In case you want to avoid a I<404 error>, or handle multiple routes in the same
-way and you don't feel like configuring all of them, you can set up a default
-route handler.
+In case you want to avoid a I<404 error>, or handle multiple routes in the
+same way and you don't feel like configuring all of them, you can set up a
+default route handler.
 
 The default route handler will handle any request that doesn't get served by
 any other route.
@@ -210,35 +109,31 @@ All you need to do is set up the following route as the B<last> route:
         template 'special_404', { path => request->path };
     };
 
-Then you can set up the template as such:
+Then you can set up the template like so:
 
     You tried to reach [% path %], but it is unavailable at the moment.
 
-    Please try again or contact us at our email at <...>.
+    Please try again or contact us at <contact@example.com>.
 
+=head2 Using the C<auto_page> feature for automatic route creation
 
-=head2 Using the auto_page feature for automatic route creation
+For simple "static" pages you can simply enable the C<auto_page> config
+setting; this means you don't need to declare a route handler for those
+pages; if a request is for C</foo/bar>, Dancer2 will check for a matching
+view (e.g. C</foo/bar.tt> and render it with the default layout etc. if
+found. For full details, see the documentation for the L<auto_page
+setting|Dancer2::Config/"auto_page">.
 
-For simple "static" pages, you can simply enable the C<auto_page> config
-setting; this means that you need not declare a route handler for those pages;
-if a request is for C</foo/bar>, Dancer2 will check for a matching view (e.g.
-C</foo/bar.tt> and render it with the default layout etc if found.  For full
-details, see the documentation for the
-L<auto_page setting|Dancer2::Config/"auto_page">.
+=head2 Simplifying AJAX queries with the Ajax plugin
 
+As an AJAX query is just an HTTP query, it's similar to a GET or POST route.
+You may ask yourself why you may want to use the C<ajax> keyword (from the
+L<Dancer2::Plugin::Ajax> plugin) instead of a simple C<get>.
 
-
-=head2 Why should I use the Ajax plugin
-
-As an Ajax query is just a HTTP query, it's similar to a GET or POST
-route. You may ask yourself why you may want to use the C<ajax>
-keyword (from the L<Dancer2::Plugin::Ajax> plugin) instead of a simple
-C<get>.
-
-Let's say you have a path like '/user/:user' in your application. You
-may want to be able to serve this page, with a layout and HTML
-content. But you may also want to be able to call this same url from a
-javascript query using Ajax.
+Let's say you have a path like C</user/:user> in your application. You may
+want to be able to serve this page with a layout and HTML content. But you
+may also want to be able to call this same url from a javascript query using
+AJAX.
 
 So, instead of having the following code:
 
@@ -249,33 +144,87 @@ So, instead of having the following code:
               header('Cache-Control' =>  'no-store, no-cache, must-revalidate');
               to_xml({...})
          }else{
-             template users, {....}
+             template users => {...}
          }
     };
 
 you can have
 
-    get '/user/:user' => sub {
-        template users, {...}
-    }
-
-and
-
     ajax '/user/:user' => sub {
          to_xml({...}, RootName => undef);
     }
 
+and
 
-Because it's an ajax query, you know you need to return a xml content,
-so the content type of the response is set for you.
+    get '/user/:user' => sub {
+        template users => {...}
+    }
 
+Because it's an AJAX query, you know you need to return XML content, so
+the content type of the response is set for you.
 
+=head3 Example: Feeding graph data through AJAX
+
+Let us assume we are building an application that uses a plotting library 
+to generate a graph and expects to get its data, which is in the form
+of wordcount from an AJAX call.
+
+For the graph, we need the url I</data> to return a JSON representation 
+of the wordcount data. Dancer infact has a C<to_json()> function that takes 
+care of the JSON encapsulation.
+
+     get '/data' => sub {
+         open my $fh, '<', $count_file;
+
+         my %contestant;
+         while (<$fh>) {
+             chomp;
+             my ( $date, $who, $count ) = split '\s*,\s*';
+
+             my $epoch = DateTime::Format::Flexible->parse_datetime($date)->epoch;
+             my $time = 1000 * $epoch;
+             $contestant{$who}{$time} = $count;
+         }
+
+         my @json;  # data structure that is going to be JSONified
+
+         while ( my ( $peep, $data ) = each %contestant ) {
+             push @json, { 
+                 label     => $peep,
+                 hoverable => \1,    # so that it becomes JavaScript's 'true'
+                 data => [ map  { [ $_, $data->{$_} ] } 
+                         sort { $a <=> $b } 
+                         keys %$data ],
+             };
+         }
+
+         my $beginning = DateTime::Format::Flexible->parse_datetime( "2010-11-01")->epoch;
+         my $end       = DateTime::Format::Flexible->parse_datetime( "2010-12-01")->epoch;
+
+         push @json, {
+             label => 'de par',
+             data => [
+                 [$beginning * 1000, 0],
+                 [   DateTime->now->epoch * 1_000,
+                     50_000 
+                       * (DateTime->now->epoch - $beginning)
+                       / ($end - $beginning)
+                 ]
+               ],
+
+         };
+
+         to_json( \@json );
+     };
+
+For more serious AJAX interaction, there's also L<Dancer2::Plugin::Ajax> 
+that adds an I<ajax> route handler to the mix.
 
 =head2 Using the prefix feature to split your application
 
 For better maintainability, you may want to separate some of your application
-components to different packages. Let's say we have a simple web app with an
-admin section, and want to maintain this in a different package:
+components into different packages. Let's say we have a simple web app with an
+admin section and want to maintain this in a different package:
 
     package myapp;
     use Dancer2;
@@ -305,315 +254,202 @@ The following routes will be generated for us:
 
 By default, a separate application is created for every package that uses
 Dancer2. The C<appname> tag is used to collect routes and hooks into a
-single Dancer2 application. In the above example, C<appname =E<gt> 'myapp'> adds
-the routes from C<myapp::admin> to the routes of the app C<myapp>.
+single Dancer2 application. In the above example, C<appname =E<gt> 'myapp'>
+adds the routes from C<myapp::admin> to the routes of the app C<myapp>.
 
-When using multiple applications please ensure that your path definitions
-do not overlap. Eg, if using a default route as described above, once a
-request is matched to the default route then no further routes
-(or applications) would be reached.
+When using multiple applications please ensure that your path definitions do
+not overlap. For example, if using a default route as described above, once
+a request is matched to the default route then no further routes (or
+applications) would be reached.
 
-=head1 MUSCLE MEMORY: STORING DATA
+=head2 Delivering custom error pages
 
-=head2 Handling sessions
+=head3 At the Core
 
-It's common to want to use sessions to give your web applications state; for
-instance, allowing a user to log in, creating a session, and checking that
-session on subsequent requests.
+In Dancer2, creating new errors is done by creating a new L<Dancer2::Core::Error>
 
-To make use of sessions, you must first enable the session engine - pick the
-session engine you want to use, then declare it in your config file like this:
+     my $oopsie = Dancer2::Core::Error->new(
+         status  => 418,
+         message => "This is the Holidays. Tea not acceptable. We want eggnog.",
+         context => $context,
+     )
 
-    session: Simple
+If not given, the status code defaults to a 500, there is no need for a message if 
+we feel taciturn, and while the C<$context> (which is a I<Dancer::Core::Context> 
+object holding all the pieces of information related to the current request) is 
+needed if we want to take advantage of the templates, we can also do without.
 
-The L<Dancer2::Session::Simple> backend implements very simple in-memory session
-storage.  This will be fast and useful for testing, but sessions do not persist
-between restarts of your app.
+However, to be seen by the end user, we have to populate the L<Dancer2::Core::Response>
+object with the error's data. This is done via:
 
-You can also use the L<Dancer2::Session::YAML> backend included with Dancer2,
-which stores session data on disc in YAML files (since YAML is a nice
-human-readable format, it makes inspecting the contents of sessions a breeze):
+     $oopsie->throw($response);
 
-    session: YAML
+Or, if we want to use the response object already present in the C<$context> 
+(which is usually the case):
 
-Or, to enable session support from within your code,
+     $oopsie->throw;
 
-    set session => 'YAML';
+This populates the status code of the response, sets its content, and throws a 
+I<halt()> in the dispatch process.
 
-(Controlling settings is best done from your config file, though).  'YAML' in
-the example is the session backend to use; this is shorthand for
-L<Dancer2::Session::YAML>.  There are other session backends you may wish to use,
-for instance L<Dancer2::Session::Memcached>, but the YAML backend is a simple and
-easy to use example which stores session data in a YAML file in sessions).
+=head3 What it will look like
 
-You can then use the L<session|Dancer2/session> keyword to manipulate the
-session:
+The error object has quite a few ways to generate its content.
 
-=head3 Storing data in the session
+First, it can be explicitly given
 
-Storing data in the session is as easy as:
+     my $oopsie = Dancer::Core::Error->new(
+         content => '<html><body><h1>OMG</h1></body></html>',
+     );
 
-    session varname => 'value';
+If the C<$context> was given, the error will check if there is a 
+template by the name of the status code (so, say you're using Template 
+Toolkit, I<418.tt>) and will use it to generate the content, passing it 
+the error's C<$message>, C<$status> code and C<$title> (which, if not 
+specified, will be the standard http error definition for the status code).
 
+If there is no template, the error will then look for a static page (to 
+continue with our example, I<418.html>) in the I<public/> directory.
 
+And finally, if all of that failed, the error object will fall back on 
+an internal template.
 
-=head3 Retrieving data from the session
+=head3 Errors in Routes
 
-Retrieving data from the session is as easy as:
+The simplest way to use errors in routes is:
 
-    session('varname')
+     get '/xmas/gift/:gift' => sub {
+         die "sorry, we're all out of ponies\n" 
+             if param('gift') eq 'pony';
+     };
 
-Or, alternatively,
+The die will be intercepted by Dancer, converted into an error (status 
+code 500, message set to the dying words) and passed to the response.
 
-    session->read("varname")
+In the cases where more control is required, C<send_error()> is the way to go:
 
+     get '/glass/eggnog' => sub {
+         send_error "Sorry, no eggnog here", 418;
+     };
 
+And if total control is needed:
 
-=head3 Controlling where sessions are stored
+     get '/xmas/wishlist' => sub {
+         Dancer::Core::Error->new(
+             response => response(),
+             status   => 406,
+             message  => "nothing but coal for you, I'm afraid",
+             template => 'naughty/index',
+         )->throw unless user_was_nice();
 
-For disc-based session back ends like L<Dancer2::Session::YAML>,
-L<Dancer2::Session::Storable> etc, session files are written to the session dir
-specified by the C<session_dir> setting, which defaults to C<./sessions> if
-not specifically set.
+         ...;
+     };
 
-If you need to control where session files are created, you can do so quickly
-and easily within your config file, for example:
+=head2 Authentication
 
-    session: YAML
-    engines:
-      session:
-        YAML:
-          session_dir: /tmp/dancer-sessions
+Writing a form for authentication is simple: we check the user credentials 
+on a request and decide whether to continue or redirect them to a form. 
+The form allows them to submit their username and password and we save that 
+and create a session for them so when they now try the original request, 
+we recognize them and allow them in.
 
-If the directory you specify does not exist, Dancer2 will attempt to create it
-for you.
+=head3 Basic Application
 
-=head3 Destroying a session
+The application is fairly simple. We have a route that needs authentication, 
+we have a route for showing the login page, and we have a route for posting 
+login information and creating a session.
 
-When you're done with your session, you can destroy it:
+     package MyApp;
+     use Dancer2;
 
-    app->destroy_session
+     get '/' => sub {
+         session('user')
+             or redirect('/login');
 
-=head2 Sessions and logging in
+         template index => {};
+     };
 
-A common requirement is to check the user is logged in, and, if not, require
-them to log in before continuing.
+     get '/login' => sub {
+         template login => {};
+     };
 
-This can easily be handled with a before filter to check their session:
+     post '/login' => sub {
+         my $username  = param('username');
+         my $password  = param('password');
+         my $redir_url = param('redirect_url') || '/login';
 
-    use Dancer2;
-    set session => "Simple";
+         $username eq 'john' && $password eq 'correcthorsebatterystaple'
+             or redirect $redir_url;
 
-    hook before => sub {
-        if (!session('user') && request->dispatch_path !~ m{^/login}) {
-            forward '/login', { requested_path => request->dispatch_path };
-        }
-    };
-
-    get '/' => sub { return "Home Page"; };
-
-    get '/secret' => sub { return "Top Secret Stuff here"; };
-
-    get '/login' => sub {
-        # Display a login page; the original URL they requested is available as
-        # param('requested_path'), so could be put in a hidden field in the form
-        template 'login', { path => param('requested_path') };
-    };
-
-    post '/login' => sub {
-        # Validate the username and password they supplied
-        if (param('user') eq 'bob' && param('pass') eq 'letmein') {
-            session user => param('user');
-            redirect param('path') || '/';
-        } else {
-            redirect '/login?failed=1';
-        }
-    };
-
-    dance();
-
-Here is what the corresponding C<login.tt> file should look like. You should place
-it in a directory called views:
-
-    <html>
-      <head>
-        <title>Session and logging in</title>
-      </head>
-      <body>
-        <form action='/login' method='POST'>
-            User Name : <input type='text' name='user'/>
-            Password: <input type='password' name='pass' />
-
-            <!-- Put the original path requested into a hidden
-                       field so it's sent back in the POST and can be
-                       used to redirect to the right page after login -->
-            <input type='hidden' name='path' value='[% path %]'/>
-
-            <input type='submit' value='Login' />
-        </form>
-      </body>
-    </html>
-
-Of course, you'll probably want to validate your users against a database table,
-or maybe via IMAP/LDAP/SSH/POP3/local system accounts via PAM etc.
-L<Authen::Simple> is probably a good starting point here!
-
-A simple working example of handling authentication against a database table
-yourself (using L<Dancer2::Plugin::Database> which provides the C<database>
-keyword, and L<Crypt::SaltedHash> to handle salted hashed passwords (well, you
-wouldn't store your users passwords in the clear, would you?)) follows:
-
-    post '/login' => sub {
-        my $user = database->quick_select('users',
-            { username => params->{user} }
-        );
-        if (!$user) {
-            warning "Failed login for unrecognised user " . params->{user};
-            redirect '/login?failed=1';
-        } else {
-            if (Crypt::SaltedHash->validate($user->{password}, params->{pass}))
-            {
-                debug "Password correct";
-                # Logged in successfully
-                session user => $user;
-                redirect params->{path} || '/';
-            } else {
-                debug("Login failed - password incorrect for " . params->{user});
-                redirect '/login?failed=1';
-            }
-        }
-    };
+         session user => $username;
+         redirect $redir_url;
+     };
 
+=head3 Tiny Authentication Helper
 
+L<Dancer2::Plugin::Auth::Tiny> allows you to abstract away not only the 
+part that checks whether the session exists, but to also generate a 
+redirect with the right path and return URL.
 
-=head3 Retrieve complete hash stored in session
-
-Get complete hash stored in session:
+We simply have to define what routes needs a login using Auth::Tiny's 
+C<needs> keyword.
 
-    my $hash = session;
+     get '/' => needs login => sub {
+         template index => {};
+     };
 
+It creates a proper return URL using C<uri_for> and the address from which 
+the user arrived.
 
+We can thus decorate all of our private routes to require authentication in 
+this manner. If a user does not have a session, it will automatically forward 
+it to I</login>, in which we would render a form for the user to send a login request.
 
-=head1 APPEARANCE: TEMPLATES AND LAYOUTS
+Auth::Tiny even provides a new parameter, C<return_url>, which can be used to send 
+the user back to their original requested path.
 
-Returning plain content is all well and good for examples or trivial apps, but
-soon you'll want to use templates to maintain separation between your code and
-your content.  Dancer2 makes this easy.
+=head3 Password Hashing
 
-Your route handlers can use the L<template|Dancer2::Manual/template> keyword to render
-templates.
+L<Dancer2::Plugin::Passphrase> provides a simple passwords-as-objects interface with 
+sane defaults for hashed passwords which you can use in your web application. It uses 
+B<bcrypt> as the default but supports anything the L<Digest> interface does.
 
-=head2 Views
+Assuming we have the original user-creation form submitting a username and password:
 
-It's possible to render the action's content with a template, this is called a
-view. The `appdir/views' directory is the place where views are located.
+     package MyApp;
+     use Dancer2;
+     use Dancer2::Plugin::Passphrase;
+     post '/register' => sub {
+         my $username = param('username');
+         my $password = passphrase( param('password') )->generate;
 
-You can change this location by changing the setting 'views'.
+         # $password is now a hashed password object
+         save_user_in_db( $username, $password->rfc2307 );
 
-By default, the internal template engine L<Dancer2::Template::Simple> is used,
-but you may want to upgrade to L<Template Toolkit|http://www.template-toolkit.org/>. If you do so, you have to
-enable this engine in your settings as explained in
-L<Dancer2::Template::TemplateToolkit>  and you'll also have to
-import the L<Template> module in your application code.
+         template registered => { success => 1 };
+     };
 
-All views must have a '.tt' extension. This may change in the future.
+We can now add the B<POST> method for verifying that username and password:
 
-In order to render a view, just call the L<template|Dancer2::Manual/template> keyword at
-the end of the action by giving the view name and the HASHREF of tokens to
-interpolate in the view (note that for convenience, the request, session, params
-and vars are automatically accessible in the view, named C<request>, C<session>,
-C<params> and C<vars>) - for example:
+     post '/login' => sub {
+         my $username   = param('username');
+         my $password   = param('password');
+         my $saved_pass = fetch_password_from_db($username);
 
-    hook before => sub { var time => scalar(localtime) };
+         if ( passphrase($password)->matches($saved_pass) ) {
+             session user => $username;
+             redirect param('return_url') || '/';
+         }
 
-    get '/hello/:name' => sub {
-        my $name = params->{name};
-        template 'hello.tt', { name => $name };
-    };
+         # let's render instead of redirect...
+         template login => { error => 'Invalid username or password' };
+     };
 
-The template C<hello.tt> could contain, for example:
+=head2 Template Toolkit's WRAPPER directive in Dancer2
 
-    <p>Hi there, [% name %]!</p>
-    <p>You're using [% request.user_agent %]</p>
-    [% IF session.username %]
-        <p>You're logged in as [% session.username %]</p>
-    [% END %]
-    It's currently [% vars.time %]
-
-For a full list of the tokens automatically added to your template
-(like C<session>, C<request> and C<vars>, refer to
-L<Dancer2::Core::Role::Template>).
-
-=head2 Layouts
-
-A layout is a special view, located in the 'layouts' directory (inside the views
-directory) which must have a token named C<content>. That token marks the place
-where to render the action view. This lets you define a global layout for your
-actions, and have each individual view contain only the specific content.  This
-is a good thing to avoid lots of needless duplication of HTML :)
-
-Here is an example of a layout: C<views/layouts/main.tt> :
-
-    <html>
-        <head>...</head>
-        <body>
-        <div id="header">
-        ...
-        </div>
-
-        <div id="content">
-        [% content %]
-        </div>
-
-        </body>
-    </html>
-
-You can tell your app which layout to use with C<layout: name> in the config
-file, or within your code:
-
-    set layout => 'main';
-
-You can control which layout to use (or whether to use a layout at all) for a
-specific request without altering the layout setting by passing an options
-hashref as the third param to the template keyword:
-
-    template 'index.tt', {}, { layout => undef };
-
-If your application is not mounted under root (B</>), you can use a
-before_template instead of hardcoding the path to your application for your
-css, images and javascript:
-
-    hook before_template_render => sub {
-        my $tokens = shift;
-        $tokens->{uri_base} = request->base->path;
-    };
-
-Then in your layout, modify your css inclusion as follows:
-
-    <link rel="stylesheet" href="[% uri_base %]/css/style.css" />
-
-From now on, you can mount your application wherever you want, without
-any further modification of the css inclusion
-
-=head2 Templates and unicode
-
-If you use L<Plack> and have some unicode problem with your Dancer2 application,
-don't forget to check if you have set your template engine to use unicode, and
-set the default charset to UTF-8. So, if you are using template toolkit, your
-config file will look like this:
-
-    charset: UTF-8
-    engines:
-      template:
-        template_toolkit:
-          ENCODING: utf8
-
-
-=head2 TT's WRAPPER directive in Dancer2
-
-Dancer2 already provides a WRAPPER-like ability, which we call a "layout". The
-reason we do not use TT's WRAPPER (which also makes us incompatible with it) is
-because not all template systems support it. Actually, most don't.
+Dancer2 already provides a WRAPPER-like ability, which we call a "layout".
+The reason we don't use Template Toolkit's WRAPPER (which also makes us incompatible with
+it) is because not all template systems support it. Actually, most don't.
 
 However, you might want to use it, and be able to define META variables and
 regular L<Template::Toolkit> variables.
@@ -624,17 +460,17 @@ These few steps will get you there:
 
 =item * Disable the layout in Dancer2
 
-You can do this by simply commenting (or removing) the C<layout> configuration
-in the config file.
+You can do this by simply commenting (or removing) the C<layout>
+configuration in the config file.
 
-=item * Use Template Toolkit template engine
+=item * Use the Template Toolkit template engine
 
 Change the configuration of the template to Template Toolkit:
 
     # in config.yml
     template: "template_toolkit"
 
-=item * Tell the Template Toolkit engine who's your wrapper
+=item * Tell the Template Toolkit engine which wrapper to use
 
     # in config.yml
     # ...
@@ -648,596 +484,18 @@ Change the configuration of the template to Template Toolkit:
 Done! Everything will work fine out of the box, including variables and META
 variables.
 
-
-
-=head1 SETTING THE STAGE: CONFIGURATION AND LOGGING
-
-=head2 Configuration and environments
-
-Configuring a Dancer2 application can be done in many ways. The easiest one (and
-maybe the dirtiest) is to put all your settings statements at the top of
-your script, before calling the dance() method.
-
-Other ways are possible, you can define all your settings in the file
-C<appdir/config.yml>. For this, you must have installed the YAML module, and of
-course, write the config file in YAML.
-
-That's better than the first option, but it's still not perfect as you can't
-switch easily from an environment to another without rewriting the config
-file.
-
-An even solution is to have one config.yml file with default global settings,
-like the following:
-
-    # appdir/config.yml
-    logger: 'file'
-    layout: 'main'
-
-And then write as many environment files as you like in C<appdir/environments>.
-That way, the appropriate environment config file will be loaded according to
-the running environment (if none is specified, it will be 'development').
-
-Note that you can change the running environment using the C<--environment>
-command line switch.
-
-Typically, you'll want to set the following values in a development config file:
-
-    # appdir/environments/development.yml
-    log: 'debug'
-    startup_info: 1
-    show_errors:  1
-
-And in a production one:
-
-    # appdir/environments/production.yml
-    log: 'warning'
-    startup_info: 0
-    show_errors:  0
-
-
-
-=head2 Accessing configuration information
-
-=head3 From inside your application
-
-A Dancer2 application can use the 'config' keyword to easily access the settings
-within its config file, for instance:
-
-    get '/appname' => sub {
-        return "This is " . config->{appname};
-    };
-
-This makes keeping your application's settings all in one place simple and easy
-- you shouldn't need to worry about implementing all that yourself :)
-
-
-=head3 From a separate script
-
-You may well want to access your webapp's configuration from outside your
-webapp. You could, of course, use the YAML module of your choice and load your
-webapps's config.yml, but chances are that this is not convenient.
-
-Use Dancer2 instead. Without any ado, magic or too big jumps, you can use the
-values from config.yml and some additional default values:
-
-    # bin/script1.pl
-    use Dancer2;
-    print "template:".config->{template}."\n"; #simple
-    print "log:".config->{log}."\n"; #undef
-
-Note that C<< config->{log} >> should result undef error on a default scaffold since
-you did not load the environment and in the default scaffold log is defined in
-the environment and not in config.yml. Hence undef.
-
-If you want to load an environment you need to tell Dancer2 where to look for it.
-One way to do so, is to tell Dancer2 where the webapp lives. From there Dancer2
-deduces where the config.yml file is (typically C<$webapp/config.yml>).
-
-    # bin/script2.pl
-    use FindBin;
-    use Cwd qw/realpath/;
-    use Dancer2;
-
-    #tell the Dancer2 where the app lives
-    my $appdir=realpath( "$FindBin::Bin/..");
-
-    Dancer2::Config::setting('appdir',$appdir);
-    Dancer2::Config::load();
-
-    #getter
-    print "environment:".config->{environment}."\n"; #development
-    print "log:".config->{log}."\n"; #value from development environment
-
-By default Dancer2 loads development environment (typically
-C<$webapp/environment/development.yml>). In contrast to the example before,  you
-do have a value from the development environment (C<environment/development.yml>)
-now. Also note that in the above example L<Cwd> and L<FindBin> are used. They are
-likely to be already loaded by Dancer2 anyways, so it's not a big overhead. You
-could just as well hand over a simple path for the app if you like that better,
-e.g.:
-
-    Dancer2::Config::setting('appdir','/path/to/app/dir');
-
-If you want to load an environment other than the default, try this:
-
-    # bin/script2.pl
-    use Dancer2;
-
-    #tell the Dancer2 where the app lives
-    Dancer2::Config::setting('appdir','/path/to/app/dir');
-
-    #which environment to load
-    config->{environment}='production';
-
-    Dancer2::Config::load();
-
-    #getter
-    print "log:".config->{log}."\n"; #has value from production environment
-
-By the way, you not only get values, you can also set values straightforward
-like we do above with C<< config->{environment}='production' >>. Of course, this value
-does not get written in any file; it only lives in memory and your webapp
-doesn't have access to it, but you can use it inside your script.
-
-
-
-=head2 Logging
-
-=head3 Configuring logging
-
-It's possible to log messages generated by the application and by Dancer2 itself.
-
-To start logging, select the logging engine you wish to use with the C<logger>
-setting; Dancer2 includes built-in log engines named C<file> and C<console>,
-which log to a logfile and to the console respectively.
-
-To enable logging to a file, add the following to your config file:
-
-    logger: 'file'
-
-Then you can choose which kind of messages you want to actually log:
-
-    log: 'core'      # will log debug, warnings, errors,
-                     # and messages from Dancer2 itself
-    log: 'debug'     # will log debug, info, warning and errors
-    log: 'info'      # will log info, warning and errors
-    log: 'warning'   # will log warning and errors
-    log: 'error'     # will log only errors
-
-If you're using the C<file> logging engine, a directory C<appdir/logs> will be
-created and will host one logfile per environment. The log message contains the
-time it was written, the PID of the current process, the message and the caller
-information (file and line).
-
-=head3 Logging your own messages
-
-Just call  L<debug|Dancer2/debug>, L<info|Dancer2/info>,
-L<warning|Dancer2/warning> or L<error|Dancer2/error> with your message:
-
-    debug "This is a debug message from my app.";
-
-
-
-=head1 RESTING
-
-=head2 Writing a REST application
-
-With Dancer2, it's easy to write REST applications. Dancer2 provides helpers to
-serialize and deserialize for the following data formats:
-
-=over 4
-
-=item JSON
-
-=item YAML
-
-=item XML
-
-=item Data::Dumper
-
-=back
-
-To activate this feature, you only have to set the C<serializer> setting to the
-format you require, for instance in your config file:
-
-   serializer: JSON
-
-Or right in your code:
-
-   set serializer => 'JSON';
-
-From now, all hash ref or array ref returned by a route will be serialized to
-the format you chose, and all data received from B<POST> or B<PUT> requests
-will be automatically deserialized.
-
-    get '/hello/:name' => sub {
-        # this structure will be returned to the client as
-        # {"name":"$name"}
-        return {name => params->{name}};
-    };
-
-It's possible to let the client choose which serializer he want to use. For
-this, use the B<mutable> serializer, and an appropriate serializer will be
-chosen from the B<Content-Type> header.
-
-It's also possible to return a custom error, using the
-L<send_error|Dancer2/send_error> keyword..
-When you don't use a serializer, the C<send_error> function will take a string
-as first parameter (the message), and an optional HTTP code. When using a
-serializer, the message can be a string, an arrayref or a hashref:
-
-    get '/hello/:name' => sub {
-        if (...) {
-           send_error("you can't do that");
-           # or
-           send_error({reason => 'access denied', message => "no"});
-        }
-    };
-
-The content of the error will be serialized using the appropriate serializer.
-
-
-=head1 DANCER ON THE STAGE: DEPLOYMENT
-
-=head2 Running stand-alone
-
-At the simplest, your Dancer2 app can run standalone, operating as its own
-webserver using L<HTTP::Server::PSGI>.
-
-Simply fire up your app:
-
-    $ perl bin/app.pl
-    >> Listening on 0.0.0.0:3000
-    == Entering the dance floor ...
-
-Point your browser at it, and away you go!
-
-This option can be useful for small personal web apps or internal apps, but if
-you want to make your app available to the world, it probably won't suit you.
-
-=head2 Auto Reloading with Plack and Shotgun
-
-To edit your files without the need to restart the webserver on each file change,
-simply start your Dancer2 app using L<plackup> and L<Plack::Loader::Shotgun>:
-
-    $ plackup -L Shotgun bin/app.pl
-    HTTP::Server::PSGI: Accepting connections at http://0:5000/
-
-Point your browser at it. Files can now be changed in your favorite editor and
-the browser needs to be refreshed to see the saved changes.
-
-Please note that this is not recommended for production for performance reasons.
-This is the Dancer2 replacement solution of the old Dancer experimental
-C<auto_reload> option.
-
-On Windows, Shotgun loader is known to cause huge memory leaks in a
-fork-emulation layer. If you are aware of this and still want to run the loader,
-please use the following command:
-
-    > set PLACK_SHOTGUN_MEMORY_LEAK=1 && plackup -L Shotgun bin\app.pl
-    HTTP::Server::PSGI: Accepting connections at http://0:5000/
-
-=head2 CGI and Fast-CGI
-
-In providing ultimate flexibility in terms of deployment, your Dancer2 app can
-be run as a simple cgi-script out-of-the-box. No additional web-server
-configuration needed.  Your web server should recognize .cgi files and be able
-to serve Perl scripts.  The Perl module L<Plack::Runner> is required.
-
-=head3 Running on Apache (CGI and FCGI)
-
-Start by adding the following to your apache configuration (C<httpd.conf> or
-C<sites-available/*site*>):
-
-    <VirtualHost *:80>
-        ServerName www.example.com
-        DocumentRoot /srv/www.example.com/public
-        ServerAdmin you@example.com
-
-        <Directory "/srv/www.example.com/public">
-           AllowOverride None
-           Options +ExecCGI -MultiViews +SymLinksIfOwnerMatch
-           Order allow,deny
-           Allow from all
-           AddHandler cgi-script .cgi
-        </Directory>
-
-        RewriteEngine On
-        RewriteCond %{REQUEST_FILENAME} !-f
-        RewriteRule ^(.*)$ /dispatch.cgi$1 [QSA,L]
-
-        ErrorLog  /var/log/apache2/www.example.com-error.log
-        CustomLog /var/log/apache2/www.example.com-access_log common
-    </VirtualHost>
-
-Note that when using fast-cgi your rewrite rule should be:
-
-        RewriteRule ^(.*)$ /dispatch.fcgi$1 [QSA,L]
-
-Here, the mod_rewrite magic for Pretty-URLs is directly put in Apache's configuration.
-But if your web server supports .htaccess files, you can drop those lines in a .htaccess file.
-
-To check if your server supports mod_rewrite type C<apache2 -l> to list modules.
-To enable mod_rewrite (Debian), run C<a2enmod rewrite>. Place following code in
-a file called .htaccess in your application's root folder:
-
-    # BEGIN dancer application htaccess
-    RewriteEngine On
-    RewriteCond %{SCRIPT_FILENAME} !-d
-    RewriteCond %{SCRIPT_FILENAME} !-f
-    RewriteRule (.*) /dispatch.cgi$1 [L]
-    # END dancer application htaccess
-
-Now you can access your dancer application URLs as if you were using the
-embedded web server.
-
-    http://localhost/
-
-This option is a no-brainer, easy to setup, low maintenance but serves requests
-slower than all other options.
-
-You can use the same technique to deploy with FastCGI, by just changing the line:
-
-    AddHandler cgi-script .cgi
-
-By:
-
-    AddHandler fastcgi-script .fcgi
-
-Of course remember to update your rewrite rules, if you have set any:
-
-    RewriteRule (.*) /dispatch.fcgi$1 [L]
-
-
-=head4 Running under an appdir
-
-If you want to deploy multiple applications under the same VirtualHost, using
-one application per directory for example, you can do the following.
-
-This example uses the FastCGI dispatcher that comes with Dancer2, but you should
-be able to adapt this to use any other way of deployment described in this
-guide. The only purpose of this example is to show how to deploy multiple
-applications under the same base directory/virtualhost.
-
-    <VirtualHost *:80>
-        ServerName localhost
-        DocumentRoot "/path/to/rootdir"
-        RewriteEngine On
-        RewriteCond %{REQUEST_FILENAME} !-f
-
-        <Directory "/path/to/rootdir">
-            AllowOverride None
-            Options +ExecCGI -MultiViews +SymLinksIfOwnerMatch
-            Order allow,deny
-            Allow from all
-            AddHandler fastcgi-script .fcgi
-        </Directory>
-
-        RewriteRule /App1(.*)$ /App1/public/dispatch.fcgi$1 [QSA,L]
-        RewriteRule /App2(.*)$ /App2/public/dispatch.fcgi$1 [QSA,L]
-        ...
-        RewriteRule /AppN(.*)$ /AppN/public/dispatch.fcgi$1 [QSA,L]
-    </VirtualHost>
-
-Of course, if your Apache configuration allows that, you can put the
-RewriteRules in a .htaccess file directly within the application's directory,
-which lets you add a new application without changing the Apache configuration.
-
-=head3 Running on lighttpd (CGI)
-
-To run as a CGI app on lighttpd, just create a soft link to the dispatch.cgi
-script (created when you run dancer -a MyApp) inside your system's cgi-bin
-folder. Make sure mod_cgi is enabled.
-
-    ln -s /path/to/MyApp/public/dispatch.cgi /usr/lib/cgi-bin/mycoolapp.cgi
-
-=head3 Running on lighttpd (FastCGI)
-
-Make sure mod_fcgi is enabled. You also must have L<FCGI> installed.
-
-This example configuration uses TCP/IP:
-
-    $HTTP["url"] == "^/app" {
-        fastcgi.server += (
-            "/app" => (
-                "" => (
-                    "host" => "127.0.0.1",
-                    "port" => "5000",
-                    "check-local" => "disable",
-                )
-            )
-        )
-    }
-
-Launch your application:
-
-    plackup -s FCGI --port 5000 bin/app.pl
-
-This example configuration uses a socket:
-
-    $HTTP["url"] =~ "^/app" {
-        fastcgi.server += (
-            "/app" => (
-                "" => (
-                    "socket" => "/tmp/fcgi.sock",
-                    "check-local" => "disable",
-                )
-            )
-        )
-    }
-
-Launch your application:
-
-    plackup -s FCGI --listen /tmp/fcgi.sock bin/app.pl
-
-
-=head2 Plack middlewares
-
-If you want to use Plack middlewares, you need to enable them using
-L<Plack::Builder> as such:
-
-    # in app.psgi or any other handler
-    use Dancer2;
-    use MyWebApp;
-    use Plack::Builder;
-
-    builder {
-        enable 'Deflater';
-        enable 'Session', store => 'File';
-        enable 'Debug', panels => [ qw<DBITrace Memory Timer> ];
-        dance;
-    };
-
-
-The nice thing about this setup is that it will work seamlessly through Plack
-or through the internal web server.
-
-    # load dev web server (without middlewares)
-    perl -Ilib app.psgi
-
-    # load plack web server (with middlewares)
-    plackup -I lib app.psgi
-
-You do not need to provide different files for either server.
-
-=head3 Path-based middlewares
-
-If you want to setup a middleware for a specific path, you can do that using
-L<Plack::Builder> which uses L<Plack::App::URLMap>:
-
-    # in your app.psgi or any other handler
-    use Dancer2;
-    use MyWebApp;
-    use Plack::Builder;
-
-    my $special_handler = sub { ... };
-
-    builder {
-        mount '/'        => dance;
-        mount '/special' => $special_handler;
-    };
-
-=head3 Running on Perl webservers with plackup
-
-A number of Perl web servers supporting PSGI are available on cpan:
-
-=over 4
-
-=item L<Starman>
-
-C<Starman> is a high performance web server, with support for preforking, signals, ...
-
-=item L<Twiggy>
-
-C<Twiggy> is an C<AnyEvent> web server, it's light and fast.
-
-=item L<Corona>
-
-C<Corona> is a C<Coro> based web server.
-
-=back
-
-To start your application, just run plackup (see L<Plack> and specific servers
-above for all available options):
-
-   $ plackup bin/app.pl
-   $ plackup -E deployment -s Starman --workers=10 -p 5001 -a bin/app.pl
-
-As you can see, the scaffolded Perl script for your app can be used as a PSGI
-startup file.
-
-=head4 Enabling content compression
-
-Content compression (gzip, deflate) can be easily enabled via a Plack
-middleware (see L<Plack/Plack::Middleware>): L<Plack::Middleware::Deflater>.
-It's a middleware to encode the response body in gzip or deflate, based on
-Accept-Encoding HTTP request header.
-
-Enable it as you would enable any Plack middleware. First you need to install
-L<Plack::Middleware::Deflater>, then in the handler (usually F<app.psgi>) edit
-it to use L<Plack::Builder>, as described above:
-
-    use Dancer2;
-    use MyWebApp;
-    use Plack::Builder;
-
-    builder {
-        enable 'Deflater';
-        dance;
-    };
-
-To test if content compression works, trace the HTTP request and response
-before and after enabling this middleware. Among other things, you should
-notice that the response is gzip or deflate encoded, and contains a header
-C<Content-Encoding> set to C<gzip> or C<deflate>
-
-=head3 Running multiple apps with Plack::Builder
-
-You can use L<Plack::Builder> to mount multiple Dancer2 applications on
-a L<PSGI> webserver like L<Starman>.
-
-Start by creating a simple app.psgi file:
-
-    use OurWiki;  # first app
-    use OurForum; # second app
-    use Plack::Builder;
-
-    builder {
-        mount '/wiki'  => OurWiki->psgi_app;
-        mount '/forum' => OurForum->psgi_app;
-    };
-
-and now use L<Starman>
-
-    plackup -a app.psgi -s Starman
-
-Currently this still demands the same appdir for both (default circumstance)
-but in a future version this will be easier to change while staying very
-simple to mount.
-
-=head3 Running from Apache with Plack
-
-You can run your app from Apache using PSGI (Plack), with a config like the
-following:
-
-    <VirtualHost myapp.example.com>
-        ServerName www.myapp.example.com
-        ServerAlias myapp.example.com
-        DocumentRoot /websites/myapp.example.com
-
-        <Directory /home/myapp/myapp>
-            AllowOverride None
-            Order allow,deny
-            Allow from all
-        </Directory>
-
-        <Location />
-            SetHandler perl-script
-            PerlResponseHandler Plack::Handler::Apache2
-            PerlSetVar psgi_app /websites/myapp.example.com/app.pl
-        </Location>
-
-        ErrorLog  /websites/myapp.example.com/logs/error_log
-        CustomLog /websites/myapp.example.com/logs/access_log common
-    </VirtualHost>
-
-To set the environment you want to use for your application (production or development), you can set it this way:
-
-    <VirtualHost>
-        ...
-        SetEnv DANCER_ENVIRONMENT "production"
-        ...
-    </VirtualHost>
-
 =head2 Creating a service
 
-You can turn your app into proper service running in background using one of the following examples:
+You can turn your app into a proper service running in the background using one of
+the following examples.
 
 =head3 Using Ubic
 
-L<Ubic> is an extensible perlish service manager. You can use it to start and stop any services, automatically start them on reboots or daemon failures, and implement custom status checks.
+L<Ubic> is an extensible perlish service manager. You can use it to start
+and stop any services, automatically start them on reboots or daemon
+failures, and implement custom status checks.
 
-A basic PSGI service description (usually in /etc/ubic/service/application):
+A basic PSGI service description (usually in C</etc/ubic/service/application>):
 
     use parent qw(Ubic::Service::Plack);
 
@@ -1250,19 +508,19 @@ A basic PSGI service description (usually in /etc/ubic/service/application):
 
     __PACKAGE__->new(
         server => 'Starman',
-        app => '/path/to/your/application/app.pl',
+        app => '/path/to/your/application/app.psgi',
         port => 5000,
         user => 'www-data',
     );
 
 Run C<ubic start application> to start the service.
 
-
 =head3 Using daemontools
 
-daemontools is a collection of tools for managing UNIX services. You can use it to easily start/restart/stop services.
+daemontools is a collection of tools for managing UNIX services. You can use
+it to easily start/restart/stop services.
 
-A basic script to start an application: (in /service/application/run)
+A basic script to start an application: (in C</service/application/run>)
 
     #!/bin/sh
 
@@ -1270,40 +528,40 @@ A basic script to start an application: (in /service/application/run)
     export PERL5LIB='/path/to/your/application/lib'
 
     exec 2>&1 \
-    /usr/local/bin/plackup -s Starman -a /path/to/your/application/app.pl -p 5000
-
+    /usr/local/bin/plackup -s Starman -a /path/to/your/application/app.psgi -p 5000
 
 =head2 Running stand-alone behind a proxy / load balancer
 
-Another option would be to run your app stand-alone as described above, but then
-use a proxy or load balancer to accept incoming requests (on the standard port
-80, say) and feed them to your Dancer2 app.
+Another option would be to run your app stand-alone as described above, but
+then use a proxy or load balancer to accept incoming requests (on the
+standard port 80, say) and feed them to your Dancer2 app.
 
 This could be achieved using various software; examples would include:
 
-=head3 Using Apache's mod_proxy
+=head3 Using Apache's C<mod_proxy>
 
-You could set up a VirtualHost for your web app, and proxy all requests through
-to it:
+You could set up a C<VirtualHost> for your web app, and proxy all requests
+through to it:
 
     <VirtualHost mywebapp.example.com:80>
     ProxyPass / http://localhost:3000/
     ProxyPassReverse / http://localhost:3000/
     </VirtualHost>
 
-Or, if you want your webapp to share an existing VirtualHost, you could have it
-under a specified dir:
+Or, if you want your webapp to share an existing VirtualHost, you could have
+it under a specified dir:
 
     ProxyPass /mywebapp/ http://localhost:3000/
     ProxyPassReverse /mywebapp/ http://localhost:3000/
 
-It is important for you to note that the Apache2 modules C<mod_proxy> and C<mod_proxy_http>
-must be enabled.
+It is important for you to note that the Apache2 modules C<mod_proxy> and
+C<mod_proxy_http> must be enabled:
 
-    a2enmod proxy
-    a2enmod proxy_http
+    $ a2enmod proxy
+    $ a2enmod proxy_http
 
-It is also important to set permissions for proxying for security purposes, below is an example.
+It is also important to set permissions for proxying for security purposes,
+below is an example.
 
     <Proxy *>
       Order allow,deny
@@ -1312,15 +570,15 @@ It is also important to set permissions for proxying for security purposes, belo
 
 =head3 Using perlbal
 
-C<perlbal> is a single-threaded event-based server written in Perl supporting HTTP load
-balancing, web serving, and a mix of the two, available from
-L<http://www.danga.com/perlbal/>
+C<perlbal> is a single-threaded event-based server written in Perl
+supporting HTTP load balancing, web serving, and a mix of the two, available
+from L<http://www.danga.com/perlbal/>.
 
-It processes hundreds of millions of requests a day just for LiveJournal, Vox
-and TypePad and dozens of other "Web 2.0" applications.
+It processes hundreds of millions of requests a day just for LiveJournal,
+Vox and TypePad and dozens of other "Web 2.0" applications.
 
-It can also provide a management interface to let you see various information on
-requests handled etc.
+It can also provide a management interface to let you see various
+information on requests handled etc.
 
 It could easily be used to handle requests for your Dancer2 apps, too.
 
@@ -1328,7 +586,7 @@ It can be easily installed from CPAN:
 
     perl -MCPAN -e 'install Perlbal'
 
-Once installed, you'll need to write a configuration file.  See the examples
+Once installed, you'll need to write a configuration file. See the examples
 provided with perlbal, but you'll probably want something like:
 
     CREATE POOL my_dancers
@@ -1346,18 +604,15 @@ provided with perlbal, but you'll probably want something like:
     SET verify_backend  = on
     ENABLE my_webapp
 
-
-
-
 =head3 Using balance
 
 C<balance> is a simple load-balancer from Inlab Software, available from
 L<http://www.inlab.de/balance.html>.
 
-It could be used simply to hand requests to a standalone Dancer2 app. You could
-even run several instances of your Dancer2 app, on the same machine or on several
-machines, and use a machine running balance to distribute the requests between
-them, for some serious heavy traffic handling!
+It could be used simply to hand requests to a standalone Dancer2 app. You
+could even run several instances of your Dancer2 app, on the same machine or
+on several machines, and use a machine running C<balance> to distribute the
+requests between them, for some serious heavy traffic handling!
 
 To listen on port 80, and send requests to a Dancer2 app on port 3000:
 
@@ -1368,10 +623,9 @@ multiple Dancer2 apps on multiple other machines:
 
     balance -b 10.0.0.1 80 10.0.0.2:3000 10.0.0.3:3000 10.0.0.4:3000
 
+=head3 Using lighttpd
 
-=head3 Using Lighttpd
-
-You can use Lighttp's mod_proxy:
+You can use lighttp's C<mod_proxy>:
 
     $HTTP["url"] =~ "/application" {
         proxy.server = (
@@ -1381,8 +635,8 @@ You can use Lighttp's mod_proxy:
         )
     }
 
-This configuration will proxy all request to the B</application> path
-to the path B</> on localhost:3000.
+This configuration will proxy all requests to the C</application> path to the
+path C</> on localhost:3000.
 
 =head3 Using Nginx
 
@@ -1419,10 +673,251 @@ with Nginx:
 You will need plackup to start a worker listening on a socket :
 
     cd YOUR_PROJECT_PATH
-    sudo -u www plackup -E production -s Starman --workers=2 -l THE_PATH_OF_YOUR_PLACKUP_SOCKET_HERE.sock -a bin/app.pl
+    sudo -u www plackup -E production -s Starman --workers=2 \
+        -l THE_PATH_OF_YOUR_PLACKUP_SOCKET_HERE.sock -a bin/app.psgi
 
-A good way to start this is to use C<daemontools> and place this line
-with all environments variables in the "run" file.
+A good way to start this is to use C<daemontools> and place this line with
+all environments variables in the "run" file.
 
+=head2 Turning off warnings
 
-=cut
+The C<warnings> pragma is already used when one loads Dancer2. However, if
+you I<really> do not want the C<warnings> pragma (for example, due to an
+undesired warning about use of undef values), add a C<no warnings> pragma to
+the appropriate block in your module or psgi file.
+
+=head2 Writing a REST application
+
+With Dancer2, it's easy to write REST applications. Dancer2 provides helpers
+to serialize and deserialize for the following data formats:
+
+=over 4
+
+=item JSON
+
+=item YAML
+
+=item XML
+
+=item Data::Dumper
+
+=back
+
+To activate this feature, you only have to set the C<serializer> setting to
+the format you require, for instance in your config file:
+
+   serializer: JSON
+
+Or directly in your code:
+
+   set serializer => 'JSON';
+
+From now, all hashrefs or arrayrefs returned by a route will be serialized
+to the format you chose, and all data received from B<POST> or B<PUT>
+requests will be automatically deserialized.
+
+    get '/hello/:name' => sub {
+        # this structure will be returned to the client as
+        # {"name":"$name"}
+        return {name => params->{name}};
+    };
+
+It's possible to let the client choose which serializer to use. For
+this, use the C<mutable> serializer, and an appropriate serializer will be
+chosen from the C<Content-Type> header.
+
+It's also possible to return a custom error using the
+L<send_error|Dancer2/send_error> keyword. When you don't use a serializer,
+the C<send_error> function will take a string as first parameter (the
+message), and an optional HTTP code. When using a serializer, the message
+can be a string, an arrayref or a hashref:
+
+    get '/hello/:name' => sub {
+        if (...) {
+           send_error("you can't do that");
+           # or
+           send_error({reason => 'access denied', message => "no"});
+        }
+    };
+
+The content of the error will be serialized using the appropriate
+serializer.
+
+=head2 Using the serializer
+
+Serializers essentially do two things:
+
+=over 4
+
+=item * Deserialize incoming requests
+
+When a user makes a request with serialized input, the serializer 
+automatically deserializes it into actual input parameters.
+
+=item * Serialize outgoing responses
+
+When you return a data structure from a route, it will automatically 
+serialize it for you before returning it to the user.
+
+=back
+
+=head3 Configuring
+
+In order to configure a serializer, you just need to pick which format 
+you want for encoding/decoding (from L<Dancer2::Serializer>) and set it 
+up using the C<serializer> configuration keyword.
+
+It is recommended to explicitly add it in the actual code instead of the 
+configuration file so it doesn't apply automatically to every app that 
+reads the configuration file (unless that's what you want):
+
+     package MyApp;
+     use Dancer2;
+     set serializer => 'JSON'; # Dancer2::Serializer::JSON
+
+     ...
+
+=head3 Using
+
+Now that we have a serializer set up, we can just return data structures:
+
+     get '/' => sub {
+         return { resources => \%resources };
+     };
+
+When we return this data structure, it will automatically be serialized 
+into JSON. No other code is necessary.
+
+We also now receive requests in JSON:
+
+     post '/:entity/:id' => sub {
+         my $entity = param('entity');
+         my $id     = param('id');
+
+         # input which was sent serialized
+         my $user = param('user');
+
+         ...
+     };
+
+We can now make a serialized request:
+
+     $ curl -X POST http://ourdomain/person/16 -d '{"user":"sawyer_x"}'
+
+=head3 App-specific feature
+
+Serializers are engines. They affect a Dancer Application, which means 
+that once you've set a serializer, B<all> routes within that package 
+will be serialized and deserialized. This is how the feature works.
+
+As suggested above, if you would like to have both, you need to create 
+another application which will not be serialized.
+
+A common usage for this is an API providing serialized endpoints (and 
+receiving serialized requests) and providing rendered pages.
+
+     # MyApp.pm
+     package MyApp;
+     use Dancer2;
+
+     # another useful feature:
+     set auto_page => 1;
+
+     get '/' => sub { template 'index' => {...} };
+
+     # MyApp/API.pm
+     package MyApp::API;
+     use Dancer2;
+     set serializer => 'JSON'; # or any other serializer
+
+     get '/' => sub { +{ resources => \%resources, ... } };
+
+     # user-specific routes, for example
+     prefix => '/users' => sub {
+         get '/view'     => sub {...};
+         get '/view/:id' => sub {...};
+         put '/add'      => sub {...}; # automatically deserialized params
+     };
+
+     ...
+
+Then those will be mounted together for a single app:
+
+     # handler: app.pl:
+     use MyApp;
+     use MyApp::API;
+     use Plack::Builder;
+
+     builder {
+         mount '/'    => MyApp->to_app;
+         mount '/api' => MyApp::API->to_app;
+     };
+
+=head3 An example: Writing API interfaces
+
+This example demonstrates an app that makes a request to a weather 
+API and then displays it dynamically in a web page.
+
+Other than L<Dancer2> for defining routes, we will use L<HTTP::Tiny> 
+to make the weather API request, L<JSON> to decode it from JSON format, 
+and finally L<File::Spec> to provide a fully-qualified path to our 
+template engine.
+
+     use JSON;
+     use Dancer2;
+     use HTTP::Tiny;
+     use File::Spec; 
+
+=head4 Configuration
+
+We use the L<Template::Toolkit> template system for this app.
+Dancer searches for our templates in our views directory, which defaults 
+to I<views> directory in our current directory. Since we want to put our 
+template in our current directory, we will configure that. However, 
+I<Template::Toolkit> does not want us to provide a relative path without 
+configuring it to allow it. This is a security issue. So, we're using 
+L<File::Spec> to create a full path to where we are.
+
+We also unset the default layout, so Dancer won't try to wrap our template 
+with another one. This is a feature in Dancer to allow you to wrap your 
+templates with a layout when your templating system doesn't support it. Since 
+we're not using a layout here, we don't need it.
+
+     set template => 'template_toolkit';       # set template engine
+     set layout   => undef;                    # disable layout
+     set views    => File::Spec->rel2abs('.'); # full path to views
+
+Now, we define our URL:
+
+     my $url = 'http://api.openweathermap.org/data/2.5/weather?id=5110629&units=imperial';
+
+=head4 Route
+
+We will define a main route which, upon a request, will fetch the information 
+from the weather API, decode it, and then display it to the user.
+
+Route definition:
+
+     get '/' => sub {
+         ...
+     };
+
+Editing the stub of route dispatching code, we start by making the request 
+and decoding it:
+
+     # fetch data
+     my $res = HTTP::Tiny->new->get($url);
+
+     # decode request
+     my $data = decode_json $res->{'content'};
+
+The data is not just a flat hash. It's a deep structure. In this example, we 
+will filter it for only the simple keys in the retrieved data:
+
+     my $metrics = { map +(
+         ref $data->{$_} ? () : ( $_ => $data->{$_} )
+     ), keys %{$data} };
+
+All that is left now is to render it:
+
+     template index => { metrics => $metrics };

--- a/lib/Dancer2/Manual.pod
+++ b/lib/Dancer2/Manual.pod
@@ -1282,6 +1282,60 @@ Environment-specific settings can also be defined in environment-specific
 files (for instance, you do not want to show error stacktraces in
 production, and might want extra logging in development).
 
+=head2 Serializers
+
+When writing a webservice, data serialization/deserialization is a common
+issue to deal with. Dancer2 can automatically handle that for you, via a
+serializer.
+
+When setting up a serializer, a new behaviour is authorized for any route
+handler you define: any non-scalar response will be rendered as a serialized
+string, via the current serializer.
+
+Here is an example of a route handler that will return a hashref:
+
+    use Dancer2;
+    set serializer => 'JSON';
+
+    get '/user/:id/' => sub {
+        { foo => 42,
+          number => 100234,
+          list => [qw(one two three)],
+        }
+    };
+
+Dancer2 will render the response via the current serializer.
+
+Hence, with the JSON serializer set, the route handler above would result in
+a content like the following:
+
+    {"number":100234,"foo":42,"list":["one","two","three"]}
+
+The following serializers are available, be aware they dynamically depend on
+Perl modules you may not have on your system.
+
+=over 4
+
+=item B<JSON>
+
+requires L<JSON>
+
+=item B<YAML>
+
+requires L<YAML>
+
+=item B<XML>
+
+requires L<XML::Simple>
+
+=item B<Mutable>
+
+will try to find the appropriate serializer using the B<Content-Type> and
+B<Accept-type> header of the request.
+
+=back
+
+
 =head2 Importing using Appname
 
 An app in Dancer2 uses the class name (defined by the C<package> function) to

--- a/lib/Dancer2/Manual.pod
+++ b/lib/Dancer2/Manual.pod
@@ -1195,6 +1195,17 @@ just do:
 
 =head1 FILE UPLOADS
 
+Files are uploaded in Dancer2 using the class L<Dancer2::Core::Request::Upload>. 
+The objects are accessible within the route handlers using the C<request->uploads> 
+keyword.
+
+    post '/upload/:file' => sub {
+    
+    my $upload_dir = "MyApp/UPLOADS";
+    my $filename = params->{file};
+    my $uploadedFile = request->upload($filename);
+    };
+
 =head1 CONFIGURATION
 
 =head2 Configuration and environments

--- a/lib/Dancer2/Manual.pod
+++ b/lib/Dancer2/Manual.pod
@@ -324,7 +324,9 @@ define their own.
 
 =head2 Request workflow
 
-C<before> hooks are evaluated before each request within the context of the
+=over
+
+=item * C<before> hooks are evaluated before each request within the context of the
 request and receives as argument the app (a L<Dancer2::Core::App> object).
 
 It's possible to define variables which will be accessible in the action
@@ -352,7 +354,7 @@ give non-logged-in users a login page:
 The request keyword returns the current L<Dancer2::Core::Request> object
 representing the incoming request.
 
-C<after> hooks are evaluated after the response has been built by a route
+=item * C<after> hooks are evaluated after the response has been built by a route
 handler, and can alter the response itself, just before it's sent to the
 client.
 
@@ -368,9 +370,13 @@ The hook is given the response object as its first argument:
         content q{The "after" hook can alter the response's content here!};
     };
 
+=back
+
 =head2 Templates
 
-C<before_template_render> hooks are called whenever a template is going to
+=over
+
+=item * C<before_template_render> hooks are called whenever a template is going to
 be processed, they are passed the tokens hash which they can alter.
 
     hook before_template_render => sub {
@@ -383,7 +389,7 @@ modifications performed by the hook. This is a good way to setup some
 global vars you like to have in all your templates, like the name of the
 user logged in or a section name.
 
-C<after_template_render> hooks are called after the view has been rendered.
+=item * C<after_template_render> hooks are called after the view has been rendered.
 They receive as their first argument the reference to the content that has
 been produced. This can be used to post-process the content rendered by the
 template engine.
@@ -396,7 +402,7 @@ template engine.
         $ref_content = \$content;
     };
 
-C<before_layout_render> hooks are called whenever the layout is going to be
+=item * C<before_layout_render> hooks are called whenever the layout is going to be
 applied to the current content. The arguments received by the hook are the
 current tokens hashref and a reference to the current content.
 
@@ -406,7 +412,7 @@ current tokens hashref and a reference to the current content.
         $ref_content = \"new content";
     };
 
-C<after_layout_render> hooks are called once the complete content of the
+=item * C<after_layout_render> hooks are called once the complete content of the
 view has been produced, after the layout has been applied to the content.
 The argument received by the hook is a reference to the complete content
 string.
@@ -416,14 +422,43 @@ string.
         # do something with ${ $ref_content }, which reflects directly
         #   in the caller
     };
+    
+=back
 
-=head2 L<Error Handling|https://github.com/SnigdhaD/Dancer2/blob/snigdha/lib/Dancer2/Manual.pod#error-handling>
+=head2 Error Handling
+
+Refer to L<Error Handling|https://github.com/SnigdhaD/Dancer2/edit/snigdha/lib/Dancer2/Manual.pod#error-handling-1>
+for details about the following hooks:
+
+=over
+
+=item * C<init_error>
+
+=item * C<before_error>
+
+=item * C<after_error>
+
+=item * C<on_route_exception>
+
+=back
 
 =head2 File Rendering
 
+Refer to L<File Rendering> for details on the following hooks:
+
+=over
+
+=item * C<before_file_render>
+
+=item * C<after_file_render>
+
+=back
+
 =head2 Serializers
 
-C<before_serializer> is called before serializing the content, and receives
+=over
+
+=item * C<before_serializer> is called before serializing the content, and receives
 the content to serialize as an argument.
 
   hook before_serializer => sub {
@@ -431,7 +466,7 @@ the content to serialize as an argument.
     ...
   };
 
-C<after_serializer> is called after the payload has been serialized, and
+=item * C<after_serializer> is called after the payload has been serialized, and
 receives the serialized content as an argument.
 
   hook after_serializer => sub {

--- a/lib/Dancer2/Manual.pod
+++ b/lib/Dancer2/Manual.pod
@@ -1196,7 +1196,7 @@ just do:
 =head1 FILE UPLOADS
 
 Files are uploaded in Dancer2 using the class L<Dancer2::Core::Request::Upload>. 
-The objects are accessible within the route handlers using the C<request->uploads> 
+The objects are accessible within the route handlers using the request->uploads 
 keyword.
 
     post '/upload/:file' => sub {

--- a/lib/Dancer2/Manual.pod
+++ b/lib/Dancer2/Manual.pod
@@ -185,35 +185,43 @@ parameters; these will be parameters supplied on the query string within
 the path itself (with named placeholders) and, for HTTP POST requests, the
 content of the POST body.
 
-=head3 Named parameters in route path declarations
+=head3 Named matching
 
-As seen above, you can use C<:somename> in a route's path to capture part of the
-path; this will become available by calling L<params|Dancer2/params>.
+A route pattern can contain one or more tokens (a word prefixed with ':'). 
+Each token found in a route pattern is used as a named-pattern match. Any 
+match will be set in the params hashref.
 
-So, for a web app where you want to display information on a company, you might
-use something like:
-
-    get '/company/view/:companyid' => sub {
-        my $company_id = params->{companyid};
-        # Look up the company and return appropriate page
+    get '/hello/:name' => sub {
+        "Hey ".param('name').", welcome here!";
     };
 
-=head3 Wildcard path matching and splat
+Tokens can be optional, for example:
 
-You can also declare wildcards in a path and retrieve the values they matched
-with the L<splat|Dancer2/splat> keyword:
-
-    get '/*/*' => sub {
-        my ($action, $id) = splat;
-        if (my $action eq 'view') {
-            return display_item($id);
-        } elsif ($action eq 'delete') {
-            return delete_item($id);
-        } else {
-            status 'not_found';
-            return "What?";
-        }
+    get '/hello/:name?' => sub {
+        defined param('name') ? "Hello there ".param('name') : "whoever you are!";
     };
+
+=head3 Wildcard matching
+
+A route can contain a wildcard (represented by a C<*>). Each wildcard match
+will be placed in a list, which the C<splat> keyword returns.
+
+    get '/download/*.*' => sub {
+        my ($file, $ext) = splat;
+        # do something with $file.$ext here
+    };
+
+An extensive, greedier wildcard represented by C<**> (A.K.A. "megasplat") can be
+used to define a route. The additional path is broken down and returned as an
+arrayref:
+
+    get '/entry/*/tags/**' => sub {
+        my ( $entry_id, $tags ) = splat;
+        my @tags = @{$tags};
+    };
+
+The C<splat> keyword in the above example for the route F</entry/1/tags/one/two>
+would set C<$entry_id> to C<1> and C<$tags> to C<['one', 'two']>.
 
 =head3 Mixed named and wildcard matching
 

--- a/lib/Dancer2/Manual.pod
+++ b/lib/Dancer2/Manual.pod
@@ -427,7 +427,7 @@ string.
 
 =head2 Error Handling
 
-Refer to L<Error Handling|https://github.com/SnigdhaD/Dancer2/edit/snigdha/lib/Dancer2/Manual.pod#error-handling-1>
+Refer to L<Error Handling|https://github.com/SnigdhaD/Dancer2/blob/snigdha/lib/Dancer2/Manual.pod#error-handling-1>
 for details about the following hooks:
 
 =over
@@ -444,7 +444,8 @@ for details about the following hooks:
 
 =head2 File Rendering
 
-Refer to L<File Rendering> for details on the following hooks:
+Refer to L<File Rendering|https://github.com/SnigdhaD/Dancer2/blob/snigdha/lib/Dancer2/Manual.pod#file-handler> 
+for details on the following hooks:
 
 =over
 
@@ -573,6 +574,79 @@ For example, the default config file for any Dancer2 application is as follows:
       File:
         public_dir: /path/to/public
       AutoPage: 1
+
+
+=head1 ERRORS
+
+=head2 Default Error Pages
+
+When an error is rendered (the action responded with a status code different
+than 200), Dancer2 first looks in the public directory for an HTML file
+matching the error code (eg: 500.html or 404.html).
+
+If such a file exists, it's used to render the error, otherwise, a default
+error page will be rendered on the fly.
+
+=head2 Execution Errors
+
+When an error occurs during the route execution, Dancer2 will render an
+error page with the HTTP status code 500.
+
+It's possible either to display the content of the error message or to hide
+it with a generic error page.
+
+This is a choice left to the end-user and can be set with the B<show_errors>
+setting.
+
+Note that you can also choose to consider all warnings in your route
+handlers as errors when the setting B<warnings> is set to 1.
+
+=head2 Error handling
+
+When an error is caught by Dancer2's core, an exception object is built (of
+the class L<Dancer2::Core::Error>). This class provides a hook to let the
+user alter the error workflow if needed.
+
+C<init_error> hooks are called whenever an error object is built, the object
+is passed to the hook.
+
+    hook init_error => sub {
+        my $error = shift;
+        # do something with $error
+    };
+
+I<This hook was named B<before_error_init> in Dancer, both names currently
+are synonyms for backward-compatibility.>
+
+C<before_error> hooks are called whenever an error is going to be thrown, it
+receives the error object as its sole argument.
+
+    hook before_error => sub {
+        my $error = shift;
+        # do something with $error
+    };
+
+I<This hook was named B<before_error_render> in Dancer, both names currently
+are synonyms for backward-compatibility.>
+
+C<after_error> hooks are called whenever an error object has been thrown, it
+receives a L<Dancer2::Core::Response> object as its sole argument.
+
+    hook after_error => sub {
+        my $response = shift;
+    };
+
+I<This hook was named B<after_error_render> in Dancer, both names currently
+are synonyms for backward-compatibility.>
+
+C<on_route_exception> is called when an exception has been caught, at the
+route level, just before rethrowing it higher. This hook receives a
+L<Dancer2::Core::App> and the error as arguments.
+
+  hook on_route_exception => sub {
+    my ($app, $error) = @_;
+  };
+  
 
 =head1 SESSIONS
 
@@ -955,78 +1029,6 @@ To conclude, an C<after> filter is set to call the flush method of the storage b
      );
 
 The code for this can be found on L<Github|https://github.com/sukria/Dancer-Session-Redis/blob/master/lib/Dancer/Session/Redis.pm>
-
-
-=head1 ERRORS
-
-=head2 Default Error Pages
-
-When an error is rendered (the action responded with a status code different
-than 200), Dancer2 first looks in the public directory for an HTML file
-matching the error code (eg: 500.html or 404.html).
-
-If such a file exists, it's used to render the error, otherwise, a default
-error page will be rendered on the fly.
-
-=head2 Execution Errors
-
-When an error occurs during the route execution, Dancer2 will render an
-error page with the HTTP status code 500.
-
-It's possible either to display the content of the error message or to hide
-it with a generic error page.
-
-This is a choice left to the end-user and can be set with the B<show_errors>
-setting.
-
-Note that you can also choose to consider all warnings in your route
-handlers as errors when the setting B<warnings> is set to 1.
-
-=head2 Error handling
-
-When an error is caught by Dancer2's core, an exception object is built (of
-the class L<Dancer2::Core::Error>). This class provides a hook to let the
-user alter the error workflow if needed.
-
-C<init_error> hooks are called whenever an error object is built, the object
-is passed to the hook.
-
-    hook init_error => sub {
-        my $error = shift;
-        # do something with $error
-    };
-
-I<This hook was named B<before_error_init> in Dancer, both names currently
-are synonyms for backward-compatibility.>
-
-C<before_error> hooks are called whenever an error is going to be thrown, it
-receives the error object as its sole argument.
-
-    hook before_error => sub {
-        my $error = shift;
-        # do something with $error
-    };
-
-I<This hook was named B<before_error_render> in Dancer, both names currently
-are synonyms for backward-compatibility.>
-
-C<after_error> hooks are called whenever an error object has been thrown, it
-receives a L<Dancer2::Core::Response> object as its sole argument.
-
-    hook after_error => sub {
-        my $response = shift;
-    };
-
-I<This hook was named B<after_error_render> in Dancer, both names currently
-are synonyms for backward-compatibility.>
-
-C<on_route_exception> is called when an exception has been caught, at the
-route level, just before rethrowing it higher. This hook receives a
-L<Dancer2::Core::App> and the error as arguments.
-
-  hook on_route_exception => sub {
-    my ($app, $error) = @_;
-  };
   
 
 =head1 TEMPLATES

--- a/lib/Dancer2/Manual.pod
+++ b/lib/Dancer2/Manual.pod
@@ -1161,6 +1161,38 @@ template toolkit, your config file will look like this:
         template_toolkit:
           ENCODING: utf8
 
+
+=head1 STATIC FILES
+
+=head2 Static Directory
+
+Static files are served from the F<./public> directory. You can specify a
+different location by setting the C<public> option:
+
+    set public => path(dirname(__FILE__), 'static');
+
+Note that the public directory name is not included in the URL. A file
+F<./public/css/style.css> is made available as
+L<http://example.com/css/style.css>.
+
+=head2 Static File from a Route Handler
+
+It's possible for a route handler to send a static file, as follows:
+
+    get '/download/*' => sub {
+        my ($file) = splat;
+
+        send_file $file;
+    };
+
+Or even if you want your index page to be a plain old F<index.html> file,
+just do:
+
+    get '/' => sub {
+        send_file '/index.html'
+    };
+
+
 =head1 FILE UPLOADS
 
 =head1 CONFIGURATION

--- a/lib/Dancer2/Manual.pod
+++ b/lib/Dancer2/Manual.pod
@@ -475,6 +475,8 @@ receives the serialized content as an argument.
     ...
   };
 
+=back
+
 
 =head1 HANDLERS
 

--- a/lib/Dancer2/Manual.pod
+++ b/lib/Dancer2/Manual.pod
@@ -1762,6 +1762,76 @@ This is handled automatically using the C<plugin_setting> keyword:
          my $dsl = shift;
          my $vol = plugin_setting->{'volume'} || 3;
      };
+     
+     
+=head1 EXPORTS
+
+By default, C<use Dancer2> exports all the DSL keywords and sets up the
+webapp under the name of the current package. The following tags control
+exports and webapp namespace.
+
+=over 4
+
+=item B<!keyword>
+
+If you want to prevent Dancer2 from exporting specific keywords (perhaps you
+plan to implement them yourself in a different way, or they clash with
+another module you're loading), you can simply exclude them:
+
+    use Test::More;
+    use Dancer2 qw(!pass);
+
+The above would import all keywords as usual, with the exception of C<pass>.
+
+=item B<appname>
+
+A larger application may split its source between several packages to aid
+maintainability. Dancer2 will create a separate application for each
+package, each having separate hooks, config and/or engines. You can force
+Dancer2 to collect the route and hooks into a single application with the
+C<appname> tag; e.g.
+
+    package MyApp;
+    use Dancer2;
+    get '/foo' => sub {...};
+
+    package MyApp::Private;
+    use Dancer2 appname => MyApp;
+    get '/bar' => sub {...};
+
+The above would add the C<bar> route to the MyApp application. Dancer2 will
+I<not> create an application with the name C<MyApp::Private>.
+
+=back
+
+When you C<use Dancer2>, you get an C<import> method added into the current
+package. This B<will> override previously declared import methods from other
+sources, such as L<Exporter>. Dancer2 applications support the following
+tags on import:
+
+=over 4
+
+=item B<with>
+
+The C<with> tag allows an app to pass one or more config entries to another
+app, when it C<use>s it.
+
+    package MyApp;
+    use Dancer2;
+
+    set session => 'YAML';
+    use Blog with => { session => engine('session') };
+
+In this example, the session engine is passed to the C<Blog> app. That way,
+anything done in the session will be shared between both apps.
+
+Anything that is defined in the config entry can be passed that way. If we
+want to pass the whole config object, it can be done like so:
+
+    use SomeApp with => { %{config()} };
+
+=back
+
 
 =head1 DSL KEYWORDS
 

--- a/lib/Dancer2/Manual.pod
+++ b/lib/Dancer2/Manual.pod
@@ -1762,3 +1762,1002 @@ This is handled automatically using the C<plugin_setting> keyword:
          my $dsl = shift;
          my $vol = plugin_setting->{'volume'} || 3;
      };
+
+=head1 DSL KEYWORDS
+
+Dancer2 provides you with a DSL (Domain-Specific Language) which makes
+implementing your web application trivial.
+
+For example, take the following example:
+
+    use Dancer2;
+
+    get '/hello/:name' => sub {
+        my $name = params->{name};
+    };
+    dance;
+
+C<get> and C<params> are keywords provided by Dancer2.
+
+This document lists all keywords provided by Dancer2. It does not cover
+additional keywords which may be provided by loaded plugins; see the
+documentation for plugins you use to see which additional keywords they make
+available to you.
+
+=head2 any
+
+Defines a route for multiple HTTP methods at once:
+
+    any ['get', 'post'] => '/myaction' => sub {
+        # code
+    };
+
+Or even, a route handler that would match any HTTP methods:
+
+    any '/myaction' => sub {
+        # code
+    };
+
+=head2 cookies
+
+Accesses cookies values, it returns a hashref of L<Dancer2::Core::Cookie>
+objects:
+
+    get '/some_action' => sub {
+        my $cookie = cookies->{name};
+        return $cookie->value;
+    };
+
+In case you have stored something other than a scalar in your cookie:
+
+    get '/some_action' => sub {
+        my $cookie = cookies->{oauth};
+        my %values = $cookie->value;
+        return ($values{token}, $values{token_secret});
+    };
+
+=head2 cookie
+
+Accesses a cookie value (or sets it). Note that this method will eventually
+be preferred over C<set_cookie>.
+
+    cookie lang => "fr-FR";              # set a cookie and return its value
+    cookie lang => "fr-FR", expires => "2 hours";   # extra cookie info
+    cookie "lang"                        # return a cookie value
+
+If your cookie value is a key/value URI string, like
+
+    token=ABC&user=foo
+
+C<cookie> will only return the first part (C<token=ABC>) if called in scalar
+context. Use list context to fetch them all:
+
+    my @values = cookie "name";
+
+=head2 config
+
+Accesses the configuration of the application:
+
+    get '/appname' => sub {
+        return "This is " . config->{appname};
+    };
+
+=head2 content
+
+Sets the content for the response.
+
+    get '/' => sub {
+        content 'Hello, world!';
+
+        # the return value of the route is ignored
+        return 'Ignored String';
+    };
+
+Once you set the content using the keyword, your return value (which
+is usually the content) is ignored.
+
+B<WARNING:> If you are using the C<pass> keyword, the last route will be
+in charge of setting the content.
+
+=head2 content_type
+
+Sets the B<content-type> rendered, for the current route handler:
+
+    get '/cat/:txtfile' => sub {
+        content_type 'text/plain';
+
+        # here we can dump the contents of param('txtfile')
+    };
+
+You can use abbreviations for content types. For instance:
+
+    get '/svg/:id' => sub {
+        content_type 'svg';
+
+        # here we can dump the image with id param('id')
+    };
+
+Note that if you want to change the default content-type for every route,
+it is easier to change the C<content_type> setting instead.
+
+=head2 dance
+
+Alias for the C<start> keyword.
+
+=head2 dancer_version
+
+Returns the version of Dancer. If you need the major version, do something
+like:
+
+  int(dancer_version);
+
+=head2 debug
+
+Logs a message of debug level:
+
+    debug "This is a debug message";
+
+See L<Dancer2::Core::Role::Logger> for details on how to configure where log
+messages go.
+
+=head2 dirname
+
+Returns the dirname of the path given:
+
+    my $dir = dirname($some_path);
+
+=head2 engine
+
+Given a namespace, returns the current engine object
+
+    my $template_engine = engine 'template';
+    my $html = $template_engine->apply_renderer(...);
+    $template_engine->apply_layout($html);
+
+=head2 error
+
+Logs a message of error level:
+
+    error "This is an error message";
+
+See L<Dancer2::Core::Role::Logger> for details on how to configure where log
+messages go.
+
+=head2 false
+
+Constant that returns a false value (0).
+
+=head2 forward
+
+Runs an "internal redirect" of the current request to another request. More
+formally; when C<forward> is executed, the current dispatch of the request is
+aborted, the request is modified (altering query params or request method),
+and the modified request is dispatched again. Any remaining code (route and
+hooks) from the current dispatch will never be run and the modified request's
+dispatch will execute hooks for the new request normally.
+
+It effectively lets you chain routes together in a clean manner.
+
+    get '/demo/articles/:article_id' => sub {
+
+        # you'll have to implement this next sub yourself :)
+        change_the_main_database_to_demo();
+
+        forward "/articles/" . params->{article_id};
+    };
+
+In the above example, the users that reach I</demo/articles/30> will
+actually reach I</articles/30> but we've changed the database to demo
+before.
+
+This is pretty cool because it lets us retain our paths and offer a demo
+database by merely going to I</demo/...>.
+
+You'll notice that in the example we didn't indicate whether it was B<GET>
+or B<POST>. That is because C<forward> chains the same type of route the
+user reached. If it was a B<GET>, it will remain a B<GET> (but if you do
+need to change the method, you can do so; read on below for details.)
+
+B<WARNING:> Any code after a C<forward> is ignored, until the end of the
+route. It's not necessary to use C<return> with C<forward> anymore.
+
+    get '/foo/:article_id' => sub {
+        if ($condition) {
+            forward "/articles/" . params->{article_id};
+            # The following code WILL NOT BE executed
+            do_stuff();
+        }
+
+        more_stuff();
+    };
+
+Note that C<forward> doesn't parse GET arguments. So, you can't use
+something like:
+
+    forward '/home?authorized=1';
+
+But C<forward> supports an optional hashref with parameters to be added to
+the actual parameters:
+
+    forward '/home', { authorized => 1 };
+
+Finally, you can add some more options to the C<forward> method, in a third
+argument, also as a hashref. That option is currently only used to change
+the method of your request. Use with caution.
+
+    forward '/home', { auth => 1 }, { method => 'POST' };
+
+=head2 from_dumper ($structure)
+
+Deserializes a Data::Dumper structure.
+
+=head2 from_json ($structure, \%options)
+
+Deserializes a JSON structure. Can receive optional arguments. Those
+arguments are valid L<JSON> arguments to change the behaviour of the default
+C<JSON::from_json> function.
+
+=head2 from_yaml ($structure)
+
+Deserializes a YAML structure.
+
+=head2 get
+
+Defines a route for HTTP B<GET> requests to the given path:
+
+    get '/' => sub {
+        return "Hello world";
+    }
+
+Note that a route to match B<HEAD> requests is automatically created as well.
+
+=head2 halt
+
+Sets a response object with the content given.
+
+When used as a return value from a hook, this breaks the execution flow and
+renders the response immediately:
+
+    hook before => sub {
+        if ($some_condition) {
+            halt("Unauthorized");
+
+            # this code is not executed
+            do_stuff();
+        }
+    };
+
+    get '/' => sub {
+        "hello there";
+    };
+
+B<WARNING:> Issuing a halt immediately exits the current route, and performs
+the halt. Thus, any code after a halt is ignored, until the end of the route.
+Hence, it's not necessary anymore to use C<return> with halt.
+
+=head2 headers
+
+Adds custom headers to responses:
+
+    get '/send/headers', sub {
+        headers 'X-Foo' => 'bar', 'X-Bar' => 'foo';
+    }
+
+=head2 header
+
+adds a custom header to response:
+
+    get '/send/header', sub {
+        header 'x-my-header' => 'shazam!';
+    }
+
+Note that it will overwrite the old value of the header, if any. To avoid
+that, see L</push_header>.
+
+=head2 push_header
+
+Do the same as C<header>, but allow for multiple headers with the same name.
+
+    get '/send/header', sub {
+        push_header 'x-my-header' => '1';
+        push_header 'x-my-header' => '2';
+        will result in two headers "x-my-header" in the response
+    }
+
+=head2 hook
+
+Adds a hook at some position. For example :
+
+  hook before_serializer => sub {
+    my $content = shift;
+    ...
+  };
+
+There can be multiple hooks assigned to a given position, and each will be
+executed in order.
+
+=head2 info
+
+Logs a message of C<info> level:
+
+    info "This is an info message";
+
+See L<Dancer2::Core::Role::Logger> for details on how to configure where log
+messages go.
+
+=head2 load
+
+Loads one or more perl scripts in the current application's namespace.
+Syntactic sugar around Perl's C<require>:
+
+    load 'UserActions.pl', 'AdminActions.pl';
+
+=head2 mime
+
+Shortcut to access the instance object of L<Dancer2::Core::MIME>. You should
+read the L<Dancer2::Core::MIME> documentation for full details, but the most
+commonly-used methods are summarized below:
+
+    # set a new mime type
+    mime->add_type( foo => 'text/foo' );
+
+    # set a mime type alias
+    mime->add_alias( f => 'foo' );
+
+    # get mime type for an alias
+    my $m = mime->for_name( 'f' );
+
+    # get mime type for a file (based on extension)
+    my $m = mime->for_file( "foo.bar" );
+
+    # get current defined default mime type
+    my $d = mime->default;
+
+    # set the default mime type using config.yml
+    # or using the set keyword
+    set default_mime_type => 'text/plain';
+
+=head2 params
+
+I<This method should be called from a route handler>.
+It's an alias for the L<Dancer2::Core::Request params
+accessor|Dancer2::Core::Request/"params($source)">. It returns a hash (in
+list context) or a hash reference (in scalar context) to all defined
+parameters. Check C<param> below to access quickly to a single parameter
+value.
+
+=head2 param
+
+I<This method should be called from a route handler>.
+This method is an accessor to the parameters hash table.
+
+   post '/login' => sub {
+       my $username = param "user";
+       my $password = param "pass";
+       # ...
+   }
+
+=head2 pass
+
+I<This method should be called from a route handler>.
+Tells Dancer2 to pass the processing of the request to the next matching
+route.
+
+B<WARNING:> Issuing a pass immediately exits the current route, and performs
+the pass. Thus, any code after a pass is ignored, until the end of the
+route. Hence, it's not necessary anymore to use C<return> with pass.
+
+    get '/some/route' => sub {
+        if (...) {
+            # we want to let the next matching route handler process this one
+            pass(...);
+
+            # this code will be ignored
+            do_stuff();
+        }
+    };
+
+B<WARNING:> You cannot set the content before passing and have it remain,
+even if you use the C<content> keyword or set it directly in the response
+object.
+
+=head2 patch
+
+Defines a route for HTTP B<PATCH> requests to the given URL:
+
+    patch '/resource' => sub { ... };
+
+(C<PATCH> is a relatively new and not-yet-common HTTP verb, which is
+intended to work as a "partial-PUT", transferring just the changes; please
+see L<RFC5789|http://tools.ietf.org/html/rfc5789> for further details.)
+
+=head2 path
+
+Concatenates multiple paths together, without worrying about the underlying
+operating system:
+
+    my $path = path(dirname($0), 'lib', 'File.pm');
+
+It also normalizes (cleans) the path aesthetically. It does not verify whether
+the path exists, though.
+
+=head2 post
+
+Defines a route for HTTP B<POST> requests to the given URL:
+
+    post '/' => sub {
+        return "Hello world";
+    }
+
+=head2 prefix
+
+Defines a prefix for each route handler, like this:
+
+    prefix '/home';
+
+From here, any route handler is defined to /home/*:
+
+    get '/page1' => sub {}; # will match '/home/page1'
+
+You can unset the prefix value:
+
+    prefix undef;
+    get '/page1' => sub {}; # will match /page1
+
+For a safer alternative you can use lexical prefix like this:
+
+    prefix '/home' => sub {
+        ## Prefix is set to '/home' here
+
+        get ...;
+        get ...;
+    };
+    ## prefix reset to the previous version here
+
+This makes it possible to nest prefixes:
+
+   prefix '/home' => sub {
+       ## some routes
+
+      prefix '/private' => sub {
+         ## here we are under /home/private...
+
+         ## some more routes
+      };
+      ## back to /home
+   };
+   ## back to the root
+
+B<Notice:> Once you have a prefix set, do not add a caret to the regex:
+
+    prefix '/foo';
+    get qr{^/bar} => sub { ... } # BAD BAD BAD
+    get qr{/bar}  => sub { ... } # Good!
+
+=head2 del
+
+Defines a route for HTTP B<DELETE> requests to the given URL:
+
+    del '/resource' => sub { ... };
+
+=head2 options
+
+Defines a route for HTTP B<OPTIONS> requests to the given URL:
+
+    options '/resource' => sub { ... };
+
+=head2 put
+
+Defines a route for HTTP B<PUT> requests to the given URL:
+
+    put '/resource' => sub { ... };
+
+=head2 redirect
+
+Generates a HTTP redirect (302). You can either redirect to a complete
+different site or within the application:
+
+    get '/twitter', sub {
+        redirect 'http://twitter.com/me';
+        # Any code after the redirect will not be executed.
+    };
+
+B<WARNING:> Issuing a C<redirect> immediately exits the current route.
+Thus, any code after a C<redirect> is ignored, until the end of the route.
+Hence, it's not necessary anymore to use C<return> with C<redirect>.
+
+You can also force Dancer to return a specific 300-ish HTTP response code:
+
+    get '/old/:resource', sub {
+        redirect '/new/'.params->{resource}, 301;
+    };
+
+=head2 request
+
+Returns a L<Dancer2::Core::Request> object representing the current request.
+
+See the L<Dancer2::Core::Request> documentation for the methods you can
+call, for example:
+
+    request->referer;         # value of the HTTP referer header
+    request->remote_address;  # user's IP address
+    request->user_agent;      # User-Agent header value
+
+=head2 send_error
+
+Returns a HTTP error. By default the HTTP code returned is 500:
+
+    get '/photo/:id' => sub {
+        if (...) {
+            send_error("Not allowed", 403);
+        } else {
+           # return content
+        }
+    }
+
+B<WARNING:> Issuing a send_error immediately exits the current route, and
+performs the C<send_error>. Thus, any code after a C<send_error> is ignored,
+until the end of the route. Hence, it's not necessary anymore to use C<return>
+with C<send_error>.
+
+    get '/some/route' => sub {
+        if (...) {
+            # Something bad happened, stop immediately!
+            send_error(..);
+
+            # this code will be ignored
+            do_stuff();
+        }
+    };
+
+=head2 send_file
+
+Lets the current route handler send a file to the client. Note that the path
+of the file must be relative to the B<public> directory unless you use the
+C<system_path> option (see below).
+
+    get '/download/:file' => sub {
+        return send_file(params->{file});
+    }
+
+B<WARNING:> Issuing a C<send_file> immediately exits the current route, and
+performs the C<send_file>. Thus, any code after a C<send_file> is ignored,
+until the end of the route. Hence, it's not necessary anymore to use C<return>
+with C<send_file>.
+
+    get '/some/route' => sub {
+        if (...) {
+            # OK, send her what she wants...
+            send_file(...);
+
+            # this code will be ignored
+            do_stuff();
+        }
+    };
+
+C<send_file> supports streaming possibility using PSGI streaming. The server
+should support it, but normal streaming is supported on most (if not all)
+servers.
+
+    get '/download/:file' => sub {
+        return send_file( params->{file}, streaming => 1 );
+    }
+
+You can control what happens using callbacks.
+
+First, C<around_content> allows you to get the writer object and the chunk
+of content read, and then decide what to do with each chunk:
+
+    get '/download/:file' => sub {
+        return send_file(
+            params->{file},
+            streaming => 1,
+            callbacks => {
+                around_content => sub {
+                    my ( $writer, $chunk ) = @_;
+                    $writer->write("* $chunk");
+                },
+            },
+        );
+    }
+
+You can use C<around> to get all the content (whether a filehandle if it's a
+regular file or a full string if it's a scalar ref) and decide what to do
+with it:
+
+    get '/download/:file' => sub {
+        return send_file(
+            params->{file},
+            streaming => 1,
+            callbacks => {
+                around => sub {
+                    my ( $writer, $content ) = @_;
+
+                    # we know it's a text file, so we'll just stream
+                    # line by line
+                    while ( my $line = <$content> ) {
+                        $writer->write($line);
+                    }
+                },
+            },
+        );
+    }
+
+Or you could use C<override> to control the entire streaming callback
+request:
+
+    get '/download/:file' => sub {
+        return send_file(
+            params->{file},
+            streaming => 1,
+            callbacks => {
+                override => sub {
+                    my ( $respond, $response ) = @_;
+
+                    my $writer = $respond->( [ $newstatus, $newheaders ] );
+                    $writer->write("some line");
+                },
+            },
+        );
+    }
+
+You can also set the number of bytes that will be read at a time (default
+being 42K bytes) using C<bytes>:
+
+    get '/download/:file' => sub {
+        return send_file(
+            params->{file},
+            streaming => 1,
+            bytes     => 524288, # 512K
+        );
+    };
+
+The content-type will be set depending on the current MIME types definition
+(see C<mime> if you want to define your own).
+
+If your filename does not have an extension, or you need to force a specific
+mime type, you can pass it to C<send_file> as follows:
+
+    return send_file(params->{file}, content_type => 'image/png');
+
+Also, you can use your aliases or file extension names on C<content_type>,
+like this:
+
+    return send_file(params->{file}, content_type => 'png');
+
+For files outside your B<public> folder, you can use the C<system_path>
+switch. Just bear in mind that its use needs caution as it can be dangerous.
+
+   return send_file('/etc/passwd', system_path => 1);
+
+If you have your data in a scalar variable, C<send_file> can be useful as
+well. Pass a reference to that scalar, and C<send_file> will behave as if
+there was a file with that contents:
+
+   return send_file( \$data, content_type => 'image/png' );
+
+Note that Dancer is unable to guess the content type from the data contents.
+Therefore you might need to set the C<content_type> properly. For this kind
+of usage an attribute named C<filename> can be useful. It is used as the
+Content-Disposition header, to hint the browser about the filename it should
+use.
+
+   return send_file( \$data, content_type => 'image/png'
+                             filename     => 'onion.png' );
+
+Note that you should always use C<return send_file ...> to stop execution of
+your route handler at that point.
+
+=head2 set
+
+Defines a setting:
+
+    set something => 'value';
+
+You can set more than one value at once:
+
+    set something => 'value', otherthing => 'othervalue';
+
+=head2 setting
+
+Returns the value of a given setting:
+
+    setting('something'); # 'value'
+
+=head2 session
+
+Provides access to all data stored in the user's session (if any).
+
+It can also be used as a setter to store data in the session:
+
+    # getter example
+    get '/user' => sub {
+        if (session('user')) {
+            return "Hello, ".session('user')->name;
+        }
+    };
+
+    # setter example
+    post '/user/login' => sub {
+        ...
+        if ($logged_in) {
+            session user => $user;
+        }
+        ...
+    };
+
+You may also need to clear a session:
+
+    # destroy session
+    get '/logout' => sub {
+        ...
+        app->destroy_session;
+        ...
+    };
+
+If you need to fetch the session ID being used for any reason:
+
+    my $id = session->id;
+
+
+=head2 splat
+
+Returns the list of captures made from a route handler with a route pattern
+which includes wildcards:
+
+    get '/file/*.*' => sub {
+        my ($file, $extension) = splat;
+        ...
+    };
+
+There is also the extensive splat (A.K.A. "megasplat"), which allows
+extensive greedier matching, available using two asterisks. The additional
+path is broken down and returned as an arrayref:
+
+    get '/entry/*/tags/**' => sub {
+        my ( $entry_id, $tags ) = splat;
+        my @tags = @{$tags};
+    };
+
+The C<splat> keyword in the above example for the route F</entry/1/tags/one/two>
+would set C<$entry_id> to C<1> and C<$tags> to C<['one', 'two']>.
+
+=head2 start
+
+Starts the application or the standalone server (depending on the deployment
+choices).
+
+This keyword should be called at the very end of the script, once all routes
+are defined. At this point, Dancer2 takes over.
+
+=head2 to_app
+
+Returns the PSGI coderef for the current (and only the current) application.
+
+You can call it as a method on the class or as a DSL:
+
+    my $app = MyApp->to_app;
+
+    # or
+
+    my $app = to_app;
+
+There is a
+L<Dancer Advent Calendar article|http://advent.perldancer.org/2014/9> covering
+this keyword and its usage further.
+
+=head2 psgi_app
+
+Provides the same functionality as C<to_app> but uses the deprecated
+Dispatcher engine. You should use C<to_app>.
+
+=head2 status
+
+Changes the status code provided by an action. By default, an action will
+produce an C<HTTP 200 OK> status code, meaning everything is OK:
+
+    get '/download/:file' => {
+        if (! -f params->{file}) {
+            status 'not_found';
+            return "File does not exist, unable to download";
+        }
+        # serving the file...
+    };
+
+In that example, Dancer will notice that the status has changed, and will
+render the response accordingly.
+
+The C<status> keyword receives either a numeric status code or its name in
+lower case, with underscores as a separator for blanks - see the list in
+L<Dancer2::Core::HTTP/"HTTP CODES">. As an example, The above call translates
+to setting the code to C<404>.
+
+=head2 template
+
+Returns the response of processing the given template with the given
+parameters (and optional settings), wrapping it in the default or specified
+layout too, if layouts are in use.
+
+An example of a  route handler which returns the result of using template to
+build a response with the current template engine:
+
+    get '/' => sub {
+        ...
+        return template 'some_view', { token => 'value'};
+    };
+
+Note that C<template> simply returns the content, so when you use it in a
+route handler, if execution of the route handler should stop at that point,
+make sure you use C<return> to ensure your route handler returns the content.
+
+Since C<template> just returns the result of rendering the template, you can
+also use it to perform other templating tasks, e.g. generating emails:
+
+    post '/some/route' => sub {
+        if (...) {
+            email {
+                to      => 'someone@example.com',
+                from    => 'foo@example.com',
+                subject => 'Hello there',
+                msg     => template('emails/foo', { name => params->{name} }),
+            };
+
+            return template 'message_sent';
+        } else {
+            return template 'error';
+        }
+    };
+
+Compatibility notice: C<template> was changed in version 1.3090 to
+immediately interrupt execution of a route handler and return the content,
+as it's typically used at the end of a route handler to return content.
+However, this caused issues for some people who were using C<template> to
+generate emails etc, rather than accessing the template engine directly, so
+this change has been reverted in 1.3091.
+
+The first parameter should be a template available in the views directory,
+the second one (optional) is a hashref of tokens to interpolate, and the
+third (again optional) is a hashref of options.
+
+For example, to disable the layout for a specific request:
+
+    get '/' => sub {
+        template 'index', {}, { layout => undef };
+    };
+
+Or to request a specific layout, of course:
+
+    get '/user' => sub {
+        template 'user', {}, { layout => 'user' };
+    };
+
+Some tokens are automatically added to your template (C<perl_version>,
+C<dancer_version>, C<settings>, C<request>, C<params>, C<vars> and, if you
+have sessions enabled, C<session>). Check L<Dancer2::Core::Role::Template>
+for further details.
+
+=head2 to_dumper ($structure)
+
+Serializes a structure with Data::Dumper.
+
+Calling this function will B<not> trigger the serialization's hooks.
+
+=head2 to_json ($structure, \%options)
+
+Serializes a structure to JSON. Can receive optional arguments. Those
+arguments are valid L<JSON> arguments to change the behaviour of the default
+C<JSON::to_json> function.
+
+Calling this function will B<not> trigger the serialization's hooks.
+
+=head2 to_yaml ($structure)
+
+Serializes a structure to YAML.
+
+Calling this function will B<not> trigger the serialization's hooks.
+
+=head2 true
+
+Constant that returns a true value (1).
+
+=head2 upload
+
+Provides access to file uploads. Any uploaded file is accessible as a
+L<Dancer2::Core::Request::Upload> object. You can access all parsed uploads
+via:
+
+    post '/some/route' => sub {
+        my $file = upload('file_input_foo');
+        # $file is a Dancer2::Core::Request::Upload object
+    };
+
+If you named multiple inputs of type "file" with the same name, the C<upload>
+keyword would return an Array of L<Dancer2::Core::Request::Upload> objects:
+
+    post '/some/route' => sub {
+        my ($file1, $file2) = upload('files_input');
+        # $file1 and $file2 are Dancer2::Core::Request::Upload objects
+    };
+
+You can also access the raw hashref of parsed uploads via the current
+C<request> object:
+
+    post '/some/route' => sub {
+        my $all_uploads = request->uploads;
+        # $all_uploads->{'file_input_foo'} is a Dancer2::Core::Request::Upload object
+        # $all_uploads->{'files_input'} is an arrayref of Dancer2::Core::Request::Upload objects
+    };
+
+Note that you can also access the filename of the upload received via the
+C<params> keyword:
+
+    post '/some/route' => sub {
+        # params->{'files_input'} is the filename of the file uploaded
+    };
+
+See L<Dancer2::Core::Request::Upload> for details about the interface provided.
+
+=head2 uri_for
+
+Returns a fully-qualified URI for the given path:
+
+    get '/' => sub {
+        redirect uri_for('/path');
+        # can be something like: http://localhost:3000/path
+    };
+
+=head2 captures
+
+Returns a reference to a copy of C<%+>, if there are named captures in the
+route's regular expression.
+
+Named captures are a feature of Perl 5.10, and are not supported in earlier
+versions:
+
+    get qr{
+        / (?<object> user   | ticket | comment )
+        / (?<action> delete | find )
+        / (?<id> \d+ )
+        /?$
+    }x
+    , sub {
+        my $value_for = captures;
+        "i don't want to $$value_for{action} the $$value_for{object} $$value_for{id} !"
+    };
+
+
+=head2 var
+
+Provides an accessor for variables shared between hooks and route
+handlers. Given a key/value pair, it sets a variable:
+
+    hook before => sub {
+        var foo => 42;
+    };
+
+Later, route handlers and other hooks will be able to read that variable:
+
+    get '/path' => sub {
+        my $foo = var 'foo';
+        ...
+    };
+
+=head2 vars
+
+Returns the hashref of all shared variables set during the hook/route
+chain with the C<var> keyword:
+
+    get '/path' => sub {
+        if (vars->{foo} eq 42) {
+            ...
+        }
+    };
+
+=head2 warning
+
+Logs a warning message through the current logger engine:
+
+    warning "This is a warning";
+
+See L<Dancer2::Core::Role::Logger> for details on how to configure where log
+messages go.

--- a/lib/Dancer2/Manual.pod
+++ b/lib/Dancer2/Manual.pod
@@ -879,55 +879,6 @@ settings within its config file, for instance:
 This makes keeping your application's settings all in one place simple and
 easy - you shouldn't need to worry about implementing all that yourself :)
 
-=head3 From a separate script
-
-You may want to access your webapp's configuration from outside your
-webapp. You could, of course, use the YAML module of your choice and load
-your webapps's C<config.yml>, but chances are that this is not convenient.
-
-Use Dancer2 instead. You can simply use
-the values from C<config.yml> and some additional default values:
-
-    # bin/show_app_config.pl
-    use Dancer2;
-    print "template:".config->{template}."\n"; # simple
-    print "log:".config->{log}."\n"; # undef
-
-Note that C<< config->{log} >> should result in an uninitialized warning
-on a default scaffold since the environment isn't loaded and
-log is defined in the environment and not in C<config.yml>. Hence C<undef>.
-
-Dancer2 will load your C<config.yml> configuration file along with the
-correct environment file located in your C<environments> directory.
-
-The environment is determined by two environment variables in the following
-order:
-
-=over 4
-
-=item * DANCER_ENVIRONMENT
-
-=item * PLACK_ENV
-
-=back
-
-If neither of those is set, it will default to loading the development
-environment (typically C<$webapp/environment/development.yml>).
-
-If you wish to load a different environment, you need to override these
-variables.
-
-You can call your script with the environment changed:
-
-    $ PLACK_ENV=production perl bin/show_app_config.pl
-
-Or you can override them directly in the script (less recommended):
-
-    BEGIN { $ENV{'DANCER_ENVIRONMENT'} = 'production' }
-    use Dancer2;
-
-    ...
-
 =head2 Settings
 
 It's possible to change almost every parameter of the application via the

--- a/lib/Dancer2/Manual.pod
+++ b/lib/Dancer2/Manual.pod
@@ -312,6 +312,133 @@ This is done with the B<pass> keyword, like in the following example
     get '/say/:number' => sub {
         "I say a number: ".params->{number};
     };
+    
+    
+=head1 HOOKS
+
+Hooks are code references (or anonymous subroutines) that are triggered at
+specific moments during the resolution of a request.
+
+Many of them are supported by the core but plugins and engines can also
+define their own.
+
+=head2 Request workflow
+
+C<before> hooks are evaluated before each request within the context of the
+request and receives as argument the app (a L<Dancer2::Core::App> object).
+
+It's possible to define variables which will be accessible in the action
+blocks with the keyword C<var>.
+
+    hook before => sub {
+        var note => 'Hi there';
+    };
+
+    get '/foo/*' => sub {
+        my ($match) = splat; # 'oversee';
+        vars->{note}; # 'Hi there'
+    };
+
+For another example, this can be used along with session support to easily
+give non-logged-in users a login page:
+
+    hook before => sub {
+        if (!session('user') && request->dispatch_path !~ m{^/login}) {
+            # Pass the original path requested along to the handler:
+            forward '/login', { requested_path => request->dispatch_path };
+        }
+    };
+
+The request keyword returns the current L<Dancer2::Core::Request> object
+representing the incoming request.
+
+C<after> hooks are evaluated after the response has been built by a route
+handler, and can alter the response itself, just before it's sent to the
+client.
+
+This hook runs after a request has been processed, but before the response
+is sent.
+
+It receives a L<Dancer2::Core::Response> object, which it can modify if it
+needs to make changes to the response which is about to be sent.
+
+The hook is given the response object as its first argument:
+
+    hook after => sub {
+        content q{The "after" hook can alter the response's content here!};
+    };
+
+=head2 Templates
+
+C<before_template_render> hooks are called whenever a template is going to
+be processed, they are passed the tokens hash which they can alter.
+
+    hook before_template_render => sub {
+        my $tokens = shift;
+        $tokens->{foo} = 'bar';
+    }
+
+The tokens hash will then be passed to the template with all the
+modifications performed by the hook. This is a good way to setup some
+global vars you like to have in all your templates, like the name of the
+user logged in or a section name.
+
+C<after_template_render> hooks are called after the view has been rendered.
+They receive as their first argument the reference to the content that has
+been produced. This can be used to post-process the content rendered by the
+template engine.
+
+    hook after_template_render => sub {
+        my $ref_content = shift;
+        my $content     = ${$ref_content};
+
+        # do something with $content
+        $ref_content = \$content;
+    };
+
+C<before_layout_render> hooks are called whenever the layout is going to be
+applied to the current content. The arguments received by the hook are the
+current tokens hashref and a reference to the current content.
+
+    hook before_layout_render => sub {
+        my ($tokens, $ref_content) = @_;
+        $tokens->{new_stuff} = 42;
+        $ref_content = \"new content";
+    };
+
+C<after_layout_render> hooks are called once the complete content of the
+view has been produced, after the layout has been applied to the content.
+The argument received by the hook is a reference to the complete content
+string.
+
+    hook after_layout_render => sub {
+        my $ref_content = shift;
+        # do something with ${ $ref_content }, which reflects directly
+        #   in the caller
+    };
+
+=head2 L<Error Handling|https://github.com/SnigdhaD/Dancer2/blob/snigdha/lib/Dancer2/Manual.pod#error-handling>
+
+=head2 File Rendering
+
+=head2 Serializers
+
+C<before_serializer> is called before serializing the content, and receives
+the content to serialize as an argument.
+
+  hook before_serializer => sub {
+    my $content = shift;
+    ...
+  };
+
+C<after_serializer> is called after the payload has been serialized, and
+receives the serialized content as an argument.
+
+  hook after_serializer => sub {
+    my $serialized_content = shift;
+    ...
+  };
+
 
 =head1 SESSIONS
 

--- a/lib/Dancer2/Manual.pod
+++ b/lib/Dancer2/Manual.pod
@@ -475,6 +475,105 @@ receives the serialized content as an argument.
   };
 
 
+=head1 HANDLERS
+
+=head2 File Handler
+
+Whenever a content is produced out of the parsing of a static file, the
+L<Dancer2::Handler::File> component is used. This component provides two
+hooks, C<before_file_render> and C<after_file_render>.
+
+C<before_file_render> hooks are called just before starting to parse the
+file, the hook receives as its first argument the file path that is going to
+be processed.
+
+    hook before_file_render => sub {
+        my $path = shift;
+    };
+
+C<after_file_render> hooks are called after the file has been parsed and the
+response content produced. It receives the response object
+(L<Dancer2::Core::Response>) produced.
+
+    hook after_file_render => sub {
+       my $response = shift;
+    };
+    
+=head2 Auto page
+
+Whenever a page that matches an existing template needs to be served, the
+L<Dancer2::Handler::AutoPage> component is used.
+
+=head2 Writing your own
+
+A route handler is a class that consumes the L<Dancer::Core::Role::Handler> 
+role. The class must implement a set of methods: C<methods>, C<regexp> and 
+C<code> which will be used to declare the route.
+
+Let's look at LDancer::Handler::AutoPage> for example.
+
+First, the matching methods are C<get> and C<head>:
+
+    sub methods { qw(head get) }
+
+Then, the C<regexp> or the I<path> we want to match:
+
+    sub regexp { '/:page' }
+    
+Anything will be matched by this route, since we want to check if there's 
+a view named with the value of the C<page> token. If not, the route needs 
+to C<pass>, letting the dispatching flow to proceed further.
+
+    sub code {
+        sub {
+            my $ctx = shift;
+    
+            my $template = $ctx->app->config->{template};
+            if (! defined $template) {
+                $ctx->response->has_passed(1);
+                return;
+            }
+    
+            my $page = $ctx->request->params->{'page'};
+            my $view_path = $template->view($page);
+            if (! -f $view_path) {
+                $ctx->response->has_passed(1);
+                return;
+            }
+    
+            my $ct = $template->process($page);
+            $ctx->response->header('Content-Length', length($ct));
+            return ($ctx->request->method eq 'GET') ? $ct : '';
+        };
+    }
+    
+The C<code> method passed the L<Dancer::Core::Context> object which provides 
+access to anything needed to process the request.
+
+A C<register> is then implemented to add the route to the registry and if 
+the C<auto_page setting> is off, it does nothing.
+
+    sub register {
+        my ($self, $app) = @_;
+    
+        return unless $app->config->{auto_page};
+    
+        $app->add_route(
+            method => $_,
+            regexp => $self->regexp,
+            code   => $self->code,
+        ) for $self->methods;
+    }
+
+The config parser looks for a C<route_handlers> section and any handler defined 
+there is loaded. Thus, any random handler can be added to your app.
+For example, the default config file for any Dancer2 application is as follows:
+
+    route_handlers:
+      File:
+        public_dir: /path/to/public
+      AutoPage: 1
+
 =head1 SESSIONS
 
 =head2 Handling sessions

--- a/lib/Dancer2/Manual.pod
+++ b/lib/Dancer2/Manual.pod
@@ -695,6 +695,79 @@ To conclude, an C<after> filter is set to call the flush method of the storage b
 
 The code for this can be found on L<Github|https://github.com/sukria/Dancer-Session-Redis/blob/master/lib/Dancer/Session/Redis.pm>
 
+
+=head1 ERRORS
+
+=head2 Default Error Pages
+
+When an error is rendered (the action responded with a status code different
+than 200), Dancer2 first looks in the public directory for an HTML file
+matching the error code (eg: 500.html or 404.html).
+
+If such a file exists, it's used to render the error, otherwise, a default
+error page will be rendered on the fly.
+
+=head2 Execution Errors
+
+When an error occurs during the route execution, Dancer2 will render an
+error page with the HTTP status code 500.
+
+It's possible either to display the content of the error message or to hide
+it with a generic error page.
+
+This is a choice left to the end-user and can be set with the B<show_errors>
+setting.
+
+Note that you can also choose to consider all warnings in your route
+handlers as errors when the setting B<warnings> is set to 1.
+
+=head2 Error handling
+
+When an error is caught by Dancer2's core, an exception object is built (of
+the class L<Dancer2::Core::Error>). This class provides a hook to let the
+user alter the error workflow if needed.
+
+C<init_error> hooks are called whenever an error object is built, the object
+is passed to the hook.
+
+    hook init_error => sub {
+        my $error = shift;
+        # do something with $error
+    };
+
+I<This hook was named B<before_error_init> in Dancer, both names currently
+are synonyms for backward-compatibility.>
+
+C<before_error> hooks are called whenever an error is going to be thrown, it
+receives the error object as its sole argument.
+
+    hook before_error => sub {
+        my $error = shift;
+        # do something with $error
+    };
+
+I<This hook was named B<before_error_render> in Dancer, both names currently
+are synonyms for backward-compatibility.>
+
+C<after_error> hooks are called whenever an error object has been thrown, it
+receives a L<Dancer2::Core::Response> object as its sole argument.
+
+    hook after_error => sub {
+        my $response = shift;
+    };
+
+I<This hook was named B<after_error_render> in Dancer, both names currently
+are synonyms for backward-compatibility.>
+
+C<on_route_exception> is called when an exception has been caught, at the
+route level, just before rethrowing it higher. This hook receives a
+L<Dancer2::Core::App> and the error as arguments.
+
+  hook on_route_exception => sub {
+    my ($app, $error) = @_;
+  };
+  
+
 =head1 TEMPLATES
 
 Returning plain content is all well and good for examples or trivial apps,

--- a/lib/Dancer2/Manual.pod
+++ b/lib/Dancer2/Manual.pod
@@ -1,21 +1,22 @@
 # ABSTRACT: A gentle introduction to Dancer2
 package Dancer2::Manual;
 
-=encoding utf8
-
 =pod
+
+=encoding utf8
 
 =head1 DESCRIPTION
 
 Dancer2 is a free and open source web application framework written in Perl.
 
-It's a complete rewrite of L<Dancer>, based on L<Moo> and using a more robust
-and extensible fully-OO design.
+It's a complete rewrite of L<Dancer>, based on L<Moo> and using a more
+robust and extensible fully-OO design.
 
-It's designed to be powerful and flexible, but also easy to use - getting up and
-running with your web app is trivial, and an ecosystem of adaptors for common
-template engines, session storage, logging methods and plugins to make
-common tasks easy mean you can do what you want to do, your way, easily.
+It's designed to be powerful and flexible, but also easy to use - getting up
+and running with your web app is trivial, and an ecosystem of adaptors for
+common template engines, session storage, logging methods, serializers, and
+plugins to make common tasks easy means you can do what you want to do, your
+way, easily.
 
 =head1 INSTALL
 
@@ -23,9 +24,9 @@ Installation of Dancer2 is simple:
 
     perl -MCPAN -e 'install Dancer2'
 
-Thanks to the magic of cpanminus, if you do not have CPAN.pm configured, or just
-want a quickfire way to get running, the following should work, at least on
-Unix-like systems:
+Thanks to the magic of cpanminus, if you do not have CPAN.pm configured, or
+just want a quickfire way to get running, the following should work, at
+least on Unix-like systems:
 
     wget -O - http://cpanmin.us | sudo perl - Dancer2
 
@@ -36,45 +37,63 @@ Dancer2 and prereqs into C<~/perl5>.)
 
 Create a web application using the dancer script:
 
-    dancer2 -a MyApp && cd MyApp
+    $ dancer2 -a mywebapp && cd mywebapp
+    + mywebapp
+    + mywebapp/config.yml
+    + mywebapp/MANIFEST.SKIP
+    + mywebapp/Makefile.PL
+    + mywebapp/lib
+    + mywebapp/lib/mywebapp.pm
+    + mywebapp/public
+    + mywebapp/public/500.html
+    + mywebapp/public/favicon.ico
+    + mywebapp/public/dispatch.cgi
+    + mywebapp/public/404.html
+    + mywebapp/public/dispatch.fcgi
+    + mywebapp/public/images
+    + mywebapp/public/images/perldancer.jpg
+    + mywebapp/public/images/perldancer-bg.jpg
+    + mywebapp/public/css
+    + mywebapp/public/css/error.css
+    + mywebapp/public/css/style.css
+    + mywebapp/public/javascripts
+    + mywebapp/public/javascripts/jquery.js
+    + mywebapp/t
+    + mywebapp/t/001_base.t
+    + mywebapp/t/002_index_route.t
+    + mywebapp/bin
+    + mywebapp/bin/app.psgi
+    + mywebapp/views
+    + mywebapp/views/index.tt
+    + mywebapp/views/layouts
+    + mywebapp/views/layouts/main.tt
+    + mywebapp/environments
+    + mywebapp/environments/development.yml
+    + mywebapp/environments/production.yml
 
-And voilà! You can now run the web application:
+Because Dancer2 is a L<PSGI> web application framework, you can use the
+C<plackup> tool (provided by L<Plack>) for launching the application:
 
-    bin/app.pl
+    plackup -p 5000 bin/app.psgi
 
 View the web application at:
 
-    http://localhost:3000
-
-Note that as Dancer2 supports the L<PSGI> specification, you can also use the C<plackup> tool
-(provided by L<Plack>) for launching the application:
-
-    plackup ./bin/app.pl -p 5000
+    http://localhost:5000
 
 =head1 USAGE
 
-When Dancer2 is imported to a script, that script becomes a webapp, and at this
-point, all the script has to do is declare a list of B<routes>.  A route
-handler is composed by an HTTP method, a path pattern and a code block.
-C<strict> and C<warnings> pragmas are also imported with Dancer2.
+When Dancer2 is imported to a script, that script becomes a webapp, and at
+this point, all the script has to do is declare a list of B<routes>. A
+route handler is composed by an HTTP method, a path pattern and a code
+block. C<strict> and C<warnings> pragmas are also imported with Dancer2.
 
-The code block given to the route handler has to return a string which will be
-used as the content to render to the client.
+The code block given to the route handler has to return a string which will
+be used as the content to render to the client.
 
-Routes are defined for a given HTTP method. For each method
-supported, a keyword is exported by the module.
+Routes are defined for a given HTTP method. For each method supported, a
+keyword is exported by the module.
 
-The following is an example of a route definition. The route is defined for the
-method 'get', so only GET requests will be honoured by that route:
-
-    get '/hello/:name' => sub {
-        # do something
-
-        return "Hello ".param('name');
-    };
-
-
-=head2 HTTP Methods
+=head2 HTTP methods
 
 Here are some of the standard HTTP methods which you can use to define your
 route handlers.
@@ -84,12 +103,12 @@ route handlers.
 =item B<GET> The GET method retrieves information, and is the most common
 
 GET requests should be used for typical "fetch" requests - retrieving
-information.  They should not be used for requests which change data on the
+information. They should not be used for requests which change data on the
 server or have other effects.
 
-When defining a route handler for the GET method, Dancer2 automatically defines
-a route handler for the HEAD method (in order to honour HEAD requests for each
-of your GET route handlers).
+When defining a route handler for the GET method, Dancer2 automatically
+defines a route handler for the HEAD method (in order to honour HEAD
+requests for each of your GET route handlers).
 
 To define a GET action, use the L<get|Dancer2::Manual/get> keyword.
 
@@ -102,14 +121,13 @@ To define a POST action, use the L<post|Dancer2::Manual/post> keyword.
 To define a PUT action, use the L<put|Dancer2::Manual/put> keyword.
 
 a PUT request should replace the existing resource with that specified - for
-instance - if you wanted to just update an email address for a user, you'd have
-to specify all attributes of the user again; to make a partial update, a
-PATCH request is used.
+instance - if you wanted to just update an email address for a user, you'd
+have to specify all attributes of the user again; to make a partial update,
+a PATCH request is used.
 
 =item B<PATCH> The PATCH method updates some attributes of an existing resource.
 
-To define a PATCH action, use the L<patch|Dancer2::Manual/patch>
-keyword.
+To define a PATCH action, use the L<patch|Dancer2::Manual/patch> keyword.
 
 =item B<DELETE> The DELETE method requests that the origin server delete the
 resource identified by the Request-URI.
@@ -118,74 +136,126 @@ To define a DELETE action, use the L<del|Dancer2::Manual/del> keyword.
 
 =back
 
-To define a route for multiple methods you can also use the special keyword
-B<any>. This example illustrates how to define a route for both GET and
-POST methods:
+=head3 Handling multiple HTTP request methods
+
+Routes can use C<any> to match all, or a specified list of HTTP methods.
+
+The following will match any HTTP request to the path C</myaction>:
+
+    any '/myaction' => sub {
+        # code
+    }
+
+The following will match GET or POST requests to C</myaction>:
 
     any ['get', 'post'] => '/myaction' => sub {
         # code
     };
 
-Or even, a route handler that would match any HTTP methods:
-
-    any '/myaction' => sub {
-        # code
-    };
-
+For convenience, any route which matches GET requests will also match HEAD
+requests.
 
 =head2 Route Handlers
 
 The route action is the code reference declared. It can access parameters
-through the C<params> keyword, which returns a hashref.
-This hashref is a merge of the route pattern matches and the request params.
+through the C<params> keyword, which returns a hashref. This hashref is a
+merge of the route pattern matches and the request params.
 
-You can have more details about how params are built and how to access them in
-the L<Dancer2::Core::Request> documentation.
+You can have more details about how params are built and how to access them
+in the L<Dancer2::Core::Request> documentation.
 
-=head3 Named Matching
+=head3 Declaring Routes
 
-A route pattern can contain one or more tokens (a word prefixed with ':'). Each
-token found in a route pattern is used as a named-pattern match. Any match will
-be set in the params hashref.
-
+To control what happens when a web request is received by your webapp,
+you'll need to declare C<routes>. A route declaration indicates which HTTP
+method(s) it is valid for, the path it matches (e.g. C</foo/bar>), and a
+coderef to execute, which returns the response.
 
     get '/hello/:name' => sub {
-        "Hey ".param('name').", welcome here!";
+        return "Hi there " . params->{name};
     };
 
-Tokens can be optional, for example:
+The above route specifies that, for GET requests to C</hello/...>, the code
+block provided should be executed.
 
-    get '/hello/:name?' => sub {
-        defined param('name') ? "Hello there ".param('name') : "whoever you are!";
+=head3 Retrieving request parameters
+
+The L<params|Dancer2/params> keyword returns a hashref of request
+parameters; these will be parameters supplied on the query string within
+the path itself (with named placeholders) and, for HTTP POST requests, the
+content of the POST body.
+
+=head3 Named parameters in route path declarations
+
+As seen above, you can use C<:somename> in a route's path to capture part of the
+path; this will become available by calling L<params|Dancer2/params>.
+
+So, for a web app where you want to display information on a company, you might
+use something like:
+
+    get '/company/view/:companyid' => sub {
+        my $company_id = params->{companyid};
+        # Look up the company and return appropriate page
     };
 
+=head3 Wildcard path matching and splat
 
-=head3 Wildcards Matching
+You can also declare wildcards in a path and retrieve the values they matched
+with the L<splat|Dancer2/splat> keyword:
 
-A route can contain a wildcard (represented by a C<*>). Each wildcard match will
-be returned in an arrayref, accessible via the C<splat> keyword.
+    get '/*/*' => sub {
+        my ($action, $id) = splat;
+        if (my $action eq 'view') {
+            return display_item($id);
+        } elsif ($action eq 'delete') {
+            return delete_item($id);
+        } else {
+            status 'not_found';
+            return "What?";
+        }
+    };
 
-    get '/download/*.*' => sub {
-        my ($file, $ext) = splat;
-        # do something with $file.$ext here
+=head3 Mixed named and wildcard matching
+
+A route can combine named (token) matching and wildcard matching.
+This is useful when chaining actions:
+
+    get '/team/:team/**' => sub {
+        var team => param('team');
+        pass;
+    };
+
+    prefix '/team/:team';
+
+    get '/player/*' => sub {
+        my ($player) = splat;
+
+        # etc...
+    };
+
+    get '/score' => sub {
+        return score_for( vars->{'team'} );
     };
 
 =head3 Regular Expression Matching
 
 A route can be defined with a Perl regular expression.
 
-In order to tell Dancer2 to consider the route as a real regexp, the route must
-be defined explicitly with C<qr{}>, like the following:
+In order to tell Dancer2 to consider the route as a real regexp, the route
+must be defined explicitly with C<qr{}>, like the following:
 
     get qr{/hello/([\w]+)} => sub {
         my ($name) = splat;
         return "Hello $name";
     };
 
+For Perl 5.10+, a route regex may use named capture groups. The C<captures>
+keyword will return a reference to a copy of C<%+>.
+
 =head3 Conditional Matching
 
-Routes may include some matching conditions (on the useragent and the hostname
-at the moment):
+Routes may include some matching conditions (on content_type, agent,
+user_agent, content_length and path_info):
 
     get '/foo', {agent => 'Songbird (\d\.\d)[\d\/]*?'} => sub {
       'foo method for songbird'
@@ -210,8 +280,8 @@ You can unset the prefix value
     prefix '/'; # or: prefix undef;
     get '/page1' => sub {}; # will match /page1
 
-Alternatively, to prevent you from ever forgetting to undef the prefix,
-you can use lexical prefix like this:
+Alternatively, to prevent you from ever forgetting to undef the prefix, you
+can use lexical prefix like this:
 
     prefix '/home' => sub {
       get '/page1' => sub {}; # will match '/home/page1'
@@ -221,8 +291,8 @@ you can use lexical prefix like this:
 
 =head2 Action Skipping
 
-An action can choose not to serve the current request and ask Dancer2 to process
-the request with the next matching route.
+An action can choose not to serve the current request and ask Dancer2 to
+process the request with the next matching route.
 
 This is done with the B<pass> keyword, like in the following example
 
@@ -235,245 +305,550 @@ This is done with the B<pass> keyword, like in the following example
         "I say a number: ".params->{number};
     };
 
+=head1 SESSIONS
 
+=head2 Handling sessions
 
-=head2 Default Error Pages
+It's common to want to use sessions to give your web applications state; for
+instance, allowing a user to log in, creating a session, and checking that
+session on subsequent requests.
 
-When an error is rendered (the action responded with a status code different
-than 200), Dancer2 first looks in the public directory for an HTML file matching
-the error code (eg: 500.html or 404.html).
+To make use of sessions, you must first enable the session engine - pick the
+session engine you want to use, then declare it in your config file like
+this:
 
-If such a file exists, it's used to render the error, otherwise, a default
-error page will be rendered on the fly.
+    session: Simple
 
-=head2 Execution Errors
+The L<Dancer2::Session::Simple> backend implements very simple in-memory
+session storage. This will be fast and useful for testing, but such sessions
+will not persist between restarts of your app.
 
-When an error occurs during the route execution, Dancer2 will render an error
-page with the HTTP status code 500.
+You can also use the L<Dancer2::Session::YAML> backend included with
+Dancer2, which stores session data on disc in YAML files (since YAML is a
+nice human-readable format, it makes inspecting the contents of sessions a
+breeze):
 
-It's possible either to display the content of the error message or to hide it
-with a generic error page.
+    session: YAML
 
-This is a choice left to the end-user and can be set with the
-B<show_errors> setting.
+Or, to enable session support from within your code,
 
-Note that you can also choose to consider all warnings in your route handlers
-as errors when the setting B<warnings> is set to 1.
+    set session => 'YAML';
 
-=head1 HOOKS
+However, controlling settings is best done from your config file.
 
-Hooks are code references (or anonymous subroutines) that are triggered at
-specific moments during the resolution of a request.
+'YAML' in the example is the session backend to use; this is shorthand for
+L<Dancer2::Session::YAML>. There are other session backends - for instance
+L<Dancer2::Session::Memcached> - but the YAML backend is simple and easy to
+use.
 
-Many of them are supported by the core but plugins and engines can also
-define their own.
+You can then use the L<session|Dancer2/session> keyword to manipulate the
+session:
 
+=head3 Storing data in the session
 
-=head2 Request workflow
+Storing data in the session is as easy as:
 
-C<before> hooks are evaluated before each request within the context of the
-request and receives as argument the app (a L<Dancer2::Core::App>
-object).
+    session varname => 'value';
 
-It's possible to define variables which will be accessible in the action blocks
-with the keyword C<var>.
+=head3 Retrieving data from the session
 
-    hook before => sub {
-        var note => 'Hi there';
-    };
+Retrieving data from the session is as easy as:
 
-    get '/foo/*' => sub {
-        my ($match) = splat; # 'oversee';
-        vars->{note}; # 'Hi there'
-    };
+    session('varname')
 
-For another example, this can be used along with session support to easily
-give non-logged-in users a login page:
+Or, alternatively,
+
+    session->read("varname")
+
+=head3 Controlling where sessions are stored
+
+For disc-based session backends like L<Dancer2::Session::YAML>,
+L<Dancer2::Session::Storable> etc., session files are written to the session
+dir specified by the C<session_dir> setting, which defaults to C<./sessions>
+if not specifically set.
+
+If you need to control where session files are created, you can do so
+quickly and easily within your config file, for example:
+
+    session: YAML
+    engines:
+      session:
+        YAML:
+          session_dir: /tmp/dancer-sessions
+
+If the directory you specify does not exist, Dancer2 will attempt to create
+it for you.
+
+=head3 Destroying a session
+
+When you're done with your session, you can destroy it:
+
+    app->destroy_session
+
+=head2 Sessions and logging in
+
+A common requirement is to check the user is logged in, and, if not, require
+them to log in before continuing.
+
+This can easily be handled using a before hook to check their session:
+
+    use Dancer2;
+    set session => "Simple";
 
     hook before => sub {
         if (!session('user') && request->dispatch_path !~ m{^/login}) {
-            # Pass the original path requested along to the handler:
             forward '/login', { requested_path => request->dispatch_path };
         }
     };
 
-The request keyword returns the current L<Dancer2::Core::Request> object
-representing the incoming request.
+    get '/' => sub { return "Home Page"; };
 
-C<after> hooks are evaluated after the response has been built by a route
-handler, and can alter the response itself, just before it's sent to the
-client.
+    get '/secret' => sub { return "Top Secret Stuff here"; };
 
-This hook runs after a request has been processed, but before the response is
-sent.
-
-It receives a L<Dancer2::Core::Response> object, which it can modify
-if it needs to make changes to the response which is about to be sent.
-
-The filter is given the response object as its first argument:
-
-    hook after => sub {
-        my $response = shift;
-        $response->(content, 'after filter got here!');
+    get '/login' => sub {
+        # Display a login page; the original URL they requested is available as
+        # param('requested_path'), so could be put in a hidden field in the form
+        template 'login', { path => param('requested_path') };
     };
 
-=head2 Templates
+    post '/login' => sub {
+        # Validate the username and password they supplied
+        if (param('user') eq 'bob' && param('pass') eq 'letmein') {
+            session user => param('user');
+            redirect param('path') || '/';
+        } else {
+            redirect '/login?failed=1';
+        }
+    };
 
-C<before_template_render> hooks are called whenever a template is going to be
-processed, they are passed the tokens hash which they can alter.
+    dance();
+
+Here is what the corresponding C<login.tt> file should look like. You should
+place it in a directory called C<views/>:
+
+    <html>
+      <head>
+        <title>Session and logging in</title>
+      </head>
+      <body>
+        <form action='/login' method='POST'>
+            User Name : <input type='text' name='user'/>
+            Password: <input type='password' name='pass' />
+
+            <!-- Put the original path requested into a hidden
+                       field so it's sent back in the POST and can be
+                       used to redirect to the right page after login -->
+            <input type='hidden' name='path' value='[% path %]'/>
+
+            <input type='submit' value='Login' />
+        </form>
+      </body>
+    </html>
+
+Of course, you'll probably want to validate your users against a database
+table, or maybe via IMAP/LDAP/SSH/POP3/local system accounts via PAM etc.
+L<Authen::Simple> is probably a good starting point here!
+
+A simple working example of handling authentication against a database table
+yourself (using L<Dancer2::Plugin::Database> which provides the C<database>
+keyword, and L<Crypt::SaltedHash> to handle salted hashed passwords (well,
+you wouldn't store your users passwords in the clear, would you?)) follows:
+
+    post '/login' => sub {
+        my $user = database->quick_select('users',
+            { username => params->{user} }
+        );
+        if (!$user) {
+            warning "Failed login for unrecognised user " . params->{user};
+            redirect '/login?failed=1';
+        } else {
+            if (Crypt::SaltedHash->validate($user->{password}, params->{pass}))
+            {
+                debug "Password correct";
+                # Logged in successfully
+                session user => $user;
+                redirect params->{path} || '/';
+            } else {
+                debug("Login failed - password incorrect for " . params->{user});
+                redirect '/login?failed=1';
+            }
+        }
+    };
+
+=head3 Retrieve complete hash stored in session
+
+Get complete hash stored in session:
+
+    my $hash = session;
+
+=head2 Writing a session engine
+
+In Dancer 2, a session backend consumes the role 
+L<Dancer::Core::Role::SessionFactory>.
+
+The following example using the Reddis session demonstrates how session
+engines are written in Dancer 2.
+
+First thing to do is to create the class for the session engine, 
+we'll name it C<Dancer::Session::Redis>:
+
+     package Dancer::Session::Redis;
+     use Moo;
+     with 'Dancer::Core::Role::SessionFactory';
+
+we want our backend to have a handle over a Redis connection. 
+To do that, we'll create an attribute C<redis>
+
+     use JSON;
+     use Redis;
+     use Dancer::Core::Types; # brings helper for types
+
+     has redis => (
+         is => 'rw',
+         isa => InstanceOf['Redis'],
+         lazy => 1,
+         builder => '_build_redis',
+     );
+
+The lazy attribute says to Moo that this attribute will be 
+built (initialized) only when called the first time. It means that  
+the connection to Redis won't be opened until necessary.
+
+     sub _build_redis {
+         my ($self) = @_;
+         Redis->new(
+             server => $self->server,
+             password => $self->password,
+             encoding => undef,
+         );
+     }
+
+Two more attributes, C<server> and C<password> need to be created.
+We do this by defining them in the config file. Dancer2 passes anything
+defined in the config to the engine creation.
+
+     # config.yml
+     ...
+     engines:
+       session:
+         Redis:
+           server: foo.mydomain.com
+           password: S3Cr3t
+
+The server and password entries are now passed to the constructor
+of the Redis session engine and can be accessed from there.
+
+     has server => (is => 'ro', required => 1);
+     has password => (is => 'ro');
+
+Next, we define the subroutine C<_retrieve> which will return a session
+object for a session ID it has passed. Since in this case, sessions are 
+going to be stored in Redis, the session ID will be the key, the session the value. 
+So retrieving is as easy as doing a get and decoding the JSON string returned:
+
+     sub _retrieve {
+         my ($self, $session_id) = @_;
+         my $json = $self->redis->get($session_id);
+         my $hash = from_json( $json );
+         return bless $hash, 'Dancer::Core::Session';
+     }
+
+The C<_flush> method is called by Dancer when the session needs to be stored in 
+the backend. That is actually a write to Redis. The method receives a C<Dancer::Core::Session>
+object and is supposed to store it.
+
+     sub _flush {
+         my ($self, $session) = @_;
+         my $json = to_json( { %{ $session } } );
+         $self->redis->set($session->id, $json);
+     }
+
+For the C<_destroy> method which is supposed to remove a session from the backend,
+deleting the key from Redis is enough.
+
+     sub _destroy {
+         my ($self, $session_id) = @_;
+         $self->redis->del($session_id);
+     }
+
+The C<_sessions> method which is supposed to list all the session IDs currently 
+stored in the backend is done by listing all the keys that Redis has.
+
+     sub _sessions {
+         my ($self) = @_;
+         my @keys = $self->redis->keys('*');
+         return \@keys;
+     }
+
+The session engine is now ready.
+
+=head3 The Session keyword
+
+When Dancer 2 executes a route handler to process a request, it creates a 
+L<Dancer::Core::Context> object. This context is passed to all the 
+components of Dancer that can play with it, to build the response. For instance, 
+a before filter will receive that context object.
+
+The session handle for the current client, is thus found in the context. Thus, 
+the builder only has to look if the client has a dancer.session cookie, and if 
+so, try to retrieve the session from the storage engine, with the value of 
+the cookie (the session ID).
+
+     has session => (
+         is      => 'rw',
+         isa     => Session,
+         lazy    => 1,
+         builder => '_build_session',
+     );
+
+     sub _build_session {
+         my ($self) = @_;
+         my $session;
+
+         # Find the session engine
+         my $engine = $self->app->setting('session');
+         croak "No session engine defined, cannot use session."
+           if ! defined $engine;
+
+         # find the session cookie if any
+         my $session_id;
+         my $session_cookie = $self->cookie('dancer.session');
+         if (defined $session_cookie) {
+             $session_id = $session_cookie->value;
+         }
+
+         # if we have a session cookie, try to retrieve the session
+         if (defined $session_id) {
+             eval { $session = $engine->retrieve(id => $session_id) };
+             croak "Fail to retreive session: $@"
+               if $@ && $@ !~ /Unable to retrieve session/;
+         }
+
+         # create the session if none retrieved
+         return $session ||= $engine->create();
+     }
+
+So the very first time session is called, the object is either retrieved
+from the backend, or a new C<Dancer::Core::Session> is created, and 
+stored in the context.
+Then, a before filter makes sure a cookie dancer.session is added to the headers.
+
+     # Hook to add the session cookie in the headers, if a session is defined
+     $self->add_hook(Dancer::Core::Hook->new(
+         name => 'core.app.before_request',
+         code => sub {
+             my $context = shift;
+
+             # make sure an engine is defined, if not, nothing to do
+             my $engine = $self->setting('session');
+             return if ! defined $engine;
+
+             # push the session in the headers
+             $context->response->push_header('Set-Cookie',
+                 $context->session->cookie->to_header);
+         }
+     ));
+
+At this time, the user's code comes into play, using the session keyword
+
+     sub session {
+         my ($self, $key, $value) = @_;
+
+         my $session = $self->context->session;
+         croak "No session available, a session engine needs to be set"
+             if ! defined $session;
+
+         # return the session object if no key
+         return $session if @_ == 1;
+
+         # read if a key is provided
+         return $session->read($key) if @_ == 2;
+
+         # write to the session
+         $session->write($key => $value);
+     }
+
+To conclude, an C<after> filter is set to call the flush method of the storage backend.
+
+     # Hook to flush the session at the end of the request, this way, we're sure we
+     # flush only once per request
+     $self->add_hook(
+         Dancer::Core::Hook->new(
+             name => 'core.app.after_request',
+             code => sub {
+                 # make sure an engine is defined, if not, nothing to do
+                 my $engine = $self->setting('session');
+                 return if ! defined $engine;
+                 return if ! defined $self->context;
+                 $engine->flush(session => $self->context->session);
+             },
+         )
+     );
+
+The code for this can be found on L<Github|https://github.com/sukria/Dancer-Session-Redis/blob/master/lib/Dancer/Session/Redis.pm>
+
+=head1 TEMPLATES
+
+Returning plain content is all well and good for examples or trivial apps,
+but soon you'll want to use templates to maintain separation between your
+code and your content. Dancer2 makes this easy.
+
+Your route handlers can use the L<template|Dancer2::Manual/template> keyword
+to render templates.
+
+=head2 Views
+
+It's possible to render the action's content with a template, this is called
+a view. The C<appdir/views> directory is the place where views are located.
+
+You can change this location by changing the setting 'views'. For instance
+if your templates are located in the 'templates' directory, do the
+following:
+
+    set views => path(dirname(__FILE__), 'templates');
+
+By default, the internal template engine L<Dancer2::Template::Simple> is
+used, but you may want to upgrade to L<Template
+Toolkit|http://www.template-toolkit.org/>. If you do so, you have to enable
+this engine in your settings as explained in
+L<Dancer2::Template::TemplateToolkit> and you'll also have to import the
+L<Template> module in your application code.
+
+In order to render a view, just call the
+L<template|Dancer2::Manual/template> keyword at the end of the action by
+giving the view name and the HASHREF of tokens to interpolate in the view
+(note that for convenience, the request, session, params and vars are
+automatically accessible in the view, named C<request>, C<session>,
+C<params> and C<vars>) - for example:
+
+    hook before => sub { var time => scalar(localtime) };
+
+    get '/hello/:name' => sub {
+        my $name = params->{name};
+        template 'hello.tt', { name => $name };
+    };
+
+The template C<hello.tt> could contain, for example:
+
+    <p>Hi there, [% name %]!</p>
+    <p>You're using [% request.user_agent %]</p>
+    [% IF session.username %]
+        <p>You're logged in as [% session.username %]</p>
+    [% END %]
+    It's currently [% vars.time %]
+
+For a full list of the tokens automatically added to your template (like
+C<session>, C<request> and C<vars>, refer to
+L<Dancer2::Core::Role::Template>).
+
+By default, views use a F<.tt> extension. This can be overridden by setting
+the C<extension> attribute in the template engine configuration:
+
+    set engines => {
+        template => {
+            template_toolkit => {
+                extension => 'foo',
+            },
+        },
+    };
+
+=head2 Layouts
+
+A layout is a special view, located in the 'layouts' directory (inside the
+views directory) which must have a token named C<content>. That token marks
+the place where to render the action view. This lets you define a global
+layout for your actions, and have each individual view contain only
+specific content. This is a good thing to avoid lots of needless
+duplication of HTML :)
+
+Here is an example of a layout: C<views/layouts/main.tt> :
+
+    <html>
+        <head>...</head>
+        <body>
+        <div id="header">
+        ...
+        </div>
+
+        <div id="content">
+        [% content %]
+        </div>
+
+        </body>
+    </html>
+
+You can tell your app which layout to use with C<layout: name> in the config
+file, or within your code:
+
+    set layout => 'main';
+
+You can control which layout to use (or whether to use a layout at all) for
+a specific request without altering the layout setting by passing an options
+hashref as the third param to the template keyword:
+
+    template 'index.tt', {}, { layout => undef };
+
+If your application is not mounted under root (C</>), you can use a
+C<before_template> hook instead of hardcoding the path into your application for your
+CSS, images and JavaScript:
 
     hook before_template_render => sub {
         my $tokens = shift;
-        $tokens->{foo} = 'bar';
-    }
-
-The tokens hash will then be passed to the template with all the modifications
-performed by the filter. This is a good way to setup some global vars you like
-to have in all your templates, like the name of the user logged in or a
-section name.
-
-C<after_template_render> hooks are called after the view has been rendered. They
-receive as their first argument the reference to the content that has been
-produced. This can be used to post-process the content rendered by the template
-engine.
-
-    hook after_template_render => sub {
-        my $ref_content = shift;
-        my $content = $$ref_content;
-        # do something with $content
-        $ref_content = \$content;
+        $tokens->{uri_base} = request->base->path;
     };
 
-C<before_layout_render> hooks are called whenever the layout is going to be
-applied to the current content. The arguments received by the hook are the
-current tokens hashref and a reference to the current content.
+Then in your layout, modify your CSS inclusion as follows:
 
-    hook before_layout_render => sub {
-        my ($tokens, $ref_content) = @_;
-        $tokens->{new_stuff} = 42;
-        $ref_conent = \"new content";
-    };
+    <link rel="stylesheet" href="[% uri_base %]/css/style.css" />
 
-C<after_layout_render> hooks are called once the complete content of the view
-has been produced, after the layout has been applied to the content. The
-argument received by the hook is a reference to the complete content string.
+From now on you can mount your application wherever you want, without any
+further modification of the CSS inclusion.
 
-    hook after_layout_render => sub {
-        my $ref_content = shift;
-        ...
-    };
+=head2 Encoding
 
-=head2 Error handling
+If you use L<Plack> and have a unicode problem with your Dancer2
+application, don't forget to check if you have set your template engine to
+use unicode, and set the default charset to UTF-8. So, if you are using
+template toolkit, your config file will look like this:
 
-When an error is caught by Dancer2's core, an exception object is built (of the
-class L<Dancer2::Core::Error>). This class provides hook to let the user alter
-the error work-flow if needed.
+    charset: UTF-8
+    engines:
+      template:
+        template_toolkit:
+          ENCODING: utf8
 
-C<init_error> hooks are called whenever an error object is built, the object is
-passed to the hook.
+=head1 FILE UPLOADS
 
-    hook init_error => sub {
-        my $error = shift;
-        # do something with $error
-    };
+=head1 CONFIGURATION
 
-I<This hook was named B<before_error_init> in Dancer, and is now aliased to
-this hook.>
+=head2 Configuration and environments
 
-C<before_error> hooks are called whenever an error is going to be thrown, it
-receives the error object as its first and unique argument.
+Configuring a Dancer2 application can be done in many ways. The easiest one
+(and maybe the dirtiest) is to put all your settings statements at the top
+of your script, before calling the C<dance()> method.
 
-    hook before_error => sub {
-        my $error = shift;
-        # do something with $error
-    };
+Other ways are possible: for example, you can define all your settings in the file
+C<appdir/config.yml>. For this, you must have installed the YAML module, and
+of course, write the config file in YAML.
 
-I<This hook was named B<before_error_render> in Dancer, and is now aliased to
-this hook.>
+That's better than the first option, but it's still not perfect as you can't
+switch easily from an environment to another without rewriting the config
+file.
 
-C<after_error> hooks are called whenever an error object has been thrown, it
-receives a L<Dancer2::Core::Response> object as the first argument.
-
-    hook after_error => sub {
-        my $response = shift;
-    };
-
-I<This hook was named <after_error_render> in Dancer, and is now aliased to
-this hook.>
-
-C<on_route_exception> is called when an exception has been caught, at the
-route level, just before rethrowing it higher. This hook receives a
-L<Dancer2::Core::App> and the error as arguments.
-
-  hook on_route_exception => sub {
-    my ($app, $error) = @_;
-  };
-
-=head2 File rendering
-
-Whenever a content is produced out of the parsing of a static file, the
-L<Dancer2::Handler::File> component is used. This component provides two hooks,
-C<before_file_render> and C<after_file_render>.
-
-C<before_file_render> hooks are called just before starting to parse the file,
-the hook receives as its first argument the file path that is going to be
-processed.
-
-    hook before_file_render => sub {
-        my $path = shift;
-    };
-
-C<after_file_render> are called after the file has been parsed and the response
-content produced. It receives the response object (L<Dancer2::Core::Response>)
-produced.
-
-    hook after_file_render => sub {
-       my $response = shift;
-    };
-
-=head2 Serializers
-
-C<before_serializer> is called before serializing the content, and receives as
-argument the content to serialize.
-
-  hook before_serializer => sub {
-    my $content = shift;
-    ...
-  };
-
-C<after_serializer> is called after the payload was serialized, and receives
-the serialized content as an argument.
-
-  hook after_serializer => sub {
-    my $content = shift;
-    ...
-  };
-
-
-=head1 CONFIGURATION AND ENVIRONMENTS
-
-Configuring a Dancer2 application can be done in many ways. The easiest one (and
-maybe the dirtiest) is to put all your settings statements at the top of
-your script, before calling the dance() method.
-
-Other ways are possible.  You could write all your setting calls in the file
-`appdir/config.yml'. You would, of course, have write the conffile in YAML.
-
-While better than the first option, it's still not perfect.  You can't easily
-switch from an environment to another (for example, from development to
-production) without rewriting the config.yml file.  The best way is to have
-one config.yml file with default global settings, like the following:
+A better solution is to have one C<config.yml> file with default global
+settings, like the following:
 
     # appdir/config.yml
     logger: 'file'
     layout: 'main'
 
-And then write as many environment files as you like in appdir/environments.
-That way, the appropriate environment config file will be loaded according to
-the running environment (if none is specified, 'development' is assumed).
+And then write as many environment files as you like in
+C<appdir/environments>. That way, the appropriate environment config file
+will be loaded according to the running environment (if none is specified,
+it will be 'development').
 
-Note that you can change the running environment using the --environment
-commandline switch.
+Note that you can change the running environment using the C<--environment>
+command line switch.
 
 Typically, you'll want to set the following values in a development config
 file:
@@ -490,1286 +865,941 @@ And in a production one:
     startup_info: 0
     show_errors:  0
 
-Please note that you are not limited to writing configuration files in YAML.
-Dancer2 supports any file format that is supported by L<Config::Any>, such as
-JSON, XML, INI files, and Apache-style config files.
+=head2 Accessing configuration information
 
-=head2 Accessing configuration data
+=head3 From inside your application
 
-A Dancer2 application can access the information from its config file easily with
-the config keyword:
+A Dancer2 application can use the C<config> keyword to easily access the
+settings within its config file, for instance:
 
     get '/appname' => sub {
         return "This is " . config->{appname};
     };
 
+This makes keeping your application's settings all in one place simple and
+easy - you shouldn't need to worry about implementing all that yourself :)
+
+=head3 From a separate script
+
+You may want to access your webapp's configuration from outside your
+webapp. You could, of course, use the YAML module of your choice and load
+your webapps's C<config.yml>, but chances are that this is not convenient.
+
+Use Dancer2 instead. You can simply use
+the values from C<config.yml> and some additional default values:
+
+    # bin/show_app_config.pl
+    use Dancer2;
+    print "template:".config->{template}."\n"; # simple
+    print "log:".config->{log}."\n"; # undef
+
+Note that C<< config->{log} >> should result in an uninitialized warning
+on a default scaffold since the environment isn't loaded and
+log is defined in the environment and not in C<config.yml>. Hence C<undef>.
+
+Dancer2 will load your C<config.yml> configuration file along with the
+correct environment file located in your C<environments> directory.
+
+The environment is determined by two environment variables in the following
+order:
+
+=over 4
+
+=item * DANCER_ENVIRONMENT
+
+=item * PLACK_ENV
+
+=back
+
+If neither of those is set, it will default to loading the development
+environment (typically C<$webapp/environment/development.yml>).
+
+If you wish to load a different environment, you need to override these
+variables.
+
+You can call your script with the environment changed:
+
+    $ PLACK_ENV=production perl bin/show_app_config.pl
+
+Or you can override them directly in the script (less recommended):
+
+    BEGIN { $ENV{'DANCER_ENVIRONMENT'} = 'production' }
+    use Dancer2;
+
+    ...
+
 =head2 Settings
 
-It's possible to change quite every parameter of the application via the
+It's possible to change almost every parameter of the application via the
 settings mechanism.
 
-A setting is key/value pair assigned by the keyword B<set>:
+A setting is a key/value pair assigned by the keyword B<set>:
 
     set setting_name => 'setting_value';
 
 More usefully, settings can be defined in a configuration file.
-Environment-specific settings can also be defined in environment-specific files
-(for instance, you do not want to show error stacktraces in production, and might want extra
-logging in development).  See the cookbook for examples.
+Environment-specific settings can also be defined in environment-specific
+files (for instance, you do not want to show error stacktraces in
+production, and might want extra logging in development).
 
-=head2 Serializers
+=head2 Importing using Appname
 
-When writing a webservice, data serialization/deserialization is a common issue
-to deal with. Dancer2 can automatically handle that for you, via a serializer.
+An app in Dancer2 uses the class name (defined by the C<package> function) to
+define the App name. Thus separating the App to multiple files, actually means
+creating multiple applications. This means that any engine defined in an application, 
+because the application is a complete separate scope, will not be available to a 
+different application:
 
-When setting up a serializer, a new behaviour is authorized for any route
-handler you define: any non-scalar response will be rendered as a serialized
-string, via the current serializer.
+     package MyApp::User {
+         use Dancer2;
+         set serializer => 'JSON';
+         get '/view' => sub {...};
+     }
 
-Here is an example of a route handler that will return a HashRef
+     package MyApp::User::Edit {
+         use Dancer2;
+         get '/edit' => sub {...};
+     }
 
-    use Dancer2;
-    set serializer => 'JSON';
+These are two different Dancer2 Apps. They have different scopes, contexts, 
+and thus different engines. While C<MyApp::User> has a serializer defined, 
+C<MyApp::User::Edit> will not have that configuration.
 
-    get '/user/:id/' => sub {
-        { foo => 42,
-          number => 100234,
-          list => [qw(one two three)],
-        }
-    };
+By using the import option C<appname>, we can ask Dancer2 to extend an 
+App without creating a new one:
 
-As soon as the content is not a scalar - and a serializer is set, which is not
-the case by default - Dancer2 renders the response via the current
-serializer.
+     package MyApp::User {
+         use Dancer2;
+         set serializer => 'JSON';
+         get '/view' => sub {...};
+     }
 
-Hence, with the JSON serializer set, the route handler above would result in a
-content like the following:
+     package MyApp::User::Edit {
+         use Dancer2 appname => 'MyApp::User'; # extending MyApp::User
+         get '/edit' => sub {...};
+     }
 
-    {"number":100234,"foo":42,"list":["one","two","three"]}
+The import option C<appname> allows you to seamlessly extend Dancer2 Apps 
+without creating unnecessary additional applications or repeat any definitions.
+This allows you to spread your application routes across multiple files and allow 
+ease of mind when developing it, and accommodate multiple developers working 
+on the same codebase.
 
-The following serializers are available, be aware they dynamically depend on
-Perl modules you may not have on your system.
+     # app.pl
+     use MyApp::User;
+     use MyApp::User::Edit;
 
-=over 4
+     # single application composed of routes provided in multiple files
+     MyApp::User->to_app;
 
-=item B<JSON>
+This way only one class needs to be loaded while creating an app:
 
-requires L<JSON>
+     # app.pl:
+     use MyApp::User;
+     MyApp::User->to_app;
 
-=item B<YAML>
+=head1 LOGGING
 
-requires L<YAML>
+=head2 Configuring logging
 
-=item B<XML>
+It's possible to log messages generated by the application and by Dancer2
+itself.
 
-requires L<XML::Simple>
+To start logging, select the logging engine you wish to use with the
+C<logger> setting; Dancer2 includes built-in log engines named C<file> and
+C<console>, which log to a logfile and to the console respectively.
 
-=item B<Mutable>
-
-will try to find the appropriate serializer using the B<Content-Type> and
-B<Accept-type> header of the request.
-
-=back
-
-
-
-=head2 Logging
-
-It's possible to log messages sent by the application. In the current version,
-only one method is possible for logging messages but future releases may add
-additional logging methods, for instance logging to syslog.
-
-In order to enable the logging system for your application, you first have to
-start the logger engine in your config file:
+To enable logging to a file, add the following to your config file:
 
     logger: 'file'
 
 Then you can choose which kind of messages you want to actually log:
 
-    log: 'core'      # will log all messages, including some from Dancer2 itself
+    log: 'core'      # will log debug, info, warnings, errors,
+                     #   and messages from Dancer2 itself
     log: 'debug'     # will log debug, info, warning and errors
     log: 'info'      # will log info, warning and errors
     log: 'warning'   # will log warning and errors
     log: 'error'     # will log only errors
 
-A directory appdir/logs will be created and will host one logfile per
-environment. The log message contains the time it was written, the PID of the
-current process, the message and the caller information (file and line).
+If you're using the C<file> logging engine, a directory C<appdir/logs> will
+be created and will host one logfile per environment. The log message
+contains the time it was written, the PID of the current process, the
+message and the caller information (file and line).
 
-To log messages, use the C<debug>, C<info>, C<warning> and C<error> methods,
-for instance:
+=head2 Logging your own messages
 
-    debug "This is a debug message";
+Just call L<debug|Dancer2/debug>, L<info|Dancer2/info>,
+L<warning|Dancer2/warning> or L<error|Dancer2/error> with your message:
 
-=head2 Using Templates
+    debug "This is a debug message from my app.";
 
-=head3 Views
+=head1 DEPLOYMENT
 
-It's possible to render the action's content with a template; this is called a
-view. The `appdir/views' directory is the place where views are located.
+=head2 Running stand-alone
 
-You can change this location by changing the setting 'views', for instance if
-your templates are located in the 'templates' directory, do the following:
+At the simplest, your Dancer2 app can run standalone, operating as its own
+webserver using L<HTTP::Server::PSGI>.
 
-    set views => path(dirname(__FILE__), 'templates');
+Simply fire up your app:
 
-By default, the internal template engine is used (L<Dancer2::Template::Simple>)
-but you may want to upgrade to Template::Toolkit. If you do so, you have to
-enable this engine in your settings as explained in
-L<Dancer2::Template::TemplateToolkit>. If you do so, you'll also have to import
-the L<Template> module in your application code.
+    $ plackup bin/app.psgi
+    >> Listening on 0.0.0.0:3000
+    == Entering the dance floor ...
 
-All views must have a '.tt' extension. This may change in the future.
+Point your browser at it, and away you go!
 
-In order to render a view, just call the 'template' keyword at the end of the
-action by giving the view name and the HASHREF of tokens to interpolate in the
-view (note that the request, session and route params are automatically
-accessible in the view, named request, session and params):
+This option can be useful for small personal web apps or internal apps, but
+if you want to make your app available to the world, it probably won't suit
+you.
 
-    use Dancer2;
-    use Template;
+=head2 Auto Reloading with Plack and Shotgun
 
-    get '/hello/:name' => sub {
-        template 'hello' => { number => 42 };
-    };
+To edit your files without the need to restart the webserver on each file
+change, simply start your Dancer2 app using L<plackup> and
+L<Plack::Loader::Shotgun>:
 
-And the appdir/views/hello.tt view can contain the following code:
+    $ plackup -L Shotgun bin/app.psgi
+    HTTP::Server::PSGI: Accepting connections at http://0:5000/
 
-   <html>
-    <head></head>
-    <body>
-        <h1>Hello [% params.name %]</h1>
-        <p>Your lucky number is [% number %]</p>
-        <p>You are using [% request.user_agent %]</p>
-        [% IF session.user %]
-            <p>You're logged in as [% session.user %]</p>
-        [% END %]
-    </body>
-   </html>
+Point your browser at it. Files can now be changed in your favorite editor
+and the browser needs to be refreshed to see the saved changes.
 
-=head3 Layouts
+Please note that this is not recommended for production for performance
+reasons. This is the Dancer2 replacement solution of the old Dancer
+experimental C<auto_reload> option.
 
-A layout is a special view, located in the 'layouts' directory (inside the
-views directory) which must have a token named `content'. That token marks the
-place where to render the action view. This lets you define a global layout
-for your actions. Any tokens that you defined when you called the 'template'
-keyword are available in the layouts, as well as the standard session,
-request, and params tokens. This allows you to insert per-page content into
-the HTML boilerplate, such as page titles, current-page tags for navigation,
-etc.
+On Windows, Shotgun loader is known to cause huge memory leaks in a
+fork-emulation layer. If you are aware of this and still want to run the
+loader, please use the following command:
 
-Here is an example of a layout: views/layouts/main.tt:
+    > set PLACK_SHOTGUN_MEMORY_LEAK=1 && plackup -L Shotgun bin\app.psgi
+    HTTP::Server::PSGI: Accepting connections at http://0:5000/
 
-    <html>
-        <head>[% page_title %]</head>
-        <body>
-        <div id="header">
+=head2 CGI and Fast-CGI
+
+In providing ultimate flexibility in terms of deployment, your Dancer2 app
+can be run as a simple cgi-script out-of-the-box. No additional web-server
+configuration needed. Your web server should recognize .cgi files and be
+able to serve Perl scripts. The Perl module L<Plack::Runner> is required.
+
+=head3 Running on Apache (CGI and FCGI)
+
+Start by adding the following to your apache configuration (C<httpd.conf> or
+C<sites-available/*site*>):
+
+    <VirtualHost *:80>
+        ServerName www.example.com
+        DocumentRoot /srv/www.example.com/public
+        ServerAdmin you@example.com
+
+        <Directory "/srv/www.example.com/public">
+           AllowOverride None
+           Options +ExecCGI -MultiViews +SymLinksIfOwnerMatch
+           Order allow,deny
+           Allow from all
+           AddHandler cgi-script .cgi
+        </Directory>
+
+        RewriteEngine On
+        RewriteCond %{REQUEST_FILENAME} !-f
+        RewriteRule ^(.*)$ /dispatch.cgi$1 [QSA,L]
+
+        ErrorLog  /var/log/apache2/www.example.com-error.log
+        CustomLog /var/log/apache2/www.example.com-access_log common
+    </VirtualHost>
+
+Note that when using fast-cgi your rewrite rule should be:
+
+        RewriteRule ^(.*)$ /dispatch.fcgi$1 [QSA,L]
+
+Here, the mod_rewrite magic for Pretty-URLs is directly put in Apache's
+configuration. But if your web server supports C<.htaccess> files, you can
+drop those lines in a C<.htaccess> file.
+
+To check if your server supports mod_rewrite type C<apache2 -l> to list
+modules. To enable C<mod_rewrite> on Debian or Ubuntu, run C<a2enmod rewrite>. Place
+following code in a file called C<.htaccess> in your application's root folder:
+
+    # BEGIN dancer application htaccess
+    RewriteEngine On
+    RewriteCond %{SCRIPT_FILENAME} !-d
+    RewriteCond %{SCRIPT_FILENAME} !-f
+    RewriteRule (.*) /dispatch.cgi$1 [L]
+    # END dancer application htaccess
+
+Now you can access your Dancer2 application URLs as if you were using the
+embedded web server:
+
+    http://localhost/
+
+This option is a no-brainer, easy to setup, low maintenance but serves
+requests slower than all other options.
+
+You can use the same technique to deploy with FastCGI, by just changing the
+line:
+
+    AddHandler cgi-script .cgi
+
+to:
+
+    AddHandler fastcgi-script .fcgi
+
+Of course remember to update your rewrite rules, if you have set any:
+
+    RewriteRule (.*) /dispatch.fcgi$1 [L]
+
+=head4 Running under an appdir
+
+If you want to deploy multiple applications under the same C<VirtualHost>
+(using one application per directory, for example) you can use the following
+example Apache configuration.
+
+This example uses the FastCGI dispatcher that comes with Dancer2, but you
+should be able to adapt this to use any other way of deployment described in
+this guide. The only purpose of this example is to show how to deploy
+multiple applications under the same base directory/C<VirtualHost>.
+
+    <VirtualHost *:80>
+        ServerName localhost
+        DocumentRoot "/path/to/rootdir"
+        RewriteEngine On
+        RewriteCond %{REQUEST_FILENAME} !-f
+
+        <Directory "/path/to/rootdir">
+            AllowOverride None
+            Options +ExecCGI -MultiViews +SymLinksIfOwnerMatch
+            Order allow,deny
+            Allow from all
+            AddHandler fastcgi-script .fcgi
+        </Directory>
+
+        RewriteRule /App1(.*)$ /App1/public/dispatch.fcgi$1 [QSA,L]
+        RewriteRule /App2(.*)$ /App2/public/dispatch.fcgi$1 [QSA,L]
         ...
-        </div>
+        RewriteRule /AppN(.*)$ /AppN/public/dispatch.fcgi$1 [QSA,L]
+    </VirtualHost>
 
-        <div id="content">
-        [% content %]
-        </div>
+Of course, if your Apache configuration allows that, you can put the
+RewriteRules in a .htaccess file directly within the application's
+directory, which lets you add a new application without changing the Apache
+configuration.
 
-        </body>
-    </html>
+=head3 Running on lighttpd (CGI)
 
-This layout can be used like the following:
+To run as a CGI app on lighttpd, just create a soft link to the C<dispatch.cgi>
+script (created when you run C<dancer -a MyApp>) inside your system's C<cgi-bin>
+folder. Make sure C<mod_cgi> is enabled.
 
-    use Dancer2;
-    set layout => 'main';
+    ln -s /path/to/MyApp/public/dispatch.cgi /usr/lib/cgi-bin/mycoolapp.cgi
 
-    get '/' => sub {
-        template 'index' => { page_title => "Your website Homepage" };
-    };
+=head3 Running on lighttpd (FastCGI)
 
-Of course, if a layout is set, it can also be disabled for a specific action,
-like the following:
+Make sure C<mod_fcgi> is enabled. You also must have L<FCGI> installed.
 
-    use Dancer2;
-    set layout => 'main';
+This example configuration uses TCP/IP:
 
-    get '/nolayout' => sub {
-        template 'some_ajax_view',
-            { tokens_var => "42" },
-            { layout => 0 };
-    };
+    $HTTP["url"] == "^/app" {
+        fastcgi.server += (
+            "/app" => (
+                "" => (
+                    "host" => "127.0.0.1",
+                    "port" => "5000",
+                    "check-local" => "disable",
+                )
+            )
+        )
+    }
 
-=head2 Static Files
+Launch your application:
 
-=head3 Static Directory
+    plackup -s FCGI --port 5000 bin/app.psgi
 
-Static files are served from the ./public directory. You can specify a
-different location by setting the 'public' option:
+This example configuration uses a socket:
 
-    set public => path(dirname(__FILE__), 'static');
+    $HTTP["url"] =~ "^/app" {
+        fastcgi.server += (
+            "/app" => (
+                "" => (
+                    "socket" => "/tmp/fcgi.sock",
+                    "check-local" => "disable",
+                )
+            )
+        )
+    }
 
-Note that the public directory name is not included in the URL. A file
-./public/css/style.css is made available as example.com/css/style.css.
+Launch your application:
 
-=head3 Static File from a Route Handler
+    plackup -s FCGI --listen /tmp/fcgi.sock bin/app.psgi
 
-It's possible for a route handler to send a static file, as follows:
+=head1 TESTING
 
-    get '/download/*' => sub {
-        my $params = shift;
-        my ($file) = @{ $params->{splat} };
+=head2 Using Plack::Test
 
-        send_file $file;
-    };
+L<Plack::Test> receives a common web request (using standard L<HTTP::Request> 
+objects), fakes a web server in order to create a proper PSGI request, and sends it 
+to the web application. When the web application returns a PSGI response 
+(which Dancer applications do), it will then convert it to a common web response 
+(as a standard L<HTTP::Response> object).
 
-Or even if you want your index page to be a plain old index.html file, just do:
+This allows you to then create requests in your test, create the code reference 
+for your web application, call them, and receive a response object, which can
+then be tested.
 
-    get '/' => sub {
-        send_file '/index.html'
-    };
+=head3 Basic Example
 
+Assuming there is a web application:
 
-=head1 EXPORTS
+     # MyApp.pm
+     package MyApp;
+     use Dancer2;
+     get '/' => sub {'OK'};
+     1;
 
-By default, C<use Dancer2> exports all the DSL keywords and sets up the
-webapp under the name of the current package. The following tags control exports
-and webapp namespace.
+The following test I<base.t> is created:
 
-=over 4
+     # base.t
+     use strict;
+     use warnings;
+     use Test::More tests => 2;
+     use Plack::Test;
+     use HTTP::Request;
+     use MyApp;
 
-=item B<!keyword>
+Creating a coderef for the application using the C<to_app> keyword:
 
-If you want to prevent Dancer2 from exporting specific keywords; perhaps you
-plan to implement them yourself in a different way, or they clash with another
-module you're loading, you can simply exclude them:
+     my $app = MyApp->to_app;
 
-    use Test::More;
-    use Dancer2 qw(!pass);
+Creating a test object from L<Plack::Test> for the application:
 
-The above would import all keywords as normal, with the exception of C<pass>.
+     my $test = Plack::Test->create($app);
 
-=item B<appname>
+Creating the first request object and sending it to the test object 
+to receive a response:
 
-A larger application may split its source between several packages to aid
-maintainability. Dancer2 will create a separate application for each package,
-each having separate hooks, config and/or engines. You can force Dancer2 to
-collect the route and hooks into a single application with the C<appname>
-tag; e.g.
+     my $request  = HTTP::Request->new( GET => '/' );
+     my $response = $test->request($request);
 
-    package MyApp;
-    use Dancer2;
-    get '/foo' => sub {...};
+It can now be tested:
 
-    package MyApp::Private;
-    use Dancer2 appname => MyApp;
-    get '/bar' => sub {...};
+     ok( $response->is_success, '[GET /] Successful request' );
+     is( $response->content, 'OK', '[GET /] Correct content' );
 
-The above would add the C<bar> route to the MyApp application. Dancer2 will not
-create an application with the name C<MyApp::Private>.
+=head3 Putting it together
+
+     # base.t
+     use strict;
+     use warnings;
+     use Test::More;
+     use Plack::Test;
+     use HTTP::Request::Common;
+     use MyApp;
+
+     my $test     = Plack::Test->create( MyApp->to_app );
+     my $response = $test->request( GET '/' );
+ 
+     ok( $response->is_success, '[GET /] Successful request' );
+     is( $response->content, 'OK', '[GET /] Correct content' );
+
+     done_testing();
+
+=head3 Subtests
+
+Tests can be separated using L<Test::More>'s C<subtest> functionality, 
+thus creating multiple self-contained tests that don't overwrite each other.
+
+Assuming we have a different app that has two states we want to test:
+
+     # MyApp.pm
+     package MyApp;
+     use Dancer2;
+     set serializer => 'JSON';
+
+     get '/' => sub {
+         my $user = param('user');
+
+         $user and return { user => $user };
+
+         return {};
+     };
+
+     1;
+
+This is a contrived example of a route that checks for a user 
+parameter. If it exists, it returns it in a hash with the key 
+'user'. If not, it returns an empty hash
+
+     # param.t
+     use strict;
+     use warnings;
+     use Test::More;
+     use Plack::Test;
+     use HTTP::Request::Common;
+     use MyApp;
+
+     my $test = Plack::Test->create( MyApp->to_app );
+
+     subtest 'A empty request' => sub {
+         my $res = $test->request( GET '/' );
+         ok( $res->is_success, 'Successful request' );
+         is( $res->content '{}', 'Empty response back' );
+     };
+
+     subtest 'Request with user' => sub {
+         my $res = $test->request( GET '/?user=sawyer_x' );
+         ok( $res->is_success, 'Successful request' );
+         is( $res->content '{"user":"sawyer_x"}', 'Empty response back' );
+     };
+
+     done_testing();
+
+=head3 Cookies
+
+To handle cookies, which are mostly used for maintaining sessions,
+the following modules can be used:  
+L<Test::WWW::Mechanize::PSGI> 
+L<LWP::Protocol::PSGI>
+L<HTTP::Cookies>
+
+Taking the previous test, assuming it actually creates and uses 
+cookies for sessions:
+
+     # ... all the use statements
+     use HTTP::Cookies;
+
+     my $jar  = HTTP::Cookies->new;
+     my $test = Plack::Test->create( MyApp->to_app );
+
+     subtest 'A empty request' => sub {
+         my $res = $test->request( GET '/' );
+         ok( $res->is_success, 'Successful request' );
+         is( $res->content '{}', 'Empty response back' );
+         $jar->extract_cookies($res);
+         ok( $jar->as_string, 'We have cookies!' );
+     };
+
+     subtest 'Request with user' => sub {
+         my $req = GET '/?user=sawyer_x';
+         $jar->add_cookie_header($req);
+         my $res = $test->request($req);
+         ok( $res->is_success, 'Successful request' );
+         is( $res->content '{"user":"sawyer_x"}', 'Empty response back' );
+         $jar->extract_cookies($res);
+
+         ok( ! $jar->as_string, 'All cookies deleted' );
+     };
+
+     done_testing();
+
+Here a cookie jar is created, all requests and responses, existing 
+cookies, as well as cookies that were deleted by the response, are checked.
+
+=head3 Accessing the configuration file
+
+By importing Dancer2 in the command line scripts, there is full 
+access to the configuration using the imported keywords:
+
+     use strict;
+     use warnings;
+     use Test::More;
+     use Plack::Test;
+     use HTTP::Request::Common;
+     use MyApp;
+     use Dancer2;
+
+     my $appname = config->{'appname'};
+     diag "Testing $appname";
+
+     # ...
+
+=head1 PACKAGING
+
+=head2 Carton
+
+=head3 What it does
+
+L<Carton> sets up a local copy of your project prerequisites. You only 
+need to define them in a file and ask Carton to download all of them 
+and set them up.
+When you want to deploy your app, you just carry the git clone and ask 
+Carton to set up the environment again and you will then be able to run it.
+
+The benefits are multifold:
+
+=over
+
+=item Local Directory copy
+
+By putting all the dependencies in a local directory, you can make 
+sure they aren't updated by someone else by accident and their versions 
+locked to the version you picked.
+
+=item Sync versions
+
+Deciding which versions of the dependent modules your project needs 
+allows you to sync this with other developers as well. Now you're all 
+using the same version and they don't change unless you want update the 
+versions you want. When updated everyone again uses the same new version 
+of everything.
+
+=item Carry only the requirement, not bundled modules
+
+Instead of bundling the modules, you only actually bundle the requirements. 
+Carton builds them for you when you need it.
 
 =back
 
-When you C<use Dancer2>, you get an C<import> method added into the current
-package. This B<will> override previously declared import methods from other
-sources, such as L<Exporter>. Dancer2 applications support the following tags
-on import:
+=head3 Setting it up
+
+First set up a new app:
+
+     $ dancer2 -a MyApp
+     ...
+
+Delete the files that are not needed:
+
+     $ rm -f Makefile.PL MANIFEST MANIFEST.SKIP
+
+Create a git repo:
+
+     $ git init && git add . && git commit -m "initial commit"
+
+Add a requirement using the L<cpanfile> format:
+
+     $ cat > cpanfile
+     requires 'Dancer2' => 0.155000;
+     requires 'Template' => 0;
+     recommends 'URL::Encode::XS' => 0;
+     recommends 'CGI::Deurl::XS' => 0;
+     recommends 'HTTP::Parser::XS' => 0;
+
+Ask carton to set it up:
+
+     $ carton install
+     Installing modules using [...]
+     Successfully installed [...]
+     ...
+     Complete! Modules were install into [...]/local
+
+Now we have two files: I<cpanfile> and I<cpanfile.snapshot>. We 
+add both of them to our Git repository and we make sure we don't 
+accidentally add the I<local/> directory Carton created which holds 
+the modules it installed:
+
+     $ echo local/ >> .gitignore
+     $ git add .gitignore cpanfile cpanfile.snapshot
+     $ git commit -m "Start using carton"
+
+When we want to update the versions on the production machine, 
+we simply call:
+
+     $ carton install --deployment
+
+By using --deployment we make sure we only install the modules 
+we have in our cpanfile.snapshot file and do not fallback to querying 
+the CPAN.
+
+=head2 FatPacker
+
+L<App::FatPacker> (using its command line interface, L<fatpack>) packs 
+dependencies into a single file, allowing you to carry a single file 
+instead of a directory tree.
+
+As long as your application is pure-Perl, you could create a single 
+file with your application and all of Dancer2 in it.
+
+The following example will demonstrate how this can be done:
+
+Assuming we have an application in I<lib/MyApp.pm>:
+
+     package MyApp;
+     use Dancer2;
+     get '/' => sub {'OK'};
+     1;
+
+And we have a handler in I<bin/app.pl>:
+
+     use strict;
+     use warnings;
+     use FindBin;
+     use lib "$FindBin::Bin/../lib";
+     use MyApp;
+
+     MyApp->to_app;
+
+To fatpack it, we begin by tracing the script:
+
+     $ fatpack trace bin/app.pl
+
+This creates a I<fatpacker.trace> file. From this we create the packlists:
+
+     $ fatpack packlists-for `cat fatpacker.trace` > packlists
+
+The packlists are stored in a file called I<packlists>.
+
+Now we create the tree using the following command:
+
+     $ fatpack tree `cat packlists`
+
+The tree is created under the directory I<fatlib>.
+
+Now we create a file containing the dependency tree, and add our script to it, 
+using the following command:
+
+     $ (fatpack file; cat bin/app.pl) > myapp.pl
+
+This creates a file called I<myapp.pl> with everything in it. Dancer2 uses 
+L<MIME::Types> which has a database of all MIME types and helps translate those. 
+The small database file containing all of these types is a binary and therefore 
+cannot be fatpacked. Hence, it needs to be copied to the current directory so our 
+script can find it:
+
+     $ cp fatlib/MIME/types.db .
+
+=head1 MIDDLEWARES 
+
+=head2 Plack middlewares
+
+If you want to use Plack middlewares, you need to enable them using
+L<Plack::Builder> as such:
+
+    # in app.psgi or any other handler
+    use Dancer2;
+    use MyWebApp;
+    use Plack::Builder;
+
+    builder {
+        enable 'Deflater';
+        enable 'Session', store => 'File';
+        enable 'Debug', panels => [ qw<DBITrace Memory Timer> ];
+        dance;
+    };
+
+The nice thing about this setup is that it will work seamlessly through
+Plack or through the internal web server.
+
+    # load dev web server (without middlewares)
+    perl -Ilib app.psgi
+
+    # load plack web server (with middlewares)
+    plackup -I lib app.psgi
+
+You do not need to provide different files for either server.
+
+=head3 Path-based middlewares
+
+If you want to set up a middleware for a specific path, you can do that using
+L<Plack::Builder> which uses L<Plack::App::URLMap>:
+
+    # in your app.psgi or any other handler
+    use Dancer2;
+    use MyWebApp;
+    use Plack::Builder;
+
+    my $special_handler = sub { ... };
+
+    builder {
+        mount '/'        => dance;
+        mount '/special' => $special_handler;
+    };
+
+=head3 Running on Perl web servers with plackup
+
+A number of Perl web servers supporting PSGI are available on CPAN:
 
 =over 4
 
-=item B<with>
+=item L<Starman|http://search.cpan.org/dist/Starman/>
 
-The C<with> tag allows an app to pass one or more config entries to another app,
-when it C<use>s it.
+C<Starman> is a high performance web server, with support for preforking,
+signals, multiple interfaces, graceful restarts and dynamic worker pool
+configuration.
 
-    package MyApp;
-    use Dancer2;
+=item L<Twiggy|http://search.cpan.org/dist/Twiggy/>
 
-    set session => 'YAML';
-    use Blog with => { session => engine('session') };
+C<Twiggy> is an C<AnyEvent> web server, it's light and fast.
 
-In this example, the session engine is passed to the C<Blog> app. That way,
-anything done in the session will be shared between both apps.
+=item L<Corona|http://search.cpan.org/dist/Corona/>
 
-Anything that is defined in the config entry can be passed that way. If we want
-to pass the whole config object, it can be done like so:
-
-    use SomeApp with => { %{config()} };
+C<Corona> is a C<Coro> based web server.
 
 =back
 
-=head1 DSL KEYWORDS
+To start your application, just run plackup (see L<Plack> and specific
+servers above for all available options):
 
-Dancer2 provides you with a DSL (Domain-Specific Language) which makes
-implementing your web application trivial.
+   $ plackup bin/app.psgi
+   $ plackup -E deployment -s Starman --workers=10 -p 5001 -a bin/app.psgi
 
-For example, take the following example:
+As you can see, the scaffolded Perl script for your app can be used as a
+PSGI startup file.
+
+=head4 Enabling content compression
+
+Content compression (gzip, deflate) can be easily enabled via a Plack
+middleware (see L<Plack/Plack::Middleware>): L<Plack::Middleware::Deflater>.
+It's a middleware to encode the response body in gzip or deflate, based on the
+C<Accept-Encoding> HTTP request header.
+
+Enable it as you would enable any Plack middleware. First you need to
+install L<Plack::Middleware::Deflater>, then in the handler (usually
+F<app.psgi>) edit it to use L<Plack::Builder>, as described above:
 
     use Dancer2;
+    use MyWebApp;
+    use Plack::Builder;
 
-    get '/hello/:name' => sub {
-        my $name = params->{name};
-    };
-    dance;
-
-C<get> and C<params> are keywords provided by Dancer2.
-
-This document lists all keywords provided by Dancer2.  It does not cover
-additional keywords which may be provided by loaded plugins; see the
-documentation for plugins you use to see which additional keywords they make
-available to you.
-
-=head2 any
-
-Defines a route for multiple HTTP methods at once:
-
-    any ['get', 'post'] => '/myaction' => sub {
-        # code
+    builder {
+        enable 'Deflater';
+        dance;
     };
 
-Or even, a route handler that would match any HTTP methods:
+To test if content compression works, trace the HTTP request and response
+before and after enabling this middleware. Among other things, you should
+notice that the response is gzip or deflate encoded, and contains a header
+C<Content-Encoding> set to C<gzip> or C<deflate>.
 
-    any '/myaction' => sub {
-        # code
+=head3 Running multiple apps with Plack::Builder
+
+You can use L<Plack::Builder> to mount multiple Dancer2 applications on a
+L<PSGI> webserver like L<Starman>.
+
+Start by creating a simple app.psgi file:
+
+    use OurWiki;  # first app
+    use OurForum; # second app
+    use Plack::Builder;
+
+    builder {
+        mount '/wiki'  => OurWiki->psgi_app;
+        mount '/forum' => OurForum->psgi_app;
     };
 
-=head2 cookies
+and now use L<Starman>
 
-Accesses cookies values, it returns a HashRef of L<Dancer2::Core::Cookie>
-objects:
+    plackup -a app.psgi -s Starman
 
-    get '/some_action' => sub {
-        my $cookie = cookies->{name};
-        return $cookie->value;
-    };
+Currently this still demands the same appdir for both (default circumstance)
+but in a future version this will be easier to change while staying very
+simple to mount.
 
-In the case you have stored something else than a Scalar in your cookie:
+=head3 Running from Apache with Plack
 
-    get '/some_action' => sub {
-        my $cookie = cookies->{oauth};
-        my %values = $cookie->value;
-        return ($values{token}, $values{token_secret});
-    };
+You can run your app from Apache using PSGI (Plack), with a config like the
+following:
 
+    <VirtualHost myapp.example.com>
+        ServerName www.myapp.example.com
+        ServerAlias myapp.example.com
+        DocumentRoot /websites/myapp.example.com
 
-=head2 cookie
+        <Directory /home/myapp/myapp>
+            AllowOverride None
+            Order allow,deny
+            Allow from all
+        </Directory>
 
-Accesses a cookie value (or sets it). Note that this method will
-eventually be preferred over C<set_cookie>.
+        <Location />
+            SetHandler perl-script
+            PerlResponseHandler Plack::Handler::Apache2
+            PerlSetVar psgi_app /websites/myapp.example.com/app.psgi
+        </Location>
 
-    cookie lang => "fr-FR";              # set a cookie and return its value
-    cookie lang => "fr-FR", expires => "2 hours";   # extra cookie info
-    cookie "lang"                        # return a cookie value
+        ErrorLog  /websites/myapp.example.com/logs/error_log
+        CustomLog /websites/myapp.example.com/logs/access_log common
+    </VirtualHost>
 
-If your cookie value is a key/value URI string, like
+To set the environment you want to use for your application (production or
+development), you can set it this way:
 
-    token=ABC&user=foo
-
-C<cookie> will only return the first part (C<token=ABC>) if called in scalar context.
-Use list context to fetch them all:
-
-    my @values = cookie "name";
-
-=head2 config
-
-Accesses the configuration of the application:
-
-    get '/appname' => sub {
-        return "This is " . config->{appname};
-    };
-
-=head2 content_type
-
-Sets the B<content-type> rendered, for the current route handler:
-
-    get '/cat/:txtfile' => sub {
-        content_type 'text/plain';
-
-        # here we can dump the contents of param('txtfile')
-    };
-
-You can use abbreviations for content types. For instance:
-
-    get '/svg/:id' => sub {
-        content_type 'svg';
-
-        # here we can dump the image with id param('id')
-    };
-
-Note that if you want to change the default content-type for every route, you
-have to change the C<content_type> setting instead.
-
-=head2 dance
-
-Alias for the C<start> keyword.
-
-=head2 dancer_version
-
-Returns the version of Dancer. If you need the major version, do something like:
-
-  int(dancer_version);
-
-=head2 debug
-
-Logs a message of debug level:
-
-    debug "This is a debug message";
-
-See L<Dancer2::Core::Role::Logger> for details on how to configure where log messages go.
-
-=head2 dirname
-
-Returns the dirname of the path given:
-
-    my $dir = dirname($some_path);
-
-=head2 engine
-
-Given a namespace, returns the current engine object
-
-    my $template_engine = engine 'template';
-    my $html = $template_engine->apply_renderer(...);
-    $template_engine->apply_layout($html);
-
-=head2 error
-
-Logs a message of error level:
-
-    error "This is an error message";
-
-See L<Dancer2::Core::Role::Logger> for details on how to configure where log messages go.
-
-=head2 false
-
-Constant that returns a false value (0).
-
-=head2 forward
-
-Runs an "internal redirect" of the current request to another request. More
-formally; when the C<forward> is executed, the current dispatch of the request
-is aborted, the request is modified (altering query params or request method),
-and the modified request is dispatched again. Any remaining code (route and
-hooks) from the current dispatch will never be run and the modified request's
-dispatch will execute hooks for the new request normally.
-
-It effectively lets you chain routes together in a clean manner.
-
-    get '/demo/articles/:article_id' => sub {
-
-        # you'll have to implement this next sub yourself :)
-        change_the_main_database_to_demo();
-
-        forward "/articles/" . params->{article_id};
-    };
-
-In the above example, the users that reach I</demo/articles/30> will actually
-reach I</articles/30> but we've changed the database to demo before.
-
-This is pretty cool because it lets us retain our paths and offer a demo
-database by merely going to I</demo/...>.
-
-You'll notice that in the example we didn't indicate whether it was B<GET> or
-B<POST>. That is because C<forward> chains the same type of route the user
-reached. If it was a B<GET>, it will remain a B<GET> (but if you do need to
-change the method, you can do so; read on below for details.)
-
-B<WARNING> : Any code after a C<forward> is ignored, until the end of the route.
-It's not necessary to use C<return> with C<forward> anymore.
-
-    get '/foo/:article_id' => sub {
-        if ($condition) {
-            forward "/articles/" . params->{article_id};
-            # The following code WILL NOT BE executed
-            do_stuff();
-        }
-
-        more_stuff();
-    };
-
-Note that C<forward> doesn't parse GET arguments. So, you can't use
-something like:
-
-    forward '/home?authorized=1';
-
-But C<forward> supports an optional HashRef with parameters to be added
-to the actual parameters:
-
-    forward '/home', { authorized => 1 };
-
-Finally, you can add some more options to the C<forward> method, in a
-third argument, also as a HashRef. That option is currently
-only used to change the method of your request. Use with caution.
-
-    forward '/home', { auth => 1 }, { method => 'POST' };
-
-=head2 from_dumper ($structure)
-
-Deserializes a Data::Dumper structure.
-
-=head2 from_json ($structure, \%options)
-
-Deserializes a JSON structure. Can receive optional arguments. Those arguments
-are valid L<JSON> arguments to change the behaviour of the default
-C<JSON::from_json> function.
-
-=head2 from_yaml ($structure)
-
-Deserializes a YAML structure.
-
-=head2 get
-
-Defines a route for HTTP B<GET> requests to the given path:
-
-    get '/' => sub {
-        return "Hello world";
-    }
-
-Note that a route to match B<HEAD> requests is automatically created as well.
-
-
-=head2 halt
-
-Sets a response object with the content given.
-
-When used as a return value from a filter, this breaks the execution flow and
-renders the response immediately:
-
-    hook before => sub {
-        if ($some_condition) {
-            halt("Unauthorized");
-            # This code is not executed :
-            do_stuff();
-        }
-    };
-
-    get '/' => sub {
-        "hello there";
-    };
-
-B<WARNING> : Issuing a halt immediately exits the current route, and perform
-the halt. Thus, any code after a halt is ignored, until the end of the route.
-So it's not necessary anymore to use C<return> with halt.
-
-=head2 headers
-
-Adds custom headers to responses:
-
-    get '/send/headers', sub {
-        headers 'X-Foo' => 'bar', X-Bar => 'foo';
-    }
-
-=head2 header
-
-adds a custom header to response:
-
-    get '/send/header', sub {
-        header 'x-my-header' => 'shazam!';
-    }
-
-Note that it will overwrite the old value of the header, if any. To avoid that,
-see L</push_header>.
-
-=head2 push_header
-
-Do the same as C<header>, but allow for multiple headers with the same name.
-
-    get '/send/header', sub {
-        push_header 'x-my-header' => '1';
-        push_header 'x-my-header' => '2';
-        will result in two headers "x-my-header" in the response
-    }
-
-=head2 hook
-
-Adds a hook at some position. For example :
-
-  hook before_serializer => sub {
-    my $content = shift;
-    ...
-  };
-
-There can be multiple hooks assigned to a given position, and each will be
-executed in order.
-
-=head2 info
-
-Logs a message of info level:
-
-    info "This is a info message";
-
-See L<Dancer2::Core::Role::Logger> for details on how to configure where log
-messages go.
-
-=head2 load
-
-Loads one or more perl scripts in the current application's namespace. Syntactic
-sugar around Perl's C<require>:
-
-    load 'UserActions.pl', 'AdminActions.pl';
-
-=head2 mime
-
-Shortcut to access the instance object of L<Dancer2::Core::MIME>. You should
-read the L<Dancer2::Core::MIME> documentation for full details, but the most
-commonly-used methods are summarized below:
-
-    # set a new mime type
-    mime->add_type( foo => 'text/foo' );
-
-    # set a mime type alias
-    mime->add_alias( f => 'foo' );
-
-    # get mime type for an alias
-    my $m = mime->for_name( 'f' );
-
-    # get mime type for a file (based on extension)
-    my $m = mime->for_file( "foo.bar" );
-
-    # get current defined default mime type
-    my $d = mime->default;
-
-    # set the default mime type using config.yml
-    # or using the set keyword
-    set default_mime_type => 'text/plain';
-
-=head2 params
-
-I<This method should be called from a route handler>.
-It's an alias for the
-L<Dancer2::Core::Request params accessor|Dancer2::Core::Request/"params-source">.
-It returns a hash (in list context) or a hash reference (in scalar context)
-to all defined parameters. Check C<param> below to
-access quickly to a single parameter value.
-
-=head2 param
-
-I<This method should be called from a route handler>.
-This method is an accessor to the parameters hash table.
-
-   post '/login' => sub {
-       my $username = param "user";
-       my $password = param "pass";
-       # ...
-   }
-
-=head2 pass
-
-I<This method should be called from a route handler>.
-Tells Dancer to pass the processing of the request to the next
-matching route.
-
-B<WARNING> : Issuing a pass immediately exits the current route, and perform
-the pass. Thus, any code after a pass is ignored, until the end of the route.
-So it's not necessary anymore to use C<return> with pass.
-
-    get '/some/route' => sub {
-        if (...) {
-            # we want to let the next matching route handler process this one
-            pass(...);
-            # This code will be ignored
-            do_stuff();
-        }
-    };
-
-=head2 patch
-
-Defines a route for HTTP B<PATCH> requests to the given URL:
-
-    patch '/resource' => sub { ... };
-
-(C<PATCH> is a relatively new and not-yet-common HTTP verb, which is intended to
-work as a "partial-PUT", transferring just the changes; please see
-L<http://tools.ietf.org/html/rfc5789|RFC5789> for further details.)
-
-Please be aware that, if you run your app in standalone mode, C<PATCH> requests
-will not reach your app unless you have a new version of L<HTTP::Server::Simple>
-which accepts C<PATCH> as a valid verb.  The current version at time of writing,
-C<0.44>, does not.  A pull request has been submitted to add this support, which
-you can find at:
-
-L<https://github.com/bestpractical/http-server-simple/pull/1>
-
-
-=head2 path
-
-Concatenates multiple paths together, without worrying about the underlying
-operating system:
-
-    my $path = path(dirname($0), 'lib', 'File.pm');
-
-It also normalizes (cleans) the path aesthetically. It does not verify the
-path exists.
-
-=head2 post
-
-Defines a route for HTTP B<POST> requests to the given URL:
-
-    post '/' => sub {
-        return "Hello world";
-    }
-
-=head2 prefix
-
-Defines a prefix for each route handler, like this:
-
-    prefix '/home';
-
-From here, any route handler is defined to /home/*:
-
-    get '/page1' => sub {}; # will match '/home/page1'
-
-You can unset the prefix value:
-
-    prefix undef;
-    get '/page1' => sub {}; # will match /page1
-
-For a safer alternative you can use lexical prefix like this:
-
-    prefix '/home' => sub {
-        ## Prefix is set to '/home' here
-
-        get ...;
-        get ...;
-    };
-    ## prefix reset to the previous version here
-
-This makes it possible to nest prefixes:
-
-   prefix '/home' => sub {
-       ## some routes
-
-      prefix '/private' => sub {
-         ## here we are under /home/private...
-
-         ## some more routes
-      };
-      ## back to /home
-   };
-   ## back to the root
-
-B<Notice:> once you have a prefix set, do not add a caret to the regex:
-
-    prefix '/foo';
-    get qr{^/bar} => sub { ... } # BAD BAD BAD
-    get qr{/bar}  => sub { ... } # Good!
-
-=head2 del
-
-Defines a route for HTTP B<DELETE> requests to the given URL:
-
-    del '/resource' => sub { ... };
-
-=head2 options
-
-Defines a route for HTTP B<OPTIONS> requests to the given URL:
-
-    options '/resource' => sub { ... };
-
-=head2 put
-
-Defines a route for HTTP B<PUT> requests to the given URL:
-
-    put '/resource' => sub { ... };
-
-=head2 redirect
-
-Generates a HTTP redirect (302).  You can either redirect to a complete
-different site or within the application:
-
-    get '/twitter', sub {
-        redirect 'http://twitter.com/me';
-        # Any code after the redirect will not be executed.
-    };
-
-B<WARNING> : Issuing a C<redirect> immediately exits the current route.
-Thus, any code after a C<redirect> is ignored, until the end of the route.
-So it's not necessary anymore to use C<return> with C<redirect>.
-
-You can also force Dancer to return a specific 300-ish HTTP response code:
-
-    get '/old/:resource', sub {
-        redirect '/new/'.params->{resource}, 301;
-    };
-
-=head2 request
-
-Returns a L<Dancer2::Core::Request> object representing the current request.
-
-See the L<Dancer2::Core::Request> documentation for the methods you can call, for
-example:
-
-    request->referer;         # value of the HTTP referer header
-    request->remote_address;  # user's IP address
-    request->user_agent;      # User-Agent header value
-
-
-=head2 send_error
-
-Returns a HTTP error.  By default the HTTP code returned is 500:
-
-    get '/photo/:id' => sub {
-        if (...) {
-            send_error("Not allowed", 403);
-        } else {
-           # return content
-        }
-    }
-
-B<WARNING> : Issuing a send_error immediately exits the current route, and perform
-the send_error. Thus, any code after a send_error is ignored, until the end of the route.
-So it's not necessary anymore to use C<return> with send_error.
-
-    get '/some/route' => sub {
-        if (...) {
-            # we want to let the next matching route handler process this one
-            send_error(..);
-            # This code will be ignored
-            do_stuff();
-        }
-    };
-
-=head2 send_file
-
-Lets the current route handler send a file to the client. Note that
-the path of the file must be relative to the B<public> directory unless you use
-the C<system_path> option (see below).
-
-    get '/download/:file' => sub {
-        return send_file(params->{file});
-    }
-
-B<WARNING> : Issuing a send_file immediately exits the current route, and perform
-the send_file. Thus, any code after a send_file is ignored, until the end of the route.
-So it's not necessary anymore to use C<return> with send_file.
-
-    get '/some/route' => sub {
-        if (...) {
-            # we want to let the next matching route handler process this one
-            send_file(...);
-            # This code will be ignored
-            do_stuff();
-        }
-    };
-
-Send file supports streaming possibility using PSGI streaming. The server should
-support it but normal streaming is supported on most, if not all.
-
-    get '/download/:file' => sub {
-        return send_file( params->{file}, streaming => 1 );
-    }
-
-You can control what happens using callbacks.
-
-First, C<around_content> allows you to get the writer object and the chunk of
-content read, and then decide what to do with each chunk:
-
-    get '/download/:file' => sub {
-        return send_file(
-            params->{file},
-            streaming => 1,
-            callbacks => {
-                around_content => sub {
-                    my ( $writer, $chunk ) = @_;
-                    $writer->write("* $chunk");
-                },
-            },
-        );
-    }
-
-You can use C<around> to get all the content (whether a filehandle if it's
-a regular file or a full string if it's a scalar ref) and decide what to do with
-it:
-
-    get '/download/:file' => sub {
-        return send_file(
-            params->{file},
-            streaming => 1,
-            callbacks => {
-                around => sub {
-                    my ( $writer, $content ) = @_;
-
-                    # we know it's a text file, so we'll just stream
-                    # line by line
-                    while ( my $line = <$content> ) {
-                        $writer->write($line);
-                    }
-                },
-            },
-        );
-    }
-
-Or you could use C<override> to control the entire streaming callback request:
-
-    get '/download/:file' => sub {
-        return send_file(
-            params->{file},
-            streaming => 1,
-            callbacks => {
-                override => sub {
-                    my ( $respond, $response ) = @_;
-
-                    my $writer = $respond->( [ $newstatus, $newheaders ] );
-                    $writer->write("some line");
-                },
-            },
-        );
-    }
-
-You can also set the number of bytes that will be read at a time (default being
-42K bytes) using C<bytes>:
-
-    get '/download/:file' => sub {
-        return send_file(
-            params->{file},
-            streaming => 1,
-            bytes     => 524288, # 512K
-        );
-    };
-
-
-The content-type will be set depending on the current MIME types definition
-(see C<mime> if you want to define your own).
-
-If your filename does not have an extension, or you need to force a
-specific mime type, you can pass it to C<send_file> as follows:
-
-    return send_file(params->{file}, content_type => 'image/png');
-
-Also, you can use your aliases or file extension names on
-C<content_type>, like this:
-
-    return send_file(params->{file}, content_type => 'png');
-
-For files outside your B<public> folder, you can use the C<system_path>
-switch. Just bear in mind that its use needs caution as it can be
-dangerous.
-
-   return send_file('/etc/passwd', system_path => 1);
-
-If you have your data in a scalar variable, C<send_file> can be useful
-as well. Pass a reference to that scalar, and C<send_file> will behave
-as if there was a file with that contents:
-
-   return send_file( \$data, content_type => 'image/png' );
-
-Note that Dancer is unable to guess the content type from the data
-contents. Therefore you might need to set the C<content_type>
-properly. For this kind of usage an attribute named C<filename> can be
-useful.  It is used as the Content-Disposition header, to hint the
-browser about the filename it should use.
-
-   return send_file( \$data, content_type => 'image/png'
-                             filename     => 'onion.png' );
-
-Note that you should always use C<return send_file ...> to stop execution of
-your route handler at that point.
-
-=head2 set
-
-Defines a setting:
-
-    set something => 'value';
-
-You can set more than one value at once:
-
-    set something => 'value', otherthing => 'othervalue';
-
-=head2 setting
-
-Returns the value of a given setting:
-
-    setting('something'); # 'value'
-
-=head2 session
-
-Provides access to all data stored in the user's session (if any).
-
-It can also be used as a setter to store data in the session:
-
-    # getter example
-    get '/user' => sub {
-        if (session('user')) {
-            return "Hello, ".session('user')->name;
-        }
-    };
-
-    # setter example
-    post '/user/login' => sub {
+    <VirtualHost>
         ...
-        if ($logged_in) {
-            session user => $user;
-        }
+        SetEnv DANCER_ENVIRONMENT "production"
         ...
-    };
+    </VirtualHost>
 
-You may also need to clear a session:
+=head1 PLUGINS
 
-    # destroy session
-    get '/logout' => sub {
-        ...
-        app->destroy_session;
-        ...
-    };
+=head2 Writing a plugin
 
-If you need to fetch the session ID being used for any reason:
+=head3 A plugin that does nothing
 
-    my $id = session->id;
+All that is needed for this is L<Dancer2::Plugin> to provide all the keywords
+needed to write a plugin.
 
+     package Dancer2::Plugin::Kitteh;
+     use Dancer2::Plugin;
 
-=head2 splat
+     # we do nothing, just like most cats do
 
-Returns the list of captures made from a route handler with a route pattern
-which includes wildcards:
+     register_plugin;
 
-    get '/file/*.*' => sub {
-        my ($file, $extension) = splat;
-        ...
-    };
+     1;
 
-There is also the extensive splat (A.K.A. "megasplat"), which allows extensive
-greedier matching, available using two asterisks. The additional path is broken
-down and returned as an ArrayRef:
+=head3 Introducing keywords
 
-    get '/entry/*/tags/**' => sub {
-        my ( $entry_id, $tags ) = splat;
-        my @tags = @{$tags};
-    };
+New keywords that the application will receive when it uses your plugin need
+to be introduced using the C<register> keyword:
 
-This helps with chained actions:
+     register meow => sub {
+         my ( $dsl ) = plugin_args(@_);
+         my $app = $dsl->app;
+     };
 
-    get '/team/*/**' => sub {
-        my ($team) = splat;
-        var team => $team;
-        pass;
-    };
+The keyword receives an object which represents the DSL object the app is 
+connected to. It can be used in order to access the Dancer2 core application 
+connected to the user's scope.
 
-    prefix '/team/*';
+Whether a keyword is C<app-global>, can also be controlled. It can be called 
+from anywhere in an app or only from a route, which means during a request:
 
-    get '/player/*' => sub {
-        my ($player) = splat;
+     register meow => sub {
+         debug 'Meow!';
+     }, { is_global => 0 };
 
-        # etc...
-    };
+=head3 Route Decorators 
 
-    get '/score' => sub {
-        return score_for( vars->{'team'} );
-    };
+Some plugins generate routes from other routes, which makes them look a little 
+bit like route decorators. Take L<Dancer2::Plugin::Auth::Tiny> for example:
 
-=head2 start
+     get '/private' => needs login => sub { ... };
 
-Starts the application or the standalone server (depending on the deployment
-choices).
+This works by taking the route sub as a parameter and creating its own route which calls it.
 
-This keyword should be called at the very end of the script, once all routes
-are defined.  At this point, Dancer takes over control.
+     package Dancer2::Plugin::OnTuesday;
+     # ABSTRACT: Make sure a route only works on Tuesday
+     use Dancer2::Plugin;
 
-=head2 psgi_app
+     register on_tuesday => sub {
+         my ( $dsl, $route_sub, @args ) = plugin_args(@_);
 
-Returns the PSGI coderef for the current (and only the current) application
+         my $day = (localtime)[6];
+         $day == 2 or return pass;
 
-This keyword will typically be used as a method to get the psgi coderef for
-testing, or building a larger application via L<Plack::Builder> from
-independent parts.
+         return $route_sub->( $dsl, @args );
+     };
 
-=head2 status
+     register_plugin;
 
-Changes the status code provided by an action.  By default, an action will
-produce an C<HTTP 200 OK> status code, meaning everything is OK:
+Now the plugin can be used as such:
 
-    get '/download/:file' => {
-        if (! -f params->{file}) {
-            status 'not_found';
-            return "File does not exist, unable to download";
-        }
-        # serving the file...
-    };
+     package MyApp;
+     use Dancer2;
+     use Dancer2::Plugin::OnTuesday;
 
-In that example, Dancer will notice that the status has changed, and will
-render the response accordingly.
+     get '/' => on_tuesday => sub { ... };
 
-The status keyword receives either a numeric status code or its name in
-lower case, with underscores as a separator for blanks - see the list in
-L<Dancer2::Core::HTTP/"HTTP CODES">.
+     # every other day
+     get '/' => sub { ... };
 
-=head2 template
+=head3 Reading the configuration
 
-Returns the response of processing the given template with the given parameters
-(and optional settings), wrapping it in the default or specified layout too, if
-layouts are in use.
+While a user can change the configuration using both the configuration 
+file and the C<set> keyword, a single source is needed for all configuration 
+options for the plugin. 
+This is handled automatically using the C<plugin_setting> keyword:
 
-An example of a  route handler which returns the result of using template to
-build a response with the current template engine:
-
-    get '/' => sub {
-        ...
-        return template 'some_view', { token => 'value'};
-    };
-
-Note that C<template> simply returns the content, so when you use it in a route
-handler, if execution of the route handler should stop at that point, make
-sure you use 'return' to ensure your route handler returns the content.
-
-Since template just returns the result of rendering the template, you can also
-use it to perform other templating tasks, e.g. generating emails:
-
-    post '/some/route' => sub {
-        if (...) {
-            email {
-                to      => 'someone@example.com',
-                from    => 'foo@example.com',
-                subject => 'Hello there',
-                msg     => template('emails/foo', { name => params->{name} }),
-            };
-
-            return template 'message_sent';
-        } else {
-            return template 'error';
-        }
-    };
-
-Compatibility notice: C<template> was changed in version 1.3090 to immediately
-interrupt execution of a route handler and return the content, as it's typically
-used at the end of a route handler to return content.  However, this caused
-issues for some people who were using C<template> to generate emails etc, rather
-than accessing the template engine directly, so this change has been reverted
-in 1.3091.
-
-The first parameter should be a template available in the views directory, the
-second one (optional) is a HashRef of tokens to interpolate, and the third
-(again optional) is a HashRef of options.
-
-For example, to disable the layout for a specific request:
-
-    get '/' => sub {
-        template 'index', {}, { layout => undef };
-    };
-
-Or to request a specific layout, of course:
-
-    get '/user' => sub {
-        template 'user', {}, { layout => 'user' };
-    };
-
-Some tokens are automatically added to your template (C<perl_version>,
-C<dancer_version>, C<settings>, C<request>, C<params>, C<vars> and, if
-you have sessions enabled, C<session>).  Check
-L<Dancer2::Core::Role::Template> for further details.
-
-=head2 to_dumper ($structure)
-
-Serializes a structure with Data::Dumper.
-
-Calling this function will B<not> trigger the serialization's hooks.
-
-=head2 to_json ($structure, \%options)
-
-Serializes a structure to JSON. Can receive optional arguments. Thoses arguments
-are valid L<JSON> arguments to change the behaviour of the default
-C<JSON::to_json> function.
-
-Calling this function will B<not> trigger the serialization's hooks.
-
-=head2 to_yaml ($structure)
-
-Serializes a structure to YAML.
-
-Calling this function will B<not> trigger the serialization's hooks.
-
-=head2 true
-
-Constant that returns a true value (1).
-
-=head2 upload
-
-Provides access to file uploads.  Any uploaded file is accessible as a
-L<Dancer2::Core::Request::Upload> object. You can access all parsed uploads via:
-
-    post '/some/route' => sub {
-        my $file = upload('file_input_foo');
-        # file is a Dancer2::Core::Request::Upload object
-    };
-
-If you named multiple input of type "file" with the same name, the upload
-keyword will return an Array of Dancer2::Core::Request::Upload objects:
-
-    post '/some/route' => sub {
-        my ($file1, $file2) = upload('files_input');
-        # $file1 and $file2 are Dancer2::Core::Request::Upload objects
-    };
-
-You can also access the raw HashRef of parsed uploads via the current request
-object:
-
-    post '/some/route' => sub {
-        my $all_uploads = request->uploads;
-        # $all_uploads->{'file_input_foo'} is a Dancer2::Core::Request::Upload object
-        # $all_uploads->{'files_input'} is an ArrayRef of Dancer2::Core::Request::Upload objects
-    };
-
-Note that you can also access the filename of the upload received via the params
-keyword:
-
-    post '/some/route' => sub {
-        # params->{'files_input'} is the filename of the file uploaded
-    };
-
-See L<Dancer2::Core::Request::Upload> for details about the interface provided.
-
-=head2 uri_for
-
-Returns a fully-qualified URI for the given path:
-
-    get '/' => sub {
-        redirect uri_for('/path');
-        # can be something like: http://localhost:3000/path
-    };
-
-=head2 captures
-
-Returns a reference to a copy of C<%+>, if there are named captures in the route
-Regexp.
-
-Named captures are a feature of Perl 5.10, and are not supported in earlier
-versions:
-
-    get qr{
-        / (?<object> user   | ticket | comment )
-        / (?<action> delete | find )
-        / (?<id> \d+ )
-        /?$
-    }x
-    , sub {
-        my $value_for = captures;
-        "i don't want to $$value_for{action} the $$value_for{object} $$value_for{id} !"
-    };
-
-
-=head2 var
-
-Provides an accessor for variables shared between filters and route handlers.
-Given a key/value pair, it sets a variable:
-
-    hook before => sub {
-        var foo => 42;
-    };
-
-Later, route handlers and other filters will be able to read that variable:
-
-    get '/path' => sub {
-        my $foo = var 'foo';
-        ...
-    };
-
-=head2 vars
-
-Returns the HashRef of all shared variables set during the filter/route
-chain with the C<var> keyword:
-
-    get '/path' => sub {
-        if (vars->{foo} eq 42) {
-            ...
-        }
-    };
-
-=head2 warning
-
-Logs a warning message through the current logger engine:
-
-    warning "This is a warning";
-
-See L<Dancer2::Core::Role::Logger> for details on how to configure where log messages go.
+     register meow => sub {
+         my $dsl = shift;
+         my $vol = plugin_setting->{'volume'} || 3;
+     };


### PR DESCRIPTION
Manual:

Some sections from the cookbook were moved to the manual :
1. 'Sessions'
2. 'Deployment'
3. 'Middlewares'
4. 'Declaring Routes' and 'Retrieving request parameters' [under Route Handlers]
5. 'Templates and Unicode' [under Templates]

Some sections were added or converted from the advent calendar articles :
1. 'Writing a session engine' [under sessions]
2. 'writing your own pluggable route handlers' [under handlers]
3. 'importing using appname' [under configuration]
4. Testing - using Plack::Test
5. Packaging [Carton and Fatpacker]
6. Writing Plugins
7. File Uploads
8. Auto Page [under Handlers]

Restructuring: 
1. The 'Hooks' section was organized as an index (for the sub-sections on file rendering and error handling)
2. Default Error Pages and Execution Errors were moved from under 'Usage' to 'Errors'
3. Error Handling was moved from under 'Hooks' to 'Errors'
4. Static Files were moved from under 'Configuration and Environments' to a separate section
5. 'Configuration' and 'Logging' sections were separated
6. File Rendering was moved from under 'Hooks' to 'Handlers'

Cookbook:

The above mentioned sections were moved from the cookbook to the manual.
The following additions were made to the manual, apart from the content left over:

1. Example under AJAX plugin : feeding graph data through AJAX
2. Delivering custom error pages
3. Using DBIx::Class
4. Authentication - basic application
5. Using the serializer (including an example : writing API interfaces)