### PR TITLE
Ensure session data is available to template engines

### DIFF
--- a/lib/Dancer2/Core/App.pm
+++ b/lib/Dancer2/Core/App.pm
@@ -7,6 +7,7 @@ use Scalar::Util       'blessed';
 use Module::Runtime    'is_module_name';
 use Return::MultiLevel ();
 use Safe::Isa;
+use Scalar::Lazy       ();
 use File::Spec;
 
 use Plack::Middleware::Conditional;
@@ -667,6 +668,11 @@ sub template {
 
     my $template = $self->template_engine;
     $template->set_settings( $self->config );
+
+    # A session may exist but the route code may not have instantiated
+    # the session object (sessions are lazy). If this is the case, do
+    # that now, so the templates have the session data for rendering.
+    $self->has_session && ! $template->has_session && $self->setup_session;
 
     # return content
     return $template->process( @_ );

--- a/lib/Dancer2/Core/App.pm
+++ b/lib/Dancer2/Core/App.pm
@@ -7,7 +7,6 @@ use Scalar::Util       'blessed';
 use Module::Runtime    'is_module_name';
 use Return::MultiLevel ();
 use Safe::Isa;
-use Scalar::Lazy       ();
 use File::Spec;
 
 use Plack::Middleware::Conditional;
@@ -672,7 +671,8 @@ sub template {
     # A session may exist but the route code may not have instantiated
     # the session object (sessions are lazy). If this is the case, do
     # that now, so the templates have the session data for rendering.
-    $self->has_session && ! $template->has_session && $self->setup_session;
+    $self->has_session && ! $template->has_session
+        and $self->setup_session;
 
     # return content
     return $template->process( @_ );


### PR DESCRIPTION
Sessions are lazy. Some effort was put in to ensure we do not instantiate a session object if it was unnecessary. 

Template engines *should* add any session data to the hash of tokens before rendering. However, if the session object hasn't been created, there is no session data for template engines to add.  The (dancr) app in our tutorial fails because of this. See #840.

This Pr fixes the existing tests to trigger this situation, and ensures a session object is created (if needed) before processing a template.