### PR TITLE
Add missing attributes for test class

### DIFF
--- a/t/classes/Dancer2-Core-Role-StandardResponses/with.t
+++ b/t/classes/Dancer2-Core-Role-StandardResponses/with.t
@@ -17,8 +17,10 @@ use Test::More tests => 24;
 {
     package Response;
     use Moo;
-    sub status { shift->{'status'}->(@_) }
-    sub header { shift->{'header'}->(@_) }
+    has status => (is => 'ro', reader => '_status');
+    has header => (is => 'ro', reader => '_header');
+    sub status { shift->_status->(@_) }
+    sub header { shift->_header->(@_) }
 }
 
 note 'Checking our fake app'; {


### PR DESCRIPTION
The test relied on Moo classes without any attributes storing everything
given to their constructor.  This will be changed with a future version
of Moo.  Instead, create the appropriate attributes for the test class.