### PR TITLE
Feature/prefix consistency modified

### DIFF
--- a/lib/Dancer2/Core/Request.pm
+++ b/lib/Dancer2/Core/Request.pm
@@ -1,9 +1,7 @@
 package Dancer2::Core::Request;
-
 # ABSTRACT: Interface for accessing incoming requests
 
 use Moo;
-
 use Carp;
 use Encode;
 use HTTP::Body;

--- a/lib/Dancer2/Core/Route.pm
+++ b/lib/Dancer2/Core/Route.pm
@@ -144,6 +144,10 @@ sub BUILDARGS {
             ref($regexp) eq 'Regexp' ? qr{^\Q${prefix}\E${regexp}$} :
             $prefix . $regexp;
     }
+    elsif ( ref($regexp) ne 'Regexp' ) {
+        # No prefix, so ensure regexp begins with a '/'
+        index( $regexp, '/', 0 ) == 0 or $args{regexp} = "/$regexp";
+    }
 
     # init regexp
     $regexp = $args{regexp}; # updated value

--- a/lib/Dancer2/Core/Route.pm
+++ b/lib/Dancer2/Core/Route.pm
@@ -138,17 +138,10 @@ sub BUILDARGS {
     my $prefix = $args{prefix};
     my $regexp = $args{regexp};
 
-    # regexp must have a leading /
-    if ( ref($regexp) ne 'Regexp' ) {
-        index( $regexp, '/', 0 ) == 0
-            or die "regexp must begin with /\n";
-    }
-
     # init prefix
     if ( $prefix ) {
         $args{regexp} =
             ref($regexp) eq 'Regexp' ? qr{^\Q${prefix}\E${regexp}$} :
-            $regexp eq '/'           ? qr{^\Q${prefix}\E/?$} :
             $prefix . $regexp;
     }
 

--- a/t/app.t
+++ b/t/app.t
@@ -41,7 +41,7 @@ is $app->environment, 'development';
 my $routes_regexps = $app->routes_regexps_for('get');
 is( scalar(@$routes_regexps), 4, "route regexps are OK" );
 
-for my $path ( '/', '/blog', '/mywebsite', '/mywebsite/blog', ) {
+for my $path ( '/', '/blog', '/mywebsite/', '/mywebsite/blog', ) {
     my $env = {
         REQUEST_METHOD => 'GET',
         PATH_INFO      => $path
@@ -50,7 +50,7 @@ for my $path ( '/', '/blog', '/mywebsite', '/mywebsite/blog', ) {
     my $expected = {
         '/'               => '/',
         '/blog'           => '/blog',
-        '/mywebsite'      => '/',
+        '/mywebsite/'     => '/',
         '/mywebsite/blog' => '/blog',
     };
 
@@ -71,7 +71,7 @@ $app->lexical_prefix(
         $app->add_route(
             method => 'get',
             regexp => '/',
-            code   => sub {'/foo'}
+            code   => sub {'/foo/'}
         );
 
         $app->add_route(
@@ -116,7 +116,7 @@ $app->lexical_prefix(
 );
 
 for
-  my $path ( '/foo', '/foo/second', '/foo/bar/second', '/root', '/somewhere' )
+  my $path ( '/foo/', '/foo/second', '/foo/bar/second', '/root', '/somewhere' )
 {
     my $env = {
         REQUEST_METHOD => 'GET',

--- a/t/classes/Dancer2-Core-Route/base.t
+++ b/t/classes/Dancer2-Core-Route/base.t
@@ -4,29 +4,64 @@ use Test::More;
 use Test::Fatal;
 use Dancer2::Core::Route;
 
-plan tests => 2;
+plan tests => 3;
 
-is(
-    exception {
-        Dancer2::Core::Route->new(
-            regexp => 'no+leading+slash',
-            method => 'get',
-            code   => sub {1},
-        )
-    },
-    undef,
-    'route pattern can start with a / or not',
-);
+my @no_leading_slash = ( 'no+leading+slash', '' );
+my @leading_slash = ('/+leading+slash', '/', '//' );
 
-is(
-    exception {
-        Dancer2::Core::Route->new(
-            regexp => '',
-            method => 'get',
-            code   => sub {1},
-        )
-    },
-    undef,
-    'route pattern can also be empty',
-);
+subtest "no prefix, paths without a leading slash" => sub {
+    for my $string ( @no_leading_slash ) {
+        my $route;
+        my $exception = exception {
+            $route = Dancer2::Core::Route->new(
+                regexp => $string,
+                method => 'get',
+                code   => sub {1},
+            );
+        };
+        is( $exception, undef,
+            "'$string' is a valid route pattern"
+        );
+        is( $route->spec_route, "/$string",
+            "undef prefix prepends '/' to spec_route"
+        );
+    }
+};
+
+subtest "no prefix, paths with a leading slash" => sub {
+    for my $string ( @leading_slash ) {
+        my $route;
+        my $exception = exception {
+            $route = Dancer2::Core::Route->new(
+                regexp => $string,
+                method => 'get',
+                code   => sub {1},
+            );
+        };
+        is( $exception, undef,
+            "'$string' is a valid route pattern"
+        );
+        is( $route->spec_route, $string,
+            "undef prefix does not prepend '/' to spec_route"
+        );
+    }
+};
+
+subtest "prefix and paths append" => sub {
+    my $prefix = '/prefix';
+    for my $string ( @no_leading_slash, @leading_slash) {
+        my $route;
+        my $exception = exception {
+            $route = Dancer2::Core::Route->new(
+                regexp => $string,
+                prefix => $prefix,
+                method => 'get',
+                code   => sub {1},
+            );
+        };
+        is( $exception, undef,
+            "'$prefix$string' is a valid route pattern"
+        );
+    }
+};
 

--- a/t/classes/Dancer2-Core-Route/base.t
+++ b/t/classes/Dancer2-Core-Route/base.t
@@ -4,10 +4,29 @@ use Test::More;
 use Test::Fatal;
 use Dancer2::Core::Route;
 
-plan tests => 1;
+plan tests => 2;
 
-like(
-    exception { Dancer2::Core::Route->new( regexp => 'no+leading+slash' ) },
-    qr/^regexp must begin with/,
-    'route pattern must start with a /',
+is(
+    exception {
+        Dancer2::Core::Route->new(
+            regexp => 'no+leading+slash',
+            method => 'get',
+            code   => sub {1},
+        )
+    },
+    undef,
+    'route pattern can start with a / or not',
 );
+
+is(
+    exception {
+        Dancer2::Core::Route->new(
+            regexp => '',
+            method => 'get',
+            code   => sub {1},
+        )
+    },
+    undef,
+    'route pattern can also be empty',
+);
+

--- a/t/classes/Dancer2-Core-Route/match.t
+++ b/t/classes/Dancer2-Core-Route/match.t
@@ -40,10 +40,27 @@ my @tests = (
         [ {}, 'concat' ]
     ],
 
+    # token in prefix tests
+    [   [ 'get', 'name', sub {35}, '/hello/:' ],
+        '/hello/sukria',
+        [ { name => 'sukria' }, 35 ],
+    ],
+
+    [   [ 'get', '/', sub {36}, '/hello/:name' ],
+        '/hello/sukria/',
+        [ { name => 'sukria' }, 36 ],
+    ],
+
     # splat test
     [   [ 'get', '/file/*.*', sub {44} ],
         '/file/dist.ini',
         [ { splat => [ 'dist', 'ini' ] }, 44 ]
+    ],
+
+    # splat in prefix
+    [   [ 'get', '', sub {42}, '/forum/*'],
+        '/forum/dancer',
+        [ { splat => [ 'dancer' ] }, 42 ]
     ],
 
     # megasplat test
@@ -72,7 +89,7 @@ my @tests = (
     ],
 );
 
-plan tests => 59;
+plan tests => 71;
 
 for my $t (@tests) {
     my ( $route, $path, $expected ) = @$t;

--- a/t/classes/Dancer2-Core-Route/match.t
+++ b/t/classes/Dancer2-Core-Route/match.t
@@ -24,16 +24,20 @@ my @tests = (
 
     # prefix tests
     [   [ 'get', '/', sub {33}, '/forum' ],
-        '/forum',
-        [ { splat => [1] }, 33 ]
+        '/forum/',
+        [ {}, 33 ]
     ],
     [   [ 'get', '/', sub {33}, '/forum' ],
         '/forum/',
-        [ { splat => [1] }, 33 ]
+        [ {}, 33 ]
     ],
     [   [ 'get', '/mywebsite', sub {33}, '/forum' ],
         '/forum/mywebsite',
         [ {}, 33 ]
+    ],
+    [   [ 'get', '', sub {'concat'}, '/' ],
+        '/',
+        [ {}, 'concat' ]
     ],
 
     # splat test
@@ -68,7 +72,7 @@ my @tests = (
     ],
 );
 
-plan tests => 55;
+plan tests => 59;
 
 for my $t (@tests) {
     my ( $route, $path, $expected ) = @$t;


### PR DESCRIPTION
This is based on @xsawyerx awesome work from #817 with some extra tests.

In the case when the prefix is `undef` and the concatenated route regexp does not begin with a `/`, implicitly adds a leading '/' to make it a matchable route. i.e. both the following will now match the path `/`.
```
  prefix '/' => sub { get '' => sub {...} };
  prefix '/' => sub { get '/' => sub {...} };
```
This seems a reasonable balance between doing what was expected, but some may find it inconsistent.
In which case I'd be happy to die in the case when the prefix is undef and the (concatenated) route regexp did not begin with a `/`.
