### PR TITLE
Issue 565: Fix HTTP Status template logic and documentation

### DIFF
--- a/Changes
+++ b/Changes
@@ -4,6 +4,7 @@
     * GH #762: Delay app cleanup until errors are rendered. (Russell Jenkins)
     * GH #835: Correct Logic error in Logger if no request exists.
       (Lennart Hengstmengel)
+    * GH #565: Fix HTTP Status template logic and documentation (Daniel Muey)
 
     [ ENHANCEMENT ]
     * GH #824: Use Plack::MIME by default, MIME::Types as failback if available.

--- a/lib/Dancer2/Config.pod
+++ b/lib/Dancer2/Config.pod
@@ -312,7 +312,7 @@ shown below.
 
 If set to true, Dancer2 will render a detailed debug screen whenever an
 error is caught. If set to false, Dancer2 will render the default error
-page, using $public/$error_code.html if it exists or the template specified
+page, using $public/$error_code.html if it exists, $views/$error_code.tt or the template specified
 by the C<error_template> setting.
 
 The error screen attempts to sanitise sensitive looking information
@@ -323,7 +323,7 @@ divulging details.
 =head3 error_template (template path)
 
 This setting lets you specify a template to be used in case of runtime
-error. At the present moment the template can use three variables:
+error. At the present moment the template (as well as $views/$error_code.tt templates) can use four variables:
 
 =over 4
 
@@ -331,15 +331,29 @@ error. At the present moment the template can use three variables:
 
 The error title.
 
-=item B<message>
+=item B<content>
 
-The error message.
+The error specific content (if any).
 
-=item B<code>
+=item B<status>
 
-The code throwing that error.
+The HTTP status code throwing that error.
+
+=item B<exception>
+
+The stringified exception (e.g. $@) if any.
 
 =back
+
+Keep in mind that 'content' and 'exception' can vary depending on the problem.
+
+For example:
+
+A 404 has an empty 'exception' and 'content' contains the URI that was not found. Unless you do the 404 yourself via  C<send_error("You chose … poorly!", 404);>, then 'content' is 'You chose … poorly!'.
+
+A 500 because of, say, dividing 0 by 0 will have an empty 'content' and 'exception like 'Illegal division by zero at …'.
+
+A 401 from C<send_error("You can not know the secret until you sign in grasshopper!", 401);> will have an empty 'exception' and 'content' will contain 'You can not know the secret until you sign in grasshopper!'.
 
 =head2 Logger engine
 

--- a/lib/Dancer2/Config.pod
+++ b/lib/Dancer2/Config.pod
@@ -312,7 +312,7 @@ shown below.
 
 If set to true, Dancer2 will render a detailed debug screen whenever an
 error is caught. If set to false, Dancer2 will render the default error
-page, using $public/$error_code.html if it exists, $views/$error_code.tt or the template specified
+page, using C<$public/$error_code.html> if it exists, C<$views/$error_code.tt> or the template specified
 by the C<error_template> setting.
 
 The error screen attempts to sanitise sensitive looking information
@@ -323,7 +323,7 @@ divulging details.
 =head3 error_template (template path)
 
 This setting lets you specify a template to be used in case of runtime
-error. At the present moment the template (as well as $views/$error_code.tt templates) can use four variables:
+error. At the present moment the template (as well as C<$views/$error_code.tt> templates) can use four variables:
 
 =over 4
 
@@ -349,9 +349,9 @@ Keep in mind that 'content' and 'exception' can vary depending on the problem.
 
 For example:
 
-A 404 has an empty 'exception' and 'content' contains the URI that was not found. Unless you do the 404 yourself via  C<send_error("You chose … poorly!", 404);>, then 'content' is 'You chose … poorly!'.
+A 404 has an empty 'exception' and 'content' contains the URI that was not found. Unless you do the 404 yourself via  C<send_error("You chose ... poorly!", 404);>, then 'content' is 'You chose ... poorly!'.
 
-A 500 because of, say, dividing 0 by 0 will have an empty 'content' and 'exception like 'Illegal division by zero at …'.
+A 500 because of, say, dividing 0 by 0 will have an empty 'content' and 'exception like 'Illegal division by zero at ...'.
 
 A 401 from C<send_error("You can not know the secret until you sign in grasshopper!", 401);> will have an empty 'exception' and 'content' will contain 'You can not know the secret until you sign in grasshopper!'.
 

--- a/share/skel/environments/development.yml
+++ b/share/skel/environments/development.yml
@@ -16,7 +16,7 @@ warnings: 1
 
 # should Dancer2 show a stacktrace when an error is caught?
 # if set to yes, public/500.html will be ignored and either
-# views/500.tt or a default error template will be used.
+# views/500.tt, 'error_template' template, or a default error template will be used.
 show_errors: 1
 
 # print the banner


### PR DESCRIPTION
* added: do, per doc, error_template after error specific static file
* fixed: error specific template file would result in a
* fixed: Config POD had incorrect template variables.
* added: more template info to Config POD including the previously
  undocumented $views/$error_code.tt
* removed unreferenced internal method _render_html
  (i.e. it is confusing and probably why this was overlooked since
   it calls a non-existent method error_template())
* other POD/comments that needs to note $views/$error_code.tt

Current t/ all pass, manual testing passed, new t/ tests via GH #846.