### PR TITLE
Feature/keyword prototypes

### DIFF
--- a/lib/Dancer2/Core/Role/DSL.pm
+++ b/lib/Dancer2/Core/Role/DSL.pm
@@ -76,6 +76,12 @@ sub _compile_keyword {
             $self->$keyword(@_)
         };
 
+    return $self->_apply_prototype($code, $opts);
+}
+
+sub _apply_prototype {
+    my ($self, $code, $opts) = @_;
+
     # set prototype if one is defined for the keyword. undef => no prototype
     my $prototype;
     exists $opts->{'prototype'} and $prototype = $opts->{'prototype'};

--- a/lib/Dancer2/Core/Role/DSL.pm
+++ b/lib/Dancer2/Core/Role/DSL.pm
@@ -4,6 +4,7 @@ package Dancer2::Core::Role::DSL;
 use Moo::Role;
 use Dancer2::Core::Types;
 use Carp 'croak';
+use Scalar::Util qw();
 
 with 'Dancer2::Core::Role::Hookable';
 
@@ -50,7 +51,7 @@ sub export_symbols_to {
     my $exports = $self->_construct_export_map($args);
 
     foreach my $export ( keys %{$exports} ) {
-        no strict 'refs';
+        no strict 'refs'; ## no critic (TestingAndDebugging::ProhibitNoStrict)
         my $existing = *{"${caller}::${export}"}{CODE};
 
         next if defined $existing;
@@ -64,20 +65,21 @@ sub export_symbols_to {
 # private
 
 sub _compile_keyword {
-    my ( $self, $keyword, $is_global ) = @_;
+    my ( $self, $keyword, $opts ) = @_;
 
-    my $compiled_code = sub { $self->$keyword(@_); };
+    my $code = $opts->{is_global}
+               ? sub { $self->$keyword(@_) }
+               : sub {
+            croak "Function '$keyword' must be called from a route handler"
+                unless defined $self->app->has_request;
 
-    if ( !$is_global ) {
-        my $code = $compiled_code;
-        $compiled_code = sub {
-            $self->app->has_request or
-                croak "Function '$keyword' must be called from a route handler";
-            $code->(@_);
+            $self->$keyword(@_)
         };
-    }
 
-    return $compiled_code;
+    # set prototype if one is defined for the keyword. undef => no prototype
+    my $prototype;
+    exists $opts->{'prototype'} and $prototype = $opts->{'prototype'};
+    return Scalar::Util::set_prototype( \&$code, $prototype );
 }
 
 sub _construct_export_map {
@@ -87,7 +89,7 @@ sub _construct_export_map {
     foreach my $keyword ( keys %$keywords ) {
         # check if the keyword were excluded from importation
         $args->{ '!' . $keyword } and next;
-        $map{$keyword} = $self->_compile_keyword( $keyword, $keywords->{$keyword}{is_global} );
+        $map{$keyword} = $self->_compile_keyword( $keyword, $keywords->{$keyword} );
     }
     return \%map;
 }

--- a/lib/Dancer2/Plugin.pm
+++ b/lib/Dancer2/Plugin.pm
@@ -40,7 +40,7 @@ sub register {
 
     $_keywords->{$plugin} ||= [];
     push @{ $_keywords->{$plugin} },
-      [ $keyword, $code, $options->{is_global} ];
+      [ $keyword, $code, $options ];
 }
 
 sub on_plugin_import(&) {
@@ -64,10 +64,10 @@ sub register_plugin {
     # bind all registered keywords to the plugin
     my $dsl = $caller->dsl;
     for my $k ( @{ $_keywords->{$plugin} } ) {
-        my ( $keyword, $code, $is_global ) = @{$k};
+        my ( $keyword, $code, $options ) = @{$k};
         {
             no strict 'refs';
-            *{"${plugin}::${keyword}"} = $code;
+            *{"${plugin}::${keyword}"} = $dsl->_apply_prototype($code, $options);
         }
     }
 
@@ -80,7 +80,8 @@ sub register_plugin {
         my $caller = caller(1);
 
         for my $k ( @{ $_keywords->{$plugin} } ) {
-            my ( $keyword, $code, $is_global ) = @{$k};
+            my ( $keyword, $code, $options ) = @{$k};
+            my $is_global = exists $options->{is_global} && $options->{is_global};
             $caller->dsl->register( $keyword, $is_global );
         }
 

--- a/t/custom_dsl.t
+++ b/t/custom_dsl.t
@@ -13,17 +13,18 @@ envoie '/' => sub {
 };
 
 prend '/' => sub {
+    proto { ::ok('in proto') }; # no sub!
     request->method;
 };
 
-my $app = __PACKAGE__->to_app;
-is( ref $app, 'CODE', 'Got app' );
 
-test_psgi $app, sub {
-    my $cb = shift;
+my $test = Plack::Test->create( __PACKAGE__->to_app );
 
-    is( $cb->( GET '/' )->content, 'GET', '[GET /] Correct content' );
-    is( $cb->( POST '/' )->content, 'POST', '[POST /] Correct content' );
-};
+is( $test->request( GET '/' )->content,
+    'GET', '[GET /] Correct content'
+);
+is( $test->request( POST '/' )->content,
+    'POST', '[POST /] Correct content'
+);
 
-done_testing;
+done_testing();

--- a/t/lib/FooPlugin.pm
+++ b/t/lib/FooPlugin.pm
@@ -18,7 +18,7 @@ register foo_wrap_request => sub {
 register foo_route => sub {
     my ($self) = plugin_args(@_);
     $self->get( '/foo', sub {'foo'} );
-};
+} => { is_global => 1, prototype => '$@' };
 
 register p_config => sub {
     my $dsl    = shift;

--- a/t/lib/MyDancerDSL.pm
+++ b/t/lib/MyDancerDSL.pm
@@ -15,9 +15,11 @@ around dsl_keywords => sub {
     $keywords->{gateau} = { is_global => 0 }; # cookie
     $keywords->{moteur} = { is_global => 1 }; # engine
     $keywords->{stop}   = { is_global => 0 }; # halt
-    $keywords->{prend}  = { is_global => 1 }; # post
-    $keywords->{envoie} = { is_global => 1 }; # post
+    $keywords->{prend}  = { is_global => 1, prototype => '@' };  # get
+    $keywords->{envoie} = { is_global => 1, prototype => '$&' }; # post
     $keywords->{entete} = { is_global => 0 }; #header
+
+    $keywords->{proto} = { is_global => 1, prototype => '&' }; # prototype
 
     return $keywords;
 };
@@ -28,5 +30,7 @@ sub stop   { goto &Dancer2::Core::DSL::halt }
 sub prend  { goto &Dancer2::Core::DSL::get }
 sub envoie { goto &Dancer2::Core::DSL::post }
 sub entete { goto &Dancer2::Core::DSL::header }
+
+sub proto { $_[1]->() }
 
 1;


### PR DESCRIPTION
This is an alternative to #792. The main differences are:
  * keyword prototypes are "optional", well, the default is undef. There are some that consider *prototypes to be evil*.. I prefer this default.
  * the prototype is applied to the keywords coderef via `Scalar::Util::set_prototype`. This avoids eval of the code strings, but does require perl 5.8.1+
  * keywords registered from plugins may also have a prototype applied.

"Old style" plugins that `use Dancer2; use Dancer2::Plugin;` don't break. When the subs with the deprecation warning redefines the imports from Dancer2, we copy the existing prototype for those coderefs.

There are some very basic tests. But still no documentation. I ran out of tuits. :(