### PR TITLE
Error template logic and encoding cleanup

### DIFF
--- a/Changes
+++ b/Changes
@@ -7,6 +7,7 @@
     * GH #843: Add missing attributes to Moo class used in tests. (Graham Knop)
     * GH #839: Correct "no_server_tokens" definition in production.yml.
                (Nikita K)
+    * GH #565: Fix HTTP Status template logic and documentation (Daniel Muey)
 
     [ ENHANCEMENT ]
     * GH #824: Use Plack::MIME by default, MIME::Types as failback if available.

--- a/lib/Dancer2/Config.pod
+++ b/lib/Dancer2/Config.pod
@@ -312,7 +312,7 @@ shown below.
 
 If set to true, Dancer2 will render a detailed debug screen whenever an
 error is caught. If set to false, Dancer2 will render the default error
-page, using $public/$error_code.html if it exists or the template specified
+page, using C<$public/$error_code.html> if it exists, C<$views/$error_code.tt> or the template specified
 by the C<error_template> setting.
 
 The error screen attempts to sanitise sensitive looking information
@@ -323,7 +323,7 @@ divulging details.
 =head3 error_template (template path)
 
 This setting lets you specify a template to be used in case of runtime
-error. At the present moment the template can use three variables:
+error. At the present moment the template (as well as C<$views/$error_code.tt> templates) can use four variables:
 
 =over 4
 
@@ -331,15 +331,29 @@ error. At the present moment the template can use three variables:
 
 The error title.
 
-=item B<message>
+=item B<content>
 
-The error message.
+The error specific content (if any).
 
-=item B<code>
+=item B<status>
 
-The code throwing that error.
+The HTTP status code throwing that error.
+
+=item B<exception>
+
+The stringified exception (e.g. $@) if any.
 
 =back
+
+Keep in mind that 'content' and 'exception' can vary depending on the problem.
+
+For example:
+
+A 404 has an empty 'exception' and 'content' contains the URI that was not found. Unless you do the 404 yourself via  C<send_error("You chose ... poorly!", 404);>, then 'content' is 'You chose ... poorly!'.
+
+A 500 because of, say, dividing 0 by 0 will have an empty 'content' and 'exception like 'Illegal division by zero at ...'.
+
+A 401 from C<send_error("You can not know the secret until you sign in grasshopper!", 401);> will have an empty 'exception' and 'content' will contain 'You can not know the secret until you sign in grasshopper!'.
 
 =head2 Logger engine
 

--- a/lib/Dancer2/Core/Error.pm
+++ b/lib/Dancer2/Core/Error.pm
@@ -205,7 +205,13 @@ has exception => (
 has response => (
     is      => 'rw',
     lazy    => 1,
-    default => sub { Dancer2::Core::Response->new }
+    default => sub {
+        my $self = shift;
+        my $serializer = $self->serializer;
+        return Dancer2::Core::Response->new(
+            ( serializer => $serializer )x!! $serializer
+        );
+    }
 );
 
 has content_type => (
@@ -222,75 +228,70 @@ has content_type => (
 has content => (
     is      => 'ro',
     lazy    => 1,
-    default => sub {
-        my $self = shift;
-
-        # Apply serializer
-        if ( $self->serializer ) {
-            my $content = {
-                message => $self->message,
-                title   => $self->title,
-                status  => $self->status,
-            };
-            $content->{exception} = $self->exception
-              if $self->has_exception;
-            return $self->serializer->serialize($content);
-        }
-
-        # Otherwise we check for a template, for a static file, for configured error_template, and,
-        # if all else fail, the default error page
-        if ( $self->has_app and $self->template ) {
-            # Render the template using apps' template engine.
-            # This may well be what caused the initial error, in which
-            # case we fall back to static page if any error was thrown.
-            # Note: this calls before/after render hooks.
-            my $content = eval {
-                $self->app->template(
-                    $self->template,
-                    {   title     => $self->title,
-                        content   => $self->message,
-                        exception => $self->exception,
-                        status    => $self->status,
-                    }
-                );
-            };
-
-            # return rendered content unless there was an error.
-            if (defined $content) {
-                # Why is this necessary here and not with other templates e.g. like route templates?
-                utf8::encode($content) if utf8::is_utf8($content); # less confusing via String::UnicodeUTF8: $content = get_utf8($content) if is_unicode($content)
-                return $content;
-            }
-        }
-
-        # It doesn't make sense to return a static page if show_errors is on
-        if ( !$self->show_errors && (my $content = $self->static_page) ) {
-            return $content;
-        }
-
-        if ($self->has_app && $self->app->config->{error_template}) {
-            my $content = eval {
-                $self->app->template(
-                    $self->app->config->{error_template},
-                    {   title     => $self->title,
-                        content   => $self->message,
-                        exception => $self->exception,
-                        status    => $self->status,
-                    }
-                );
-            };
-
-            # return rendered content unless there was an error.
-            if (defined $content) {
-                # Why is this necessary here and not with other templates e.g. like route templates?
-                utf8::encode($content) if utf8::is_utf8($content); # less confusing via String::UnicodeUTF8: $content = get_utf8($content) if is_unicode($content)
-                return $content;
-            }
-        }
-
-        return $self->default_error_page;
-    },
+    builder => '_build_content',
 );
+
+sub _build_content {
+    my $self = shift;
+
+    # return a hashref if a serializer is available
+    if ( $self->serializer ) {
+        my $content = {
+            message => $self->message,
+            title   => $self->title,
+            status  => $self->status,
+        };
+        $content->{exception} = $self->exception
+          if $self->has_exception;
+        return $content;
+    }
+
+    # otherwise we check for a template, for a static file,
+    # for configured error_template, and, if all else fails,
+    # the default error page
+    if ( $self->has_app and $self->template ) {
+        # Render the template using apps' template engine.
+        # This may well be what caused the initial error, in which
+        # case we fall back to static page if any error was thrown.
+        # Note: this calls before/after render hooks.
+        my $content = eval {
+            $self->app->template(
+                $self->template,
+                {   title     => $self->title,
+                    content   => $self->message,
+                    exception => $self->exception,
+                    status    => $self->status,
+                }
+            );
+        };
+
+        # return rendered content unless there was an error.
+        return $content if defined $content;
+    }
+
+    # It doesn't make sense to return a static page if show_errors is on
+    if ( !$self->show_errors && (my $content = $self->static_page) ) {
+        return $content;
+    }
+
+    if ($self->has_app && $self->app->config->{error_template}) {
+        my $content = eval {
+            $self->app->template(
+                $self->app->config->{error_template},
+                {   title     => $self->title,
+                    content   => $self->message,
+                    exception => $self->exception,
+                    status    => $self->status,
+                }
+            );
+        };
+
+        # return rendered content unless there was an error.
+        return $content if defined $content;
+    }
+
+    return $self->default_error_page;
+}
 
 sub throw {
     my $self = shift;
@@ -307,6 +308,7 @@ sub throw {
     $self->response->status( $self->status );
     $self->response->content_type( $self->content_type );
     $self->response->content($message);
+    $self->response->encode_content;
 
     $self->has_app &&
         $self->app->execute_hook('core.error.after', $self->response);

--- a/share/skel/environments/development.yml
+++ b/share/skel/environments/development.yml
@@ -16,7 +16,7 @@ warnings: 1
 
 # should Dancer2 show a stacktrace when an error is caught?
 # if set to yes, public/500.html will be ignored and either
-# views/500.tt or a default error template will be used.
+# views/500.tt, 'error_template' template, or a default error template will be used.
 show_errors: 1
 
 # print the banner


### PR DESCRIPTION
This is @drmuey commits from #847 (rebased onto current master and squished into a single commit) to fix the Fix HTTP Status template logic. There are still tests "outstanding" as per #846.

Those changes requires the Error `content` attribute to have byte (octect) strings to be for the http response. That implies the Error object needs to know about such things, hinting that we didn't have the abstraction/delegations correct; Error objects should only be concerned with character strings.

The response class handles serialization & encoding already, and `throw`ing an error populates a response object. The extra commit ensures that the Error's response object is generated with a serializer if the Error object has one, and calls `response->encode_content` when the error is thrown. Delegation FTW. 

Thanks also to @DavsX for picking this up in previous comments :)