### PR TITLE
Fix an uninitialized variable on malformed cookies (without a value).

### DIFF
--- a/lib/Dancer2/Core/Request.pm
+++ b/lib/Dancer2/Core/Request.pm
@@ -661,7 +661,7 @@ sub _build_cookies {
         # we want `cookie_name' as the value and `foo=bar' as the value
         my ( $name, $value ) = split( /\s*=\s*/, $cookie, 2 );
         my @values;
-        if ( $value ne '' ) {
+        if ( defined $value and $value ne '' ) {
             @values = map { uri_unescape($_) } split( /[&;]/, $value );
         }
         $cookies->{$name} =

--- a/t/request.t
+++ b/t/request.t
@@ -28,7 +28,7 @@ sub run_test {
         REMOTE_HOST          => 'localhost',
         HTTP_USER_AGENT      => 'Mozilla',
         REMOTE_USER          => 'sukria',
-        HTTP_COOKIE          => 'cookie.a=foo=bar; cookie.b=1234abcd',
+        HTTP_COOKIE          => 'cookie.a=foo=bar; cookie.b=1234abcd; no.value.cookie',
     };
 
     my $req = Dancer2::Core::Request->new( env => $env );
@@ -66,7 +66,7 @@ sub run_test {
     is_deeply { $req->params }, { foo => 42, bar => [ 12, 13, 14 ] };
 
     note "tests cookies";
-    is( keys %{ $req->cookies }, 2, "multiple cookies extracted" );
+    is( keys %{ $req->cookies }, 3, "multiple cookies extracted" );
 
     my $forward = Dancer2::Core::App->new( request => $req )
                                     ->make_forward_to('/somewhere');


### PR DESCRIPTION
Add such a cookie to the request test. It should simply be parsed same as
the valued cookies.

Fixes issue #852 