### PR TITLE
Fix the after_template_render hook example.

### DIFF
--- a/lib/Dancer2/Manual.pod
+++ b/lib/Dancer2/Manual.pod
@@ -448,7 +448,7 @@ template engine.
         my $content     = ${$ref_content};
 
         # do something with $content
-        $ref_content = \$content;
+        ${$ref_content} = $content;
     };
 
 =item * C<before_layout_render>


### PR DESCRIPTION
The example given for the `after_template_render` hook doesn't actually alter the content.

`$ref_content` is local to the sub, so anything done to it won't show up to the caller. Need to dereference it to assign to it; the `after_layout_render` example has it right.