### PR TITLE
Add "accept" header to supported routing match options

### DIFF
--- a/lib/Dancer2/Core/Route.pm
+++ b/lib/Dancer2/Core/Route.pm
@@ -46,7 +46,7 @@ sub _check_options {
 
     my @supported_options = (
         qw/content_type agent user_agent content_length
-          path_info/
+          path_info accept/
     );
     for my $opt ( keys %{$options} ) {
         croak "Not a valid option for route matching: `$opt'"

--- a/lib/Dancer2/Manual.pod
+++ b/lib/Dancer2/Manual.pod
@@ -272,7 +272,7 @@ keyword will return a reference to a copy of C<%+>.
 =head3 Conditional Matching
 
 Routes may include some matching conditions (on content_type, agent,
-user_agent, content_length and path_info):
+user_agent, content_length, path_info and accept):
 
     get '/foo', {agent => 'Songbird (\d\.\d)[\d\/]*?'} => sub {
       'foo method for songbird'

--- a/t/classes/Dancer2-Core-Route/match.t
+++ b/t/classes/Dancer2-Core-Route/match.t
@@ -68,7 +68,7 @@ my @tests = (
     ],
 );
 
-plan tests => 55;
+plan tests => 57;
 
 for my $t (@tests) {
     my ( $route, $path, $expected ) = @$t;
@@ -182,7 +182,7 @@ SKIP: {
     );
 
     my $m = $route_w_options->match($req);
-    ok !defined $m;
+    ok !defined $m, "no match with option agent";
 
     $req = Dancer2::Core::Request->new(
         path   => '/',
@@ -191,5 +191,30 @@ SKIP: {
     );
 
     $m = $route_w_options->match($req);
-    ok defined $m;
+    ok defined $m, "match with option agent";
+
+    my $route_w_accept = Dancer2::Core::Route->new(
+        method  => 'get',
+        regexp  => '/',
+        code    => sub {'options'},
+        options => { 'accept' => 'foo/bar-v3' },
+    );
+
+    $req = Dancer2::Core::Request->new(
+        path   => '/',
+        method => 'get',
+        env    => { 'HTTP_ACCEPT' => 'foo/bar-v2' },
+    );
+
+    $m = $route_w_accept->match($req);
+    ok !defined $m, "no match with option accept";
+    $req = Dancer2::Core::Request->new(
+        path   => '/',
+        method => 'get',
+        env    => { 'HTTP_ACCEPT' => 'foo/bar-v3' },
+    );
+
+    $m = $route_w_accept->match($req);
+    ok defined $m, "match with option accept";
+
 }


### PR DESCRIPTION
It would be nice if one could route depending on the accept header (for example if it contains an API version).