### PR TITLE
Eliminate a memory leak with hooks

### DIFF
--- a/Changes
+++ b/Changes
@@ -2,6 +2,8 @@
 
     [ BUG FIXES ]
     * Fixed another memory leak with compiled hooks. (Sawyer X)
+    * Fixed a memory leak with conditionally applied static middleware
+      (Russell Jenkins)
 
 0.159002  2015-03-03 19:21:21+01:00 Europe/Amsterdam
 

--- a/Changes
+++ b/Changes
@@ -1,5 +1,8 @@
 {{$NEXT}}
 
+    [ BUG FIXES ]
+    * Fixed another memory leak with compiled hooks. (Sawyer X)
+
 0.159002  2015-03-03 19:21:21+01:00 Europe/Amsterdam
 
     [ BUG FIXES ]

--- a/t/memory_cycles.t
+++ b/t/memory_cycles.t
@@ -19,10 +19,10 @@ use Plack::Test;
     };
 }
 
-MyApp::Cycles->to_app;
+my $app = MyApp::Cycles->to_app;
 
 my $runner = Dancer2->runner;
 memory_cycle_ok( $runner, "runner has no memory cycles" );
-memory_cycle_ok( $runner->apps->[0], "App has no memory cycles" );
+memory_cycle_ok( $app, "App has no memory cycles" );
 
 done_testing();

--- a/t/memory_cycles.t
+++ b/t/memory_cycles.t
@@ -17,8 +17,9 @@ use Plack::Test;
     get '/**' => sub {
         return { hello => 'world' };
     };
-
 }
+
+MyApp::Cycles->to_app;
 
 my $runner = Dancer2->runner;
 memory_cycle_ok( $runner, "runner has no memory cycles" );


### PR DESCRIPTION
When we compile hooks (`compile_hooks` method), we create a closure
that holds on to `$self`, causing a memory leak.

This wasn't detected in our memory leak test because we didn't
call `to_app` method on it (which finalizes the app and compiles
the hooks).

After calling `to_app`, the error shows itself. We then fix it
by closing over a weakened copy.

We also moved `$self->request` to `$Dancer2::Core::Route::REQUEST`,
which represents the current localized request.

(pinging @veryrusty to approve)