### PR TITLE
Dancer2::Core::Error - fix broken accessor

### DIFF
--- a/lib/Dancer2/Core/Error.pm
+++ b/lib/Dancer2/Core/Error.pm
@@ -295,7 +295,7 @@ sub _build_content {
 
 sub throw {
     my $self = shift;
-    $self->set_response(shift) if @_;
+    $self->response(shift) if @_;
 
     $self->response
         or croak "error has no response to throw at";

--- a/t/error.t
+++ b/t/error.t
@@ -116,6 +116,17 @@ subtest 'Response->error()' => sub {
     ok $resp->is_halted, 'response is halted';
 };
 
+subtest 'Throwing an error with a response' => sub {
+    my $resp = Dancer2::Core::Response->new;
+
+    my $err = eval { Dancer2::Core::Error->new(
+        exception   => 'our exception',
+        show_errors => 1
+    )->throw($resp) };
+      
+    isa_ok($err, 'Dancer2::Core::Response', "Error->throw() accepts a response");
+};
+
 subtest 'Error with show_errors: 0' => sub {
     my $err = Dancer2::Core::Error->new(
         exception   => 'our exception',


### PR DESCRIPTION
Dancer2::Core::Error::throw() attempts to set the response using set_response(), but response is 'rw', not 'rwp'.
