### PR TITLE
Cleanup: logging methods

### DIFF
--- a/lib/Dancer2/Core/DSL.pm
+++ b/lib/Dancer2/Core/DSL.pm
@@ -97,10 +97,11 @@ sub dancer_major_version {
     return ( split /\./, dancer_version )[0];
 }
 
-sub debug   { shift->log( debug   => @_ ) }
-sub info    { shift->log( info    => @_ ) }
-sub warning { shift->log( warning => @_ ) }
-sub error   { shift->log( error   => @_ ) }
+sub log     { shift->app->log( @_ ) }
+sub debug   { shift->app->log( debug   => @_ ) }
+sub info    { shift->app->log( info    => @_ ) }
+sub warning { shift->app->log( warning => @_ ) }
+sub error   { shift->app->log( error   => @_ ) }
 
 sub true  {1}
 sub false {0}
@@ -408,8 +409,6 @@ sub to_dumper {
     require Dancer2::Serializer::Dumper;
     Dancer2::Serializer::Dumper::to_dumper(@_);
 }
-
-sub log { shift->app->log(@_) }
 
 1;
 

--- a/lib/Dancer2/Core/Role/Hookable.pm
+++ b/lib/Dancer2/Core/Role/Hookable.pm
@@ -5,6 +5,7 @@ use Moo::Role;
 use Dancer2::Core;
 use Dancer2::Core::Types;
 use Carp 'croak';
+use Safe::Isa;
 
 requires 'supported_hooks';
 
@@ -134,8 +135,8 @@ sub execute_hook {
     croak "Hook '$name' does not exist"
       if !$self->has_hook($name);
 
-    ref($self) eq 'Dancer2::Core::App' &&
-        $self->engine('logger')->core("Entering hook $name");
+    $self->$_isa('Dancer2::Core::App') &&
+      $self->log( core => "Entering hook $name" );
 
     for my $hook ( @{ $self->hooks->{$name} } ) {
         $hook->(@args);

--- a/lib/Dancer2/Core/Role/Logger.pm
+++ b/lib/Dancer2/Core/Role/Logger.pm
@@ -75,7 +75,7 @@ sub format_message {
     $message = Encode::encode( $self->auto_encoding_charset, $message )
       if $self->auto_encoding_charset;
 
-    my @stack = caller(6);
+    my @stack = caller(5);
     my $request = $self->request;
     my $config = $self->config;
 

--- a/t/logger_console.t
+++ b/t/logger_console.t
@@ -5,14 +5,30 @@ use Test::More;
 use Capture::Tiny 0.12 'capture_stderr';
 use Dancer2::Logger::Console;
 
-my $l =
-  Dancer2::Logger::Console->new( app_name => 'test', log_level => 'core' );
+my $file = __FILE__;
+my $l = Dancer2::Logger::Console->new(
+    app_name => 'test',
+    log_level => 'core'
+);
 
-for my $level (qw{core debug warning error}) {
+for my $level (qw{core debug info warning error}) {
     my $stderr = capture_stderr { $l->$level("$level") };
 
-    # Again, we are dealing directly with the logger, not through the
-    # DSL, so the caller(6) stack has a different size
-    like $stderr, qr{$level in -}, "$level message sent";
+    # We are dealing directly with the logger, not through the DSL.
+    # Skipping 5 stack frames is likely to point to somewhere outside
+    # this test; however Capture::Tiny adds in several call frames
+    # (see below) to capture the output, giving a reasonable caller
+    # to test for
+    like $stderr, qr{$level in $file l. 15}, "$level message sent";
 }
 done_testing;
+
+__END__
+
+# Stack frames involved where Role::Logger executes caller(5):
+#   Dancer2::Core::Role::Logger::format_message(Dancer2::Logger::Console=HASH(0x7f8e41029c60), "error", "error") called at lib/Dancer2/Logger/Console.pm line 10
+#   Dancer2::Logger::Console::log(Dancer2::Logger::Console=HASH(0x7f8e41029c60), "error", "error") called at lib/Dancer2/Core/Role/Logger.pm line 183
+#   Dancer2::Core::Role::Logger::error(Dancer2::Logger::Console=HASH(0x7f8e41029c60), "error") called at t/logger_console.t line 12
+#   main::__ANON__() called at Capture/Tiny.pm line 369
+#   eval {...} called at Capture/Tiny.pm line 369
+#   Capture::Tiny::_capture_tee(0, 1, 0, 0, CODE(0x7f8e418181e0)) called at t/logger_console.t line 12


### PR DESCRIPTION
The DSL keywords for logging (`debug`, `info`, `warning` and `error`) as well as `Role::Hookable` now call the `log` method on an app object.  

While this doesn't solve #791, it reduces the number of cases we need to deal with for the "magic" number of call stacks to skip to report the caller from 4 to 2.