### PR TITLE
Add cookie timeout example to YAML session

### DIFF
--- a/lib/Dancer2/Session/YAML.pm
+++ b/lib/Dancer2/Session/YAML.pm
@@ -58,6 +58,7 @@ files in /tmp/dancer-sessions
       session:
         YAML:
           session_dir: "/tmp/dancer-sessions"
+          cookie_duration: 3600    # Default cookie timeout in seconds
 
 =head1 DEPENDENCY
 


### PR DESCRIPTION
I dare say this is in the documentation somewhere, but I couldn't find it, and this is one place where I thought I might find the information.