### PR TITLE
GH #879: Remove the requirement for two version numbers:

### DIFF
--- a/lib/Dancer2.pm
+++ b/lib/Dancer2.pm
@@ -13,11 +13,6 @@ use Dancer2::FileUtils;
 
 our $AUTHORITY = 'SUKRIA';
 
-# set version in dist.ini now
-# but we still need a basic version for
-# the tests
-$Dancer2::VERSION ||= '0.159000';
-
 our $runner;
 
 sub runner   {$runner}

--- a/lib/Dancer2/Core/DSL.pm
+++ b/lib/Dancer2/Core/DSL.pm
@@ -91,7 +91,7 @@ sub dsl_keywords {
 }
 
 sub dancer_app     { shift->app }
-sub dancer_version { Dancer2->VERSION }
+sub dancer_version { $Dancer2::VERSION || 'DUMMY' }
 
 sub dancer_major_version {
     return ( split /\./, dancer_version )[0];

--- a/lib/Dancer2/Core/Error.pm
+++ b/lib/Dancer2/Core/Error.pm
@@ -113,7 +113,7 @@ sub default_error_page {
         title    => $self->title,
         charset  => $self->charset,
         content  => $message,
-        version  => Dancer2->VERSION,
+        version  => $Dancer2::VERSION || 'DUMMY',
         uri_base => $uri_base,
     };
 

--- a/lib/Dancer2/Core/Response.pm
+++ b/lib/Dancer2/Core/Response.pm
@@ -125,8 +125,9 @@ sub new_from_array {
 sub to_psgi {
     my ($self) = @_;
 
+    my $version = $Dancer2::VERSION || 'DUMMY';
     Dancer2->runner->config->{'no_server_tokens'}
-        or $self->header( 'Server' => "Perl Dancer2 $Dancer2::VERSION" );
+        or $self->header( 'Server' => "Perl Dancer2 $version" );
 
     # It is possible to have no content and/or no content type set
     # e.g. if all routes 'pass'. Apply defaults here..

--- a/lib/Dancer2/Core/Role/Template.pm
+++ b/lib/Dancer2/Core/Role/Template.pm
@@ -171,7 +171,7 @@ sub _prepare_tokens_options {
     # these are the default tokens provided for template processing
     $tokens ||= {};
     $tokens->{perl_version}   = $];
-    $tokens->{dancer_version} = Dancer2->VERSION;
+    $tokens->{dancer_version} = $Dancer2::VERSION || 'DUMMY';
 
     $tokens->{settings} = $self->settings;
     $tokens->{request}  = $self->request;

--- a/lib/Dancer2/Core/Runner.pm
+++ b/lib/Dancer2/Core/Runner.pm
@@ -76,11 +76,12 @@ has timeout => (
 sub _build_server {
     my $self = shift;
 
+    my $version = $Dancer2::VERSION || 'DUMMY';
     HTTP::Server::PSGI->new(
         host            => $self->host,
         port            => $self->port,
         timeout         => $self->timeout,
-        server_software => "Perl Dancer2 $Dancer2::VERSION",
+        server_software => "Perl Dancer2 $version",
     );
 }
 
@@ -229,7 +230,8 @@ sub print_banner {
     $self->config->{'startup_info'} or return;
 
     # bare minimum
-    print STDERR ">> Dancer2 v$Dancer2::VERSION server $pid listening "
+    my $version = $Dancer2::VERSION || 'DUMMY';
+    print STDERR ">> Dancer2 v$version server $pid listening "
       . 'on http://'
       . $self->host . ':'
       . $self->port . "\n";

--- a/lib/Dancer2/Test.pm
+++ b/lib/Dancer2/Test.pm
@@ -98,6 +98,7 @@ sub _build_request_from_env {
       : ref $_[0] eq 'ARRAY' ? @{ $_[0] }
       :                        ( GET => $_[0], {} );
 
+    my $version = $Dancer2::VERSION || 'DUMMY';
     my $env = {
         %ENV,
         REQUEST_METHOD    => uc($method),
@@ -108,7 +109,7 @@ sub _build_request_from_env {
         SERVER_NAME       => 'localhost',
         SERVER_PORT       => 3000,
         HTTP_HOST         => 'localhost',
-        HTTP_USER_AGENT   => "Dancer2::Test simulator v " . Dancer2->VERSION,
+        HTTP_USER_AGENT   => "Dancer2::Test simulator v " . $version,
     };
 
     if ( defined $options->{params} ) {
@@ -183,6 +184,7 @@ sub _build_request_from_env {
 sub _build_env_from_request {
     my ($request) = @_;
 
+    my $version = $Dancer2::VERSION || 'DUMMY';
     my $env = {
         REQUEST_METHOD    => $request->method,
         PATH_INFO         => $request->path,
@@ -192,7 +194,7 @@ sub _build_env_from_request {
         SERVER_NAME       => 'localhost',
         SERVER_PORT       => 3000,
         HTTP_HOST         => 'localhost',
-        HTTP_USER_AGENT   => "Dancer2::Test simulator v $Dancer2::VERSION",
+        HTTP_USER_AGENT   => "Dancer2::Test simulator v $version",
     };
 
     # TODO

--- a/t/classes/Dancer2-Core-Runner/new.t
+++ b/t/classes/Dancer2-Core-Runner/new.t
@@ -47,9 +47,11 @@ note 'server'; {
         is( $server->{$attr}, $runner->$attr, "$attr set correctly in Server" );
     }
 
+    my $version = $Dancer2::VERSION || 'DUMMY';
+
     is(
         $server->{'server_software'},
-        "Perl Dancer2 $Dancer2::VERSION",
+        "Perl Dancer2 $version",
         'server_software set correctly in Server',
     );
 }

--- a/t/dancer-test.t
+++ b/t/dancer-test.t
@@ -69,7 +69,8 @@ response_content_unlike $_ => qr/ought/ for @routes;
 response_status_is $_   => 200 for @routes;
 response_status_isnt $_ => 203 for @routes;
 
-response_headers_include $_ => [ Server => "Perl Dancer2 $Dancer2::VERSION" ]
+my $version = $Dancer2::VERSION || 'DUMMY';
+response_headers_include $_ => [ Server => "Perl Dancer2 $version" ]
   for @routes;
 
 ## Check parameters get through ok

--- a/t/dispatcher.t
+++ b/t/dispatcher.t
@@ -15,6 +15,7 @@ set logger => 'Null';
 # init our test fixture
 my $buffer = {};
 my $app = Dancer2::Core::App->new( name => 'main' );
+my $version = $Dancer2::VERSION || 'DUMMY';
 
 $app->setting( logger      => engine('logger') );
 $app->setting( show_errors => 1 );
@@ -74,7 +75,7 @@ my @tests = (
             200,
             [   'Content-Length' => 4,
                 'Content-Type'   => 'text/html; charset=UTF-8',
-                'Server'         => "Perl Dancer2 $Dancer2::VERSION",
+                'Server'         => "Perl Dancer2 $version",
             ],
             ["home"]
         ]
@@ -87,7 +88,7 @@ my @tests = (
             200,
             [   'Content-Length' => 12,
                 'Content-Type'   => 'text/html; charset=UTF-8',
-                'Server'         => "Perl Dancer2 $Dancer2::VERSION",
+                'Server'         => "Perl Dancer2 $version",
             ],
             ["Hello Johnny"]
         ]
@@ -99,7 +100,7 @@ my @tests = (
         expected => [
             204,
             [   'Content-Type'   => 'text/html; charset=UTF-8',
-                'Server'         => "Perl Dancer2 $Dancer2::VERSION",
+                'Server'         => "Perl Dancer2 $version",
             ],
             []
         ]
@@ -113,7 +114,7 @@ my @tests = (
             [   'Location'       => 'http://perldancer.org',
                 'Content-Length' => '305',
                 'Content-Type'   => 'text/html; charset=utf-8',
-                'Server'         => "Perl Dancer2 $Dancer2::VERSION",
+                'Server'         => "Perl Dancer2 $version",
             ],
             qr/This item has moved/
         ]

--- a/t/dsl/halt.t
+++ b/t/dsl/halt.t
@@ -37,10 +37,11 @@ subtest 'halt within routes' => sub {
 
         {
             my $res = $cb->( GET '/halt' );
+            my $version = $Dancer2::VERSION || 'DUMMY';
 
             is(
                 $res->server,
-                "Perl Dancer2 $Dancer2::VERSION",
+                "Perl Dancer2 $version",
                 '[/halt] Correct Server header',
             );
 

--- a/t/forward.t
+++ b/t/forward.t
@@ -36,6 +36,8 @@ get '/go_to_post/' => sub {
 my $app = __PACKAGE__->to_app;
 is( ref $app, 'CODE', 'Got app' );
 
+my $version = $Dancer2::VERSION || 'DUMMY';
+
 test_psgi $app, sub {
     my $cb = shift;
     is( $cb->( GET '/' )->code, 200, '[GET /] Correct code' );
@@ -111,7 +113,7 @@ test_psgi $app, sub {
 
         is(
             $res->headers->server,
-            "Perl Dancer2 $Dancer2::VERSION",
+            "Perl Dancer2 $version",
             '[GET /bounce/] Correct Server',
         );
 
@@ -159,7 +161,7 @@ test_psgi $app, sub {
 
         is(
             $res->headers->server,
-            "Perl Dancer2 $Dancer2::VERSION",
+            "Perl Dancer2 $version",
             '[POST /bounce/] Correct Server',
         );
     }

--- a/t/forward_test_tcp.t
+++ b/t/forward_test_tcp.t
@@ -38,6 +38,8 @@ use HTTP::Request::Common;
 my $app = Dancer2->psgi_app;
 is( ref $app, 'CODE', 'Got app' );
 
+my $version = $Dancer2::VERSION || 'DUMMY';
+
 test_psgi $app, sub {
     my $cb = shift;
 
@@ -64,7 +66,7 @@ test_psgi $app, sub {
     $res = $cb->(GET "/bounce/");
     is $res->header('Content-Length') => 5;
     is $res->header('Content-Type')   => 'text/html; charset=UTF-8';
-    is $res->header('Server')         => "Perl Dancer2 $Dancer2::VERSION";
+    is $res->header('Server')         => "Perl Dancer2 $version";
 
     $res = $cb->(POST "/");
     is $res->code    => 200;
@@ -75,7 +77,7 @@ test_psgi $app, sub {
     is $res->content                  => 'post-home';
     is $res->header('Content-Length') => 9;
     is $res->header('Content-Type')   => 'text/html; charset=UTF-8';
-    is $res->header('Server')         => "Perl Dancer2 $Dancer2::VERSION";
+    is $res->header('Server')         => "Perl Dancer2 $version";
 };
 
 done_testing();

--- a/t/response.t
+++ b/t/response.t
@@ -14,9 +14,10 @@ $r = Dancer2::Core::Response->new(
     content => 'foo',
 );
 
+my $version = $Dancer2::VERSION || 'DUMMY';
 is_deeply $r->to_psgi,
   [ 200,
-    [   Server         => "Perl Dancer2 $Dancer2::VERSION",
+    [   Server         => "Perl Dancer2 $version",
         'Content-Type' => 'text/html',
     ],
     ['foo']

--- a/t/template_default_tokens.t
+++ b/t/template_default_tokens.t
@@ -30,8 +30,9 @@ my $views =
     };
 }
 
+my $version  = $Dancer2::VERSION || 'DUMMY';
 my $expected = "perl_version: $]
-dancer_version: ${Dancer2::VERSION}
+dancer_version: $version
 settings.foo: in settings
 params.foo: 42
 session.foo in session


### PR DESCRIPTION
Dist::Zilla (dzil) was in charge of providing the version number for
the Dancer release, except some test scripts depended on having a
version number too (for example, when testing headers containing the
Server with version).

The issue GH #879 raises is that Dist::Zilla's PkgVersion doesn't
add the version so if dzil's version number is ignored and the one
in the .pm file is used instead.

This commit resolves it by removing the version number everywhere
and any place that requires a version will check for
VERSION || "DUMMY".