### PR TITLE
Alt implementation to remove dual version numbers

### DIFF
--- a/lib/Dancer2.pm
+++ b/lib/Dancer2.pm
@@ -13,10 +13,7 @@ use Dancer2::FileUtils;
 
 our $AUTHORITY = 'SUKRIA';
 
-# set version in dist.ini now
-# but we still need a basic version for
-# the tests
-$Dancer2::VERSION ||= '0.159000';
+sub VERSION { shift->SUPER::VERSION || '0.000000_000' }
 
 our $runner;
 

--- a/lib/Dancer2/CLI/Command/gen.pm
+++ b/lib/Dancer2/CLI/Command/gen.pm
@@ -108,7 +108,7 @@ NOYAML
 
 sub version {
     require Dancer2;
-    return $Dancer2::VERSION;
+    return Dancer2->VERSION;
 }
 
 # skel creation routines

--- a/lib/Dancer2/CLI/Command/version.pm
+++ b/lib/Dancer2/CLI/Command/version.pm
@@ -11,7 +11,7 @@ sub command_names {
 
 sub execute {
     require Dancer2;
-    print 'Dancer2 ' . $Dancer2::VERSION . "\n";
+    print 'Dancer2 ' . Dancer2->VERSION . "\n";
     return 0;
 }
 

--- a/lib/Dancer2/Core/Response.pm
+++ b/lib/Dancer2/Core/Response.pm
@@ -126,7 +126,7 @@ sub to_psgi {
     my ($self) = @_;
 
     Dancer2->runner->config->{'no_server_tokens'}
-        or $self->header( 'Server' => "Perl Dancer2 $Dancer2::VERSION" );
+        or $self->header( 'Server' => "Perl Dancer2 " . Dancer2->VERSION );
 
     # It is possible to have no content and/or no content type set
     # e.g. if all routes 'pass'. Apply defaults here..

--- a/lib/Dancer2/Core/Runner.pm
+++ b/lib/Dancer2/Core/Runner.pm
@@ -80,7 +80,7 @@ sub _build_server {
         host            => $self->host,
         port            => $self->port,
         timeout         => $self->timeout,
-        server_software => "Perl Dancer2 $Dancer2::VERSION",
+        server_software => "Perl Dancer2 " . Dancer2->VERSION,
     );
 }
 
@@ -229,7 +229,7 @@ sub print_banner {
     $self->config->{'startup_info'} or return;
 
     # bare minimum
-    print STDERR ">> Dancer2 v$Dancer2::VERSION server $pid listening "
+    print STDERR ">> Dancer2 v" . Dancer2->VERSION . " server $pid listening "
       . 'on http://'
       . $self->host . ':'
       . $self->port . "\n";

--- a/lib/Dancer2/Test.pm
+++ b/lib/Dancer2/Test.pm
@@ -192,7 +192,7 @@ sub _build_env_from_request {
         SERVER_NAME       => 'localhost',
         SERVER_PORT       => 3000,
         HTTP_HOST         => 'localhost',
-        HTTP_USER_AGENT   => "Dancer2::Test simulator v $Dancer2::VERSION",
+        HTTP_USER_AGENT   => "Dancer2::Test simulator v" . Dancer2->VERSION,
     };
 
     # TODO

--- a/t/classes/Dancer2-Core-Runner/new.t
+++ b/t/classes/Dancer2-Core-Runner/new.t
@@ -49,7 +49,7 @@ note 'server'; {
 
     is(
         $server->{'server_software'},
-        "Perl Dancer2 $Dancer2::VERSION",
+        "Perl Dancer2 " . Dancer2->VERSION,
         'server_software set correctly in Server',
     );
 }

--- a/t/dancer-test.t
+++ b/t/dancer-test.t
@@ -69,7 +69,7 @@ response_content_unlike $_ => qr/ought/ for @routes;
 response_status_is $_   => 200 for @routes;
 response_status_isnt $_ => 203 for @routes;
 
-response_headers_include $_ => [ Server => "Perl Dancer2 $Dancer2::VERSION" ]
+response_headers_include $_ => [ Server => "Perl Dancer2 " . Dancer2->VERSION ]
   for @routes;
 
 ## Check parameters get through ok

--- a/t/dispatcher.t
+++ b/t/dispatcher.t
@@ -74,7 +74,7 @@ my @tests = (
             200,
             [   'Content-Length' => 4,
                 'Content-Type'   => 'text/html; charset=UTF-8',
-                'Server'         => "Perl Dancer2 $Dancer2::VERSION",
+                'Server'         => "Perl Dancer2 " . Dancer2->VERSION,
             ],
             ["home"]
         ]
@@ -87,7 +87,7 @@ my @tests = (
             200,
             [   'Content-Length' => 12,
                 'Content-Type'   => 'text/html; charset=UTF-8',
-                'Server'         => "Perl Dancer2 $Dancer2::VERSION",
+                'Server'         => "Perl Dancer2 " . Dancer2->VERSION,
             ],
             ["Hello Johnny"]
         ]
@@ -99,7 +99,7 @@ my @tests = (
         expected => [
             204,
             [   'Content-Type'   => 'text/html; charset=UTF-8',
-                'Server'         => "Perl Dancer2 $Dancer2::VERSION",
+                'Server'         => "Perl Dancer2 " . Dancer2->VERSION,
             ],
             []
         ]
@@ -113,7 +113,7 @@ my @tests = (
             [   'Location'       => 'http://perldancer.org',
                 'Content-Length' => '305',
                 'Content-Type'   => 'text/html; charset=utf-8',
-                'Server'         => "Perl Dancer2 $Dancer2::VERSION",
+                'Server'         => "Perl Dancer2 " . Dancer2->VERSION,
             ],
             qr/This item has moved/
         ]

--- a/t/dsl/halt.t
+++ b/t/dsl/halt.t
@@ -40,7 +40,7 @@ subtest 'halt within routes' => sub {
 
             is(
                 $res->server,
-                "Perl Dancer2 $Dancer2::VERSION",
+                "Perl Dancer2 " . Dancer2->VERSION,
                 '[/halt] Correct Server header',
             );
 

--- a/t/forward.t
+++ b/t/forward.t
@@ -111,7 +111,7 @@ test_psgi $app, sub {
 
         is(
             $res->headers->server,
-            "Perl Dancer2 $Dancer2::VERSION",
+            "Perl Dancer2 " . Dancer2->VERSION,
             '[GET /bounce/] Correct Server',
         );
 
@@ -159,7 +159,7 @@ test_psgi $app, sub {
 
         is(
             $res->headers->server,
-            "Perl Dancer2 $Dancer2::VERSION",
+            "Perl Dancer2 " . Dancer2->VERSION,
             '[POST /bounce/] Correct Server',
         );
     }

--- a/t/forward_test_tcp.t
+++ b/t/forward_test_tcp.t
@@ -64,7 +64,7 @@ test_psgi $app, sub {
     $res = $cb->(GET "/bounce/");
     is $res->header('Content-Length') => 5;
     is $res->header('Content-Type')   => 'text/html; charset=UTF-8';
-    is $res->header('Server')         => "Perl Dancer2 $Dancer2::VERSION";
+    is $res->header('Server')         => "Perl Dancer2 " . Dancer2->VERSION;
 
     $res = $cb->(POST "/");
     is $res->code    => 200;
@@ -75,7 +75,7 @@ test_psgi $app, sub {
     is $res->content                  => 'post-home';
     is $res->header('Content-Length') => 9;
     is $res->header('Content-Type')   => 'text/html; charset=UTF-8';
-    is $res->header('Server')         => "Perl Dancer2 $Dancer2::VERSION";
+    is $res->header('Server')         => "Perl Dancer2 " . Dancer2->VERSION;
 };
 
 done_testing();

--- a/t/response.t
+++ b/t/response.t
@@ -16,7 +16,7 @@ $r = Dancer2::Core::Response->new(
 
 is_deeply $r->to_psgi,
   [ 200,
-    [   Server         => "Perl Dancer2 $Dancer2::VERSION",
+    [   Server         => "Perl Dancer2 " . Dancer2->VERSION,
         'Content-Type' => 'text/html',
     ],
     ['foo']

--- a/t/template_default_tokens.t
+++ b/t/template_default_tokens.t
@@ -30,8 +30,9 @@ my $views =
     };
 }
 
+my $version = Dancer2->VERSION;
 my $expected = "perl_version: $]
-dancer_version: ${Dancer2::VERSION}
+dancer_version: ${version}
 settings.foo: in settings
 params.foo: 42
 session.foo in session


### PR DESCRIPTION
Overrides the VERSION method (provided by UNIVERSAL) to supply the
default Dancer2 versionstring the test suite requires. Dzil will
then add the appropriate $Dancer2::VERSION on package build.

This is an alternate implementation to what is provided in #882
(without which I wouldn't have bothered attempting this). @xsawyerx++

Fixes #879.