### PR TITLE
Workaround Plugin Hooks problem

### DIFF
--- a/lib/Dancer2/Core/Role/Hookable.pm
+++ b/lib/Dancer2/Core/Role/Hookable.pm
@@ -9,12 +9,25 @@ use Carp 'croak';
 requires 'supported_hooks';
 
 # The hooks registry
-has hooks => (
-    is      => 'ro',
-    isa     => HashRef,
-    builder => '_build_hooks',
-    lazy    => 1,
+#has hooks => (
+#    is      => 'ro',
+#    isa     => HashRef,
+#    builder => '_build_hooks',
+#    lazy    => 1,
+#);
+
+has _hooks => (
+    is => 'ro',
+    isa => HashRef,
+    default => sub { +{} },
 );
+
+sub hooks {
+    my $self = shift;
+    my $hooks = $self->_build_hooks;
+    $hooks = { %$hooks, %{$self->_hooks}};
+    return $hooks;
+}
 
 sub BUILD { }
 
@@ -100,7 +113,7 @@ sub add_hook {
     croak "Unsupported hook '$name'"
       unless $self->has_hook($name);
 
-    push @{ $self->hooks->{$name} }, $code;
+    push @{ $self->_hooks->{$name} }, $code;
 }
 
 # allows the caller to replace the current list of hooks at the given position
@@ -112,7 +125,7 @@ sub replace_hook {
     croak "Hook '$position' must be installed first"
       unless $self->has_hook($position);
 
-    $self->hooks->{$position} = $hooks;
+    $self->_hooks->{$position} = $hooks;
 }
 
 # Boolean flag to tells if the hook is registered or not

--- a/lib/Dancer2/Plugin.pm
+++ b/lib/Dancer2/Plugin.pm
@@ -71,8 +71,8 @@ sub register_plugin {
         }
     }
 
-# create the import method of the caller (the actual plugin) in order to make it
-# imports all the DSL's keyword when it's used.
+    # create the import method of the caller (the actual plugin) in order to
+    # make it imports all the DSL's keyword when it's used.
     my $import = sub {
         my $plugin = shift;
 
@@ -109,7 +109,7 @@ sub register_plugin {
     # The plugin is ready now.
 }
 
-sub plugin_args {@_}
+sub plugin_args { @_ }
 
 sub plugin_setting {
     my $plugin = caller;


### PR DESCRIPTION
As @veryrusty mentioned, plugins are a problem, and there are
changes planned. Nevertheless, I think that the fact of Dancer2
not being able to use two "often used" modules together, like
Dancer2::Plugin::Database and Dancer2::Plugin::Deferred, it also
a big problem.

While we do not do the module rewriting, I am suggesting this
simple workaround. It is not brilliant, it is not efficient, but
it seems to work.