### PR TITLE
Have set() perform merge when passed a hashref value

### DIFF
--- a/lib/Dancer2/Core/Role/ConfigReader.pm
+++ b/lib/Dancer2/Core/Role/ConfigReader.pm
@@ -157,7 +157,13 @@ sub _set_config_entry {
 
     $value = $self->_normalize_config_entry( $name, $value );
     $value = $self->_compile_config_entry( $name, $value, $self->config );
-    $self->config->{$name} = $value;
+
+    if ( ref $self->config->{$name} eq 'HASH' && ref $value eq 'HASH' ) {
+        $self->config->{$name} = Hash::Merge::Simple->merge( $self->config->{$name}, $value );
+    }
+    else {
+       $self->config->{$name} = $value;
+    }
 }
 
 sub _normalize_config {

--- a/t/config_settings.t
+++ b/t/config_settings.t
@@ -28,4 +28,21 @@ ok( setting('foo') == 43 && setting('bar') == 44,
     'set multiple values successful'
 );
 
+setting( plugins => {
+    Foo => {
+        option => 'value',
+    }
+} );
+set( plugins => {
+    Bar => {
+        setting => 'yes',
+    }
+} );
+
+is( config->{plugins}->{Foo}->{option}, 'value', 'plugins settings merged' );
+is( config->{plugins}->{Bar}->{setting}, 'yes', 'new plugin cfg set correctly' );
+
+set( plugins => 'ohno' );
+is( config->{plugins}, 'ohno', 'plugins value replaced when hashref not passed' );
+
 done_testing;


### PR DESCRIPTION
Apropos of some discussion on irc.perl.org#dancer, this change will merge config settings when `set()` or similar is passed a hashref value and the existing value is a hashref.

Use case is, I'm a bad developer and have set config values both in files and in code. I would like to set, say, an 'engines' or 'plugins' value in code without that rolling over existing settings. Instead of having to do, say:

```perl
    set(
        engines  => {
            ( config->{engines} )
            ? %{ config->{engines} }
            : (),
            serializer => {
                JSON => {
                    convert_blessed => 1,
                },
            },
        }
    )
```

You could simply:

```perl
    set(
        engines  => {
            serializer => {
                JSON => {
                    convert_blessed => 1,
                },
            },
        }
    )
```

Though I'm unsure how badly this breaks expected behaviour. Since merge is done for config files, I kind of expected it to be done for `set()` too.