### PR TITLE
workaround: multiple plugins with hooks

### DIFF
--- a/lib/Dancer2/Core/App.pm
+++ b/lib/Dancer2/Core/App.pm
@@ -618,6 +618,39 @@ sub supported_hooks {
       /;
 }
 
+sub hook_aliases {
+    {
+        before                 => 'core.app.before_request',
+        before_request         => 'core.app.before_request',
+        after                  => 'core.app.after_request',
+        after_request          => 'core.app.after_request',
+        init_error             => 'core.error.init',
+        before_error           => 'core.error.before',
+        after_error            => 'core.error.after',
+        on_route_exception     => 'core.app.route_exception',
+
+        # send_file builds a Handler::File object
+        # #869 replaces these with core hook equivilants
+        before_file_render     => 'handler.file.before_render',
+        after_file_render      => 'handler.file.after_render',
+
+        # compatibility from Dancer1
+        before_error_render    => 'core.error.before',
+        after_error_render     => 'core.error.after',
+        before_error_init      => 'core.error.init',
+
+        # TODO: call $engine->hook_aliases as needed
+        # But.. currently there are use cases where hook_aliases
+        # are needed before the engines are intiialized :(
+        before_template_render => 'engine.template.before_render',
+        after_template_render  => 'engine.template.after_render',
+        before_layout_render   => 'engine.template.before_layout_render',
+        after_layout_render    => 'engine.template.after_layout_render',
+        before_serializer      => 'engine.serializer.before',
+        after_serializer       => 'engine.serializer.after',
+    };
+}
+
 # FIXME not needed anymore, I suppose...
 sub api_version {2}
 

--- a/lib/Dancer2/Core/App.pm
+++ b/lib/Dancer2/Core/App.pm
@@ -159,7 +159,7 @@ sub _build_logger_engine {
         location        => $self->config_location,
         environment     => $self->environment,
         app_name        => $self->name,
-        postponed_hooks => $self->get_postponed_hooks
+        postponed_hooks => $self->postponed_hooks
     );
 
     exists $config->{log} and $logger->log_level($config->{log});
@@ -188,7 +188,7 @@ sub _build_session_engine {
     return $self->_factory->create(
         session         => $value,
         %{$engine_options},
-        postponed_hooks => $self->get_postponed_hooks,
+        postponed_hooks => $self->postponed_hooks,
 
         log_cb => sub { $weak_self->logger->log(@_) },
     );
@@ -221,7 +221,7 @@ sub _build_template_engine {
     return $self->_factory->create(
         template        => $value,
         %{$engine_attrs},
-        postponed_hooks => $self->get_postponed_hooks,
+        postponed_hooks => $self->postponed_hooks,
 
         log_cb => sub { $weak_self->logger->log(@_) },
     );
@@ -246,7 +246,7 @@ sub _build_serializer_engine {
     return $self->_factory->create(
         serializer      => $value,
         config          => $engine_options,
-        postponed_hooks => $self->get_postponed_hooks,
+        postponed_hooks => $self->postponed_hooks,
 
         log_cb => sub { $weak_self->logger_engine->log(@_) },
     );

--- a/lib/Dancer2/Core/App.pm
+++ b/lib/Dancer2/Core/App.pm
@@ -804,6 +804,10 @@ sub finish {
     my $self = shift;
     $self->register_route_handlers;
     $self->compile_hooks;
+    @{$self->plugins} &&
+      $self->plugins->[0]->_add_postponed_plugin_hooks(
+        $self->postponed_hooks
+    );
 }
 
 sub init_route_handlers {

--- a/lib/Dancer2/Core/DSL.pm
+++ b/lib/Dancer2/Core/DSL.pm
@@ -11,6 +11,26 @@ use Dancer2::Core::Response::Delayed;
 
 with 'Dancer2::Core::Role::DSL';
 
+sub _add_postponed_plugin_hooks {
+    my ( $self, $postponed_hooks) = @_;
+
+    $postponed_hooks = $postponed_hooks->{'plugin'};
+    return unless defined $postponed_hooks;
+
+    for my $plugin ( keys %{$postponed_hooks} ) {
+        for my $name ( keys %{$postponed_hooks->{$plugin} } ) {
+            my $hook   = $postponed_hooks->{$plugin}{$name}{hook};
+            my $caller = $postponed_hooks->{$plugin}{$name}{caller};
+
+            $self->has_hook($name)
+              or croak "plugin $plugin does not support the hook `$name'. ("
+              . join( ", ", @{$caller} ) . ")";
+
+            $self->add_hook($hook);
+        }
+    }
+}
+
 sub dsl_keywords {
 
     # the flag means : 1 = is global, 0 = is not global. global means can be

--- a/lib/Dancer2/Core/DSL.pm
+++ b/lib/Dancer2/Core/DSL.pm
@@ -11,6 +11,9 @@ use Dancer2::Core::Response::Delayed;
 
 with 'Dancer2::Core::Role::DSL';
 
+sub hook_aliases { +{} }
+sub supported_hooks { () }
+
 sub _add_postponed_plugin_hooks {
     my ( $self, $postponed_hooks) = @_;
 

--- a/lib/Dancer2/Core/Role/ConfigReader.pm
+++ b/lib/Dancer2/Core/Role/ConfigReader.pm
@@ -215,11 +215,6 @@ sub load_config_file {
     return $config;
 }
 
-sub get_postponed_hooks {
-    my ($self) = @_;
-    return $self->postponed_hooks;
-}
-
 # private
 
 my $_normalizers = {
@@ -315,5 +310,3 @@ Verifies that a key exists in the configuration.
 =head2 load_config_file
 
 Load the configuration files.
-
-=head2 get_postponed_hooks

--- a/lib/Dancer2/Core/Role/DSL.pm
+++ b/lib/Dancer2/Core/Role/DSL.pm
@@ -17,8 +17,6 @@ has keywords => (
     builder => '_build_dsl_keywords',
 );
 
-sub supported_hooks { }
-
 sub _build_dsl_keywords {
     my ($self) = @_;
     $self->can('dsl_keywords')

--- a/lib/Dancer2/Core/Role/Hookable.pm
+++ b/lib/Dancer2/Core/Role/Hookable.pm
@@ -19,34 +19,6 @@ has hooks => (
 
 sub BUILD { }
 
-# this hash contains all known core hooks with their 'human' name
-# classes that consume the role can override this method to provide
-# their own aliases for their own hooks
-sub hook_aliases {
-    {   before                 => 'core.app.before_request',
-        before_request         => 'core.app.before_request',
-        after                  => 'core.app.after_request',
-        after_request          => 'core.app.after_request',
-        before_file_render     => 'handler.file.before_render',
-        after_file_render      => 'handler.file.after_render',
-        before_template_render => 'engine.template.before_render',
-        after_template_render  => 'engine.template.after_render',
-        before_layout_render   => 'engine.template.before_layout_render',
-        after_layout_render    => 'engine.template.after_layout_render',
-        before_serializer      => 'engine.serializer.before',
-        after_serializer       => 'engine.serializer.after',
-        init_error             => 'core.error.init',
-        before_error           => 'core.error.before',
-        after_error            => 'core.error.after',
-        on_route_exception     => 'core.app.route_exception',
-
-        # compatibility from Dancer1
-        before_error_render    => 'core.error.before',
-        after_error_render     => 'core.error.after',
-        before_error_init      => 'core.error.init',
-    };
-}
-
 # after a hookable object is built, we go over its postponed hooks and register
 # them if any.
 after BUILD => sub {

--- a/lib/Dancer2/Core/Role/Hookable.pm
+++ b/lib/Dancer2/Core/Role/Hookable.pm
@@ -62,7 +62,7 @@ sub _add_postponed_hooks {
     # find the internal name of the hooks, from the caller name
     my $caller = ref($self);
     my ( $dancer, $h_type, $h_name, @rest ) = map {lc} split /::/, $caller;
-    $h_name = $rest[0] if $h_name eq 'Role';
+    $h_name = $rest[0] if $h_name eq 'role';
     if ( $h_type =~ /(template|logger|serializer|session)/ ) {
         $h_name = $h_type;
         $h_type = 'engine';

--- a/lib/Dancer2/Core/Role/Hookable.pm
+++ b/lib/Dancer2/Core/Role/Hookable.pm
@@ -7,7 +7,7 @@ use Dancer2::Core::Types;
 use Carp 'croak';
 use Safe::Isa;
 
-requires 'supported_hooks';
+requires 'supported_hooks', 'hook_aliases';
 
 # The hooks registry
 has hooks => (

--- a/lib/Dancer2/Core/Role/Logger.pm
+++ b/lib/Dancer2/Core/Role/Logger.pm
@@ -9,6 +9,7 @@ use Data::Dumper;
 
 with 'Dancer2::Core::Role::Engine';
 
+sub hook_aliases { +{} }
 sub supported_hooks {
     qw(
       engine.logger.before

--- a/lib/Dancer2/Core/Role/Serializer.pm
+++ b/lib/Dancer2/Core/Role/Serializer.pm
@@ -7,12 +7,14 @@ use Dancer2::Core::Types;
 
 with 'Dancer2::Core::Role::Engine';
 
-sub supported_hooks {
-    qw(
-      engine.serializer.before
-      engine.serializer.after
-    );
+sub hook_aliases {
+    {
+        before_serializer => 'engine.serializer.before',
+        after_serializer  => 'engine.serializer.after',
+    }
 }
+
+sub supported_hooks { values %{ shift->hook_aliases } }
 
 sub _build_type {'Serializer'}
 

--- a/lib/Dancer2/Core/Role/SessionFactory.pm
+++ b/lib/Dancer2/Core/Role/SessionFactory.pm
@@ -12,6 +12,7 @@ use Digest::SHA 'sha1';
 use List::Util 'shuffle';
 use MIME::Base64 'encode_base64url';
 
+sub hook_aliases { +{} }
 sub supported_hooks {
     qw/
       engine.session.before_retrieve

--- a/lib/Dancer2/Core/Role/Template.pm
+++ b/lib/Dancer2/Core/Role/Template.pm
@@ -10,14 +10,16 @@ use Data::Dumper;
 use Moo::Role;
 with 'Dancer2::Core::Role::Engine';
 
-sub supported_hooks {
-    qw/
-      engine.template.before_render
-      engine.template.after_render
-      engine.template.before_layout_render
-      engine.template.after_layout_render
-      /;
+sub hook_aliases {
+    {
+        before_template_render => 'engine.template.before_render',
+        after_template_render  => 'engine.template.after_render',
+        before_layout_render   => 'engine.template.before_layout_render',
+        after_layout_render    => 'engine.template.after_layout_render',
+    }
 }
+
+sub supported_hooks { values %{ shift->hook_aliases } }
 
 sub _build_type {'Template'}
 

--- a/lib/Dancer2/Handler/File.pm
+++ b/lib/Dancer2/Handler/File.pm
@@ -15,12 +15,14 @@ with qw<
     Dancer2::Core::Role::Hookable
 >;
 
-sub supported_hooks {
-    qw(
-      handler.file.before_render
-      handler.file.after_render
-    );
+sub hook_aliases {
+    {
+        before_file_render => 'handler.file.before_render',
+        after_file_render  => 'handler.file.after_render',
+    }
 }
+
+sub supported_hooks { values %{ shift->hook_aliases } }
 
 has mime => (
     is      => 'ro',

--- a/lib/Dancer2/Plugin.pm
+++ b/lib/Dancer2/Plugin.pm
@@ -10,6 +10,9 @@ use Scalar::Util qw();
 # their code and the plugin they come from
 my $_keywords = {};
 
+# singleton for storing all hooks and their aliases
+my $_hooks = {};
+
 # singleton for applying code-blocks at import time
 # so their code gets the callers DSL
 my $_on_import = {};
@@ -122,20 +125,10 @@ sub plugin_setting {
 }
 
 sub register_hook {
-    my $caller = caller;
-    my $plugin = $caller;
-
     my (@hooks) = @_;
 
-    my $current_hooks = [];
-    if ( $plugin->can('supported_hooks') ) {
-        $current_hooks = [ $plugin->supported_hooks ];
-    }
-
-    my $current_aliases = {};
-    if ( $plugin->can('hook_aliases') ) {
-        $current_aliases = $plugin->hook_aliases;
-    }
+    my $caller = caller;
+    my $plugin = $caller;
 
     $plugin =~ s/^Dancer2::Plugin:://;
     $plugin =~ s/::/_/g;
@@ -143,16 +136,7 @@ sub register_hook {
     my $base_name = "plugin." . lc($plugin);
     for my $hook (@hooks) {
         my $hook_name = "${base_name}.$hook";
-
-        push @{$current_hooks}, $hook_name;
-        $current_aliases->{$hook} = $hook_name;
-    }
-
-    {
-        no strict 'refs';
-        no warnings 'redefine';
-        *{"${caller}::supported_hooks"} = sub {@$current_hooks};
-        *{"${caller}::hook_aliases"}    = sub {$current_aliases};
+        $_hooks->{$caller}->{$hook_name} = $hook;
     }
 }
 

--- a/t/classes/Dancer2-Core-Role-Engine/with.t
+++ b/t/classes/Dancer2-Core-Role-Engine/with.t
@@ -6,6 +6,7 @@ use Test::More tests => 4;
     package App;
     use Moo;
     with 'Dancer2::Core::Role::Engine';
+    sub hook_aliases { +{} }
     sub supported_hooks {}
 }
 

--- a/t/lib/EmptyPlugin.pm
+++ b/t/lib/EmptyPlugin.pm
@@ -1,0 +1,10 @@
+package t::lib::EmptyPlugin;
+use Dancer2::Plugin;
+
+# This plugin does nothing.
+# Based on test from @e11it in #510
+
+register_plugin;
+
+1;
+

--- a/t/lib/OnPluginImport.pm
+++ b/t/lib/OnPluginImport.pm
@@ -1,0 +1,26 @@
+package t::lib::OnPluginImport;
+use Dancer2::Plugin;
+
+# register keyword
+register some_import => sub { shift->dancer_version };
+
+# register hook
+register_hook qw(imported_plugin);
+
+# add hook. This triggers the $dsl->hooks attribute
+# to be built plugins added after this should still
+# be able to register and add hooks. See #889.
+on_plugin_import {
+    my $dsl = shift;
+
+    $dsl->app->add_hook(
+        Dancer2::Core::Hook->new(
+            name => 'imported_plugin',
+            code => sub { $dsl->dancer_version }
+        )
+    );
+};
+
+register_plugin;
+
+1;

--- a/t/plugin_syntax.t
+++ b/t/plugin_syntax.t
@@ -100,6 +100,7 @@ subtest 'hooks in plugins' => sub {
     {
         package App3;
         use Dancer2;
+        use t::lib::OnPluginImport;
         use t::lib::Hookee;
         use t::lib::EmptyPlugin;
 
@@ -125,6 +126,10 @@ subtest 'hooks in plugins' => sub {
         get '/hook_returns_stuff' => sub {
             some_keyword(); # executes 'start_hookee'
         };
+
+        get '/on_import' => sub {
+            some_import(); # execute 'plugin_import'
+        }
 
     }
 
@@ -152,6 +157,12 @@ subtest 'hooks in plugins' => sub {
 
         # call the route that has an additional test
         $cb->( GET '/hook_with_var' );
+
+        is (
+            $cb->( GET '/on_import' )->content,
+            Dancer2->VERSION,
+            'hooks added by on_plugin_import dont stop hooks being added later'
+        );
     };
 };
 

--- a/t/plugin_syntax.t
+++ b/t/plugin_syntax.t
@@ -101,6 +101,7 @@ subtest 'hooks in plugins' => sub {
         package App3;
         use Dancer2;
         use t::lib::Hookee;
+        use t::lib::EmptyPlugin;
 
         hook 'third_hook' => sub {
             var( hook => 'third hook' );

--- a/t/roles/hook.t
+++ b/t/roles/hook.t
@@ -15,6 +15,7 @@ is $h->code->(), 'BT';
     package Foo;
     use Moo;
     with 'Dancer2::Core::Role::Hookable';
+    sub hook_aliases { +{} }
     sub supported_hooks {'foobar'}
 }
 


### PR DESCRIPTION
This is a "workaround" (not really a feature or a bugfix) to allow multiple plugins register and add hooks until the core devs settle and implement a rewrite of the plugin system.

Adds a registry of hooks (to Dancer2::Plugin), similar to the register of keywords. Though no checking to see if multiple plugins register the same hook has been implemented.

Registered hooks are added to the DSL object *after* the role composition dance, including adding the appropriate entries to the `hooks` hashref to `has_hook` just works. However, due to that role composition "tango", it was necessary to have consumers of `::Role::Hookable` provide _both_ the `supported_hooks` and `hook_aliases` methods.

Added tests from #510, plus a cut-down test that @ambs reported between Dancer2::Plugin::Deferred and Dancer2::Plugin::Database.