### PR TITLE
Fix for #893

### DIFF
--- a/lib/Dancer2/Core/Role/ConfigReader.pm
+++ b/lib/Dancer2/Core/Role/ConfigReader.pm
@@ -205,7 +205,7 @@ sub load_config_file {
         my @files = ($file);
         my $tmpconfig =
           Config::Any->load_files( { files => \@files, use_ext => 1 } )->[0];
-        ( $file, $config ) = %{$tmpconfig};
+        ( $file, $config ) = %{$tmpconfig} if defined $tmpconfig;
     };
     if ( my $err = $@ || ( !$config ) ) {
         croak "Unable to parse the configuration file: $file: $@";

--- a/t/config/environments/failure.yml
+++ b/t/config/environments/failure.yml
@@ -1,1 +1,3 @@
-not a valid YAML file
+not valid YAML - inconsistent indentation
+foo: 42
+  bar: baz

--- a/t/config_reader.t
+++ b/t/config_reader.t
@@ -94,7 +94,7 @@ is_deeply $fail->config_files,
 
 like(
     exception { $fail->config },
-    qr{YAML}, 'Configuration file parsing failure',
+    qr{Unable to parse the configuration file}, 'Configuration file parsing failure',
 );
 
 note "config merging";


### PR DESCRIPTION
Ensure `failure.yml` environment config used in the tests is actually invalid YAML. Then catch the undef that Config::Any returns in that case before trying to use it as a hashref.
