### PR TITLE
Base Dancer2::Core::Request on Plack::Request

### DIFF
--- a/lib/Dancer2/Core/Request.pm
+++ b/lib/Dancer2/Core/Request.pm
@@ -58,7 +58,7 @@ _EVAL
 our $XS_URL_DECODE         = try_load_class('URL::Encode::XS');
 our $XS_PARSE_QUERY_STRING = try_load_class('CGI::Deurl::XS');
 
-our $_count = 0;
+our $_id = 0;
 
 # self->new( env => {}, serializer => $s, is_behind_proxy => 0|1 )
 sub new {
@@ -81,7 +81,7 @@ sub new {
     }
 
     # additionally supported attributes
-    $self->{'id'}              = ++$_count;
+    $self->{'id'}              = ++$_id;
     $self->{'vars'}            = {};
     $self->{'is_behind_proxy'} = !!$opts{'is_behind_proxy'};
 
@@ -108,7 +108,7 @@ sub set_path_info { $_[0]->env->{'PATH_INFO'} = $_[1] }
 # XXX: incompatible with Plack::Request
 sub body { $_[0]->{'body'} || '' }
 
-sub id { $_count }
+sub id { $_id }
 
 # Private 'read-only' attributes for request params. See the params()
 # method for the public interface.

--- a/lib/Dancer2/Core/Request.pm
+++ b/lib/Dancer2/Core/Request.pm
@@ -186,14 +186,14 @@ sub scheme {
 }
 
 sub serializer { $_[0]->{'serializer'} }
-sub has_serializer { defined $_[0]->{'serializer'} }
 
 sub data { $_[0]->{'data'} ||= &deserialize }
 
 sub deserialize {
     my $self = shift;
 
-    return unless $self->has_serializer;
+    my $serializer = $self->serializer
+        or return;
 
     # The latest draft of the RFC does not forbid DELETE to have content,
     # rather the behaviour is undefined. Take the most lenient route and
@@ -207,7 +207,7 @@ sub deserialize {
     $body && length $body > 0
         or return;
 
-    my $data = $self->serializer->deserialize($self->body);
+    my $data = $serializer->deserialize($self->body);
     return if !defined $data;
 
     # Set _body_params directly rather than using the setter. Deserializiation

--- a/lib/Dancer2/Core/Request.pm
+++ b/lib/Dancer2/Core/Request.pm
@@ -744,7 +744,8 @@ in scalar.
 
 =method headers
 
-Returns an L<HTTP::Headers> object representing the headers.
+Returns either an L<HTTP::Headers> or an L<HTTP::Headers::Fast> object
+representing the headers.
 
 =method id
 

--- a/lib/Dancer2/Core/Request.pm
+++ b/lib/Dancer2/Core/Request.pm
@@ -17,25 +17,6 @@ use Dancer2::Core::Types;
 use Dancer2::Core::Request::Upload;
 use Dancer2::Core::Cookie;
 
-# comes from Dancer2::Core::Role::Headers
-# ("headers" attribute is available in Plack::Request already)
-sub headers_to_array {
-    my $self = shift;
-
-    my $headers = [
-        map {
-            my $k = $_;
-            map {
-                my $v = $_;
-                $v =~ s/^(.+)\r?\n(.*)$/$1\r\n $2/;
-                ( $k => $v )
-            } $self->headers->header($_);
-          } $self->headers->header_field_names
-    ];
-
-    return $headers;
-}
-
 # add an attribute for each HTTP_* variables
 # (HOST is managed manually)
 my @http_env_keys = (qw/

--- a/lib/Dancer2/Core/Request.pm
+++ b/lib/Dancer2/Core/Request.pm
@@ -155,8 +155,8 @@ sub is_behind_proxy { $_[0]->{'is_behind_proxy'} || 0 }
 sub host {
     my ($self) = @_;
 
-    if ( $self->is_behind_proxy and exists $self->env->{HTTP_X_FORWARDED_HOST} ) {
-        my @hosts = split /\s*,\s*/, $self->env->{HTTP_X_FORWARDED_HOST}, 2;
+    if ( $self->is_behind_proxy and exists $self->env->{'HTTP_X_FORWARDED_HOST'} ) {
+        my @hosts = split /\s*,\s*/, $self->env->{'HTTP_X_FORWARDED_HOST'}, 2;
         return $hosts[0];
     } else {
         return $self->env->{'HTTP_HOST'};
@@ -178,17 +178,11 @@ sub forwarded_protocol    {
 
 sub scheme {
     my ($self) = @_;
-    my $scheme;
-    if ( $self->is_behind_proxy ) {
-        # Note the 'HTTP_' prefix the PSGI spec adds to headers.
-        $scheme =
-             $self->env->{'HTTP_X_FORWARDED_PROTOCOL'}
-          || $self->env->{'HTTP_X_FORWARDED_PROTO'}
-          || $self->env->{'HTTP_FORWARDED_PROTO'}
-          || '';
-    }
+    my $scheme = $self->is_behind_proxy
+               ? $self->forwarded_protocol
+               : '';
 
-    return $scheme || $self->env->{'psgi.url_scheme'} || '';
+    return $scheme || $self->env->{'psgi.url_scheme'};
 }
 
 sub serializer { $_[0]->{'serializer'} }

--- a/lib/Dancer2/Core/Request.pm
+++ b/lib/Dancer2/Core/Request.pm
@@ -238,8 +238,6 @@ sub BUILD {
     $self->{_chunk_size}    = 4096;
     $self->{_read_position} = 0;
 
-    $self->_init_request_headers();
-
     $self->{_http_body} =
       HTTP::Body->new( $self->content_type || '', $self->content_length );
     $self->{_http_body}->cleanup(1);
@@ -526,21 +524,6 @@ sub _read {
     else {
         croak "Unknown error reading input: $!";
     }
-}
-
-sub _init_request_headers {
-    my ($self) = @_;
-    my $env = $self->env;
-
-    $self->headers(
-        HTTP::Headers::Fast->new(
-            map {
-                ( my $field = $_ ) =~ s/^HTTPS?_//;
-                ( $field => $env->{$_} );
-              }
-              grep {/^(?:HTTP|CONTENT)/i} keys %$env
-        )
-    );
 }
 
 # Taken gently from Plack::Request, thanks to Plack authors.

--- a/lib/Dancer2/Core/Request.pm
+++ b/lib/Dancer2/Core/Request.pm
@@ -85,7 +85,7 @@ sub new {
     $self->{'vars'}            = {};
     $self->{'is_behind_proxy'} = !!$opts{'is_behind_proxy'};
 
-    $self->BUILD;
+    $self->init;
 
     return $self;
 }
@@ -232,7 +232,7 @@ sub is_patch  { $_[0]->method eq 'PATCH' }
 sub request_method { $_[0]->method }
 sub input_handle { $_[0]->env->{'psgi.input'} }
 
-sub BUILD {
+sub init {
     my ($self) = @_;
 
     $self->{_chunk_size}    = 4096;

--- a/t/classes/Dancer2-Core-Request/new.t
+++ b/t/classes/Dancer2-Core-Request/new.t
@@ -180,11 +180,6 @@ subtest 'Defaults' => sub {
         my $request = Dancer2::Core::Request->new( env => $env );
         isa_ok( $request, 'Dancer2::Core::Request' );
 
-        ok(
-            $request->DOES('Dancer2::Core::Role::Headers'),
-            'Consumes D2::C::R::Headers',
-        );
-
         can_ok( $request, 'env' );
         isa_ok( $request->env, 'HASH' );
 
@@ -278,15 +273,11 @@ subtest 'Create with single env' => sub {
         'Create with env hash',
     );
 
-    isa_ok(
-        Dancer2::Core::Request->new({ env => {} }),
-        'Dancer2::Core::Request',
-        'Create with env hashref',
-    );
-
     my $request;
     isa_ok(
-        $request = Dancer2::Core::Request->new({ REQUEST_METHOD => 'X' }),
+        $request = Dancer2::Core::Request->new(
+            env => { REQUEST_METHOD => 'X' }
+        ),
         'Dancer2::Core::Request',
         'Create with single argument for env',
     );
@@ -409,7 +400,7 @@ subtest 'Checking request ID' => sub {
     my $test = Plack::Test->create( sub {
         my $env     = shift;
         my $request = Dancer2::Core::Request->new( env => $env );
-        is( $request->id, 10, 'Correct request id' );
+        is( $request->id, 8, 'Correct request id' );
 
         return psgi_ok;
     } );

--- a/t/classes/Dancer2-Core-Request/new.t
+++ b/t/classes/Dancer2-Core-Request/new.t
@@ -288,8 +288,8 @@ subtest 'Create with single env' => sub {
 subtest 'Serializer' => sub {
     {
         my $request = Dancer2::Core::Request->new( env => {} );
-        can_ok( $request, qw<serializer has_serializer> );
-        ok( ! $request->has_serializer, 'No serializer set' );
+        can_ok( $request, qw<serializer> );
+        ok( ! $request->serializer, 'No serializer set' );
     }
 
     {
@@ -327,7 +327,7 @@ subtest 'Serializer' => sub {
             'Can create request with serializer',
         );
 
-        ok( $request->has_serializer, 'Serializer set' );
+        ok( $request->serializer, 'Serializer set' );
         isa_ok( $request->serializer, 'Serializer' );
     }
 };

--- a/t/classes/Dancer2-Core-Route/match.t
+++ b/t/classes/Dancer2-Core-Route/match.t
@@ -118,7 +118,10 @@ for my $t (@tests) {
         isa_ok $r, 'Dancer2::Core::Route';
 
         my $request = Dancer2::Core::Request->new(
-            env => {}, method => $route->[0], path => $path
+            env => {
+                PATH_INFO      => $path,
+                REQUEST_METHOD => $route->[0],
+            }
         );
         my $m = $r->match($request);
         is_deeply $m, $expected->[0], "got expected data for '$path'";
@@ -138,10 +141,12 @@ for my $t (@tests) {
 
         # failing request
         my $failing_request = Dancer2::Core::Request->new(
-            env    => {},
-            method => 'get',
-            path   => '/something_that_doesnt_exist',
+            env => {
+                PATH_INFO      => '/something_that_doesnt_exist',
+                REQUEST_METHOD => 'GET',
+            },
         );
+
         $m = $r->match($failing_request);
         is $m, undef, "dont match failing request";
     }
@@ -171,9 +176,10 @@ SKIP: {
     );
 
     my $request = Dancer2::Core::Request->new(
-        env    => {},
-        method => 'get',
-        path   => '/user/delete/234',
+        env => {
+            PATH_INFO      => '/user/delete/234',
+            REQUEST_METHOD => 'GET',
+        },
     );
 
     my $m = $r->match($request);
@@ -203,7 +209,7 @@ SKIP: {
     );
 
     my $m = $route_w_options->match($req);
-    ok !defined $m;
+    ok !defined $m, 'Route did not match';
 
     $req = Dancer2::Core::Request->new(
         path   => '/',
@@ -212,5 +218,5 @@ SKIP: {
     );
 
     $m = $route_w_options->match($req);
-    ok defined $m;
+    ok defined $m, 'Route matched';
 }

--- a/t/request.t
+++ b/t/request.t
@@ -245,13 +245,13 @@ run_test();
 if ($Dancer2::Core::Request::XS_PARSE_QUERY_STRING) {
     note "Run test without XS_PARSE_QUERY_STRING";
     $Dancer2::Core::Request::XS_PARSE_QUERY_STRING = 0;
-    $Dancer2::Core::Request::_count                = 0;
+    $Dancer2::Core::Request::_id                   = 0;
     run_test();
 }
 if ($Dancer2::Core::Request::XS_URL_DECODE) {
     note "Run test without XS_URL_DECODE";
     $Dancer2::Core::Request::XS_URL_DECODE = 0;
-    $Dancer2::Core::Request::_count        = 0;
+    $Dancer2::Core::Request::_id           = 0;
     run_test();
 }
 

--- a/t/request.t
+++ b/t/request.t
@@ -245,13 +245,13 @@ run_test();
 if ($Dancer2::Core::Request::XS_PARSE_QUERY_STRING) {
     note "Run test without XS_PARSE_QUERY_STRING";
     $Dancer2::Core::Request::XS_PARSE_QUERY_STRING = 0;
-    $Dancer2::Core::Request::_count                = 1;
+    $Dancer2::Core::Request::_count                = 0;
     run_test();
 }
 if ($Dancer2::Core::Request::XS_URL_DECODE) {
     note "Run test without XS_URL_DECODE";
     $Dancer2::Core::Request::XS_URL_DECODE = 0;
-    $Dancer2::Core::Request::_count        = 1;
+    $Dancer2::Core::Request::_count        = 0;
     run_test();
 }
 


### PR DESCRIPTION
I couldn't see how to do the majority of this in more than one commit.

This commit bases D2::Core::Request on Plack::Request instead of delegating to an internal Plack::Request object.

This allows to utilize the existing implementation of many PSGI perspectives already available in Plack::Request while adding our own variations (such as using "is_behind_proxy") without having to keep another object around and delegating to it.

Here are also a few benchmarks showing about 13.57% increase in speed as a result of this change.

Before:

    $ perl bench-request.pl
    Ran 12 iterations (2 outliers).
    Rounded run time per iteration: 9.741e+00 +/- 2.9e-02 (0.3%)

After:

    $ perl bench-request.pl
    Ran 11 iterations (1 outliers).
    Rounded run time per iteration: 8.419e+00 +/- 3.3e-02 (0.4%)