### PR TITLE
Show error stack traces in default_error_page

### DIFF
--- a/lib/Dancer2/Core/Error.pm
+++ b/lib/Dancer2/Core/Error.pm
@@ -409,31 +409,20 @@ sub dumper {
 sub environment {
     my ($self) = @_;
 
-    my $request = $self->has_app ? $self->app->request : 'TODO';
-    my $r_env = {};
-    $r_env = $request->env if defined $request;
+    my $stack = $self->get_caller;
+    my $settings = $self->has_app && $self->app->settings;
+    my $session = $self->session && $self->session->data;
+    my $env = $self->has_app && $self->app->has_request && $self->app->request->env;
 
-    my $env =
-        qq|<div class="title">Environment</div><pre class="content">|
-      . dumper($r_env)
-      . "</pre>";
-    my $settings =
-        qq|<div class="title">Settings</div><pre class="content">|
-      . dumper( $self->app->settings )
-      . "</pre>";
-    my $source =
-        qq|<div class="title">Stack</div><pre class="content">|
-      . $self->get_caller
-      . "</pre>";
-    my $session = "";
+    # Get a sanitised dump of the settings, session and environment
+    $_ = $_ ? dumper($_) : '<i>undefined</i>' for $settings, $session, $env;
 
-    if ( $self->session ) {
-        $session =
-            qq[<div class="title">Session</div><pre class="content">]
-          . dumper( $self->session->data )
-          . "</pre>";
-    }
-    return "$source $settings $session $env";
+    return <<"END_HTML";
+<div class="title">Stack</div><pre class="content">$stack</pre>
+<div class="title">Settings</div><pre class="content">$settings</pre>
+<div class="title">Session</div><pre class="content">$session</pre>
+<div class="title">Environment</div><pre class="content">$env</pre>
+END_HTML
 }
 
 sub get_caller {

--- a/lib/Dancer2/Core/Error.pm
+++ b/lib/Dancer2/Core/Error.pm
@@ -340,7 +340,7 @@ sub backtrace {
     return $message unless ( $file and $line );
 
     # file and line are located, let's read the source Luke!
-    my $fh = open_file( '<', $file ) or return $message;
+    my $fh = eval { open_file( '<', $file ) } or return $message;
     my @lines = <$fh>;
     close $fh;
 

--- a/lib/Dancer2/Core/Error.pm
+++ b/lib/Dancer2/Core/Error.pm
@@ -455,6 +455,8 @@ sub _censor {
     my $censored = 0;
     for my $key ( keys %$hash ) {
         if ( ref $hash->{$key} eq 'HASH' ) {
+            # Take a copy of the data, so we can hide sensitive-looking stuff:
+            $hash->{$key} = { %{ $hash->{$key} } };
             $censored += _censor( $hash->{$key} );
         }
         elsif ( $key =~ /(pass|card?num|pan|secret)/i ) {

--- a/lib/Dancer2/Core/Error.pm
+++ b/lib/Dancer2/Core/Error.pm
@@ -177,11 +177,6 @@ sub _build_serializer {
     return;
 }
 
-has session => (
-    is  => 'ro',
-    isa => ConsumerOf ['Dancer2::Core::Role::Session'],
-);
-
 sub BUILD {
     my ($self) = @_;
 
@@ -414,7 +409,7 @@ sub environment {
 
     my $stack = $self->get_caller;
     my $settings = $self->has_app && $self->app->settings;
-    my $session = $self->session && $self->session->data;
+    my $session = $self->has_app && $self->app->_has_session && $self->app->session->data;
     my $env = $self->has_app && $self->app->has_request && $self->app->request->env;
 
     # Get a sanitised dump of the settings, session and environment

--- a/lib/Dancer2/Core/Error.pm
+++ b/lib/Dancer2/Core/Error.pm
@@ -106,15 +106,10 @@ sub default_error_page {
     my $uri_base = $self->has_app ?
         $self->app->request->uri_base : '';
 
-    my $message = $self->message;
-    if ( $self->show_errors && $self->exception) {
-        $message .= "\n" . $self->exception;
-    }
-
     my $opts = {
         title    => $self->title,
         charset  => $self->charset,
-        content  => $message,
+        content  => $self->show_errors ? $self->full_message : $self->message || 'Wooops, something went wrong',
         version  => Dancer2->VERSION,
         uri_base => $uri_base,
     };
@@ -325,14 +320,14 @@ sub throw {
 sub backtrace {
     my ($self) = @_;
 
-    my $message = $self->exception ? $self->exception : $self->message;
-    $message =
-      qq|<pre class="error">| . _html_encode( $message ) . "</pre>";
-
-    if ( $self->exception && !ref($self->exception) ) {
-        $message .= qq|<pre class="error">|
-                 . _html_encode($self->exception) . "</pre>";
+    my $message = $self->message;
+    if ($self->exception) {
+        $message .= "\n" if $message;
+        $message .= $self->exception;
     }
+    $message ||= 'Wooops, something went wrong';
+
+    $message = '<pre class="error">' . _html_encode($message) . '</pre>';
 
     # the default perl warning/error pattern
     my ( $file, $line ) = ( $message =~ /at (\S+) line (\d+)/ );

--- a/lib/Dancer2/Core/Error.pm
+++ b/lib/Dancer2/Core/Error.pm
@@ -392,10 +392,12 @@ sub dumper {
     #use Data::Dumper;
     my $dd = Data::Dumper->new( [ \%data ] );
     my $hash_separator = '  @@!%,+$$#._(--  '; # Very unlikely string to exist already
-    $dd->Terse(1)->Quotekeys(0)->Indent(1)->Sortkeys(1)->Pair($hash_separator);
+    my $prefix_padding = '  #+#+@%.,$_-!((  '; # Very unlikely string to exist already
+    $dd->Terse(1)->Quotekeys(0)->Indent(1)->Sortkeys(1)->Pair($hash_separator)->Pad($prefix_padding);
     my $content = _html_encode( $dd->Dump );
     $content =~ s/^.+//;   # Remove the first line
     $content =~ s/\n.+$//; # Remove the last line
+    $content =~ s/^\Q$prefix_padding\E  //gm; # Remove the padding
     $content =~ s{^(\s*)(.+)\Q$hash_separator}{$1<span class="key">$2</span> =&gt; }gm;
     if ($censored) {
         $content

--- a/lib/Dancer2/Core/Error.pm
+++ b/lib/Dancer2/Core/Error.pm
@@ -396,9 +396,12 @@ sub dumper {
 
     #use Data::Dumper;
     my $dd = Data::Dumper->new( [ \%data ] );
-    $dd->Terse(1)->Quotekeys(0)->Indent(1);
-    my $content = $dd->Dump();
-    $content =~ s{(\s*)(\S+)(\s*)=>}{$1<span class="key">$2</span>$3 =&gt;}g;
+    my $hash_separator = '  @@!%,+$$#._(--  '; # Very unlikely string to exist already
+    $dd->Terse(1)->Quotekeys(0)->Indent(1)->Sortkeys(1)->Pair($hash_separator);
+    my $content = _html_encode( $dd->Dump );
+    $content =~ s/^.+//;   # Remove the first line
+    $content =~ s/\n.+$//; # Remove the last line
+    $content =~ s{^(\s*)(.+)\Q$hash_separator}{$1<span class="key">$2</span> =&gt; }gm;
     if ($censored) {
         $content
           .= "\n\nNote: Values of $censored sensitive-looking keys hidden\n";

--- a/share/skel/public/css/error.css
+++ b/share/skel/public/css/error.css
@@ -41,6 +41,7 @@ pre.content {
     border: 1px solid #aaa;
     border-top: 0;
     margin-bottom: 1em;
+    overflow-x: auto;
 }
 
 div.title {

--- a/t/dispatcher.t
+++ b/t/dispatcher.t
@@ -204,7 +204,7 @@ foreach my $test (
         expected => [
             500,
             [ 'Content-Length', "Content-Type", 'text/html' ],
-            qr{Internal Server Error.*Can't locate object method "fail" via package "Fail" \(perhaps you forgot to load "Fail"\?\) at t[\\/]dispatcher\.t line \d+.*$}ms
+            qr!Internal Server Error.*Can&#39;t locate object method &quot;fail&quot; via package &quot;Fail&quot; \(perhaps you forgot to load &quot;Fail&quot;\?\) at t[\\/]dispatcher\.t line \d+\.!s
         ]
     }
   )


### PR DESCRIPTION
Fix for the missing stack trace on the default error page.

When `show_errors` is true, the `default_error_page` will now display a full stack trace (currently unused!) instead of the very useless basic message.

This is obviously the intended behaviour. See #769

If `show_errors` is false, a static page is shown if available, but if it's not available then the current `default_error_page` will actually show the error, ignoring the `show_errors` setting.
This is also fixed by this change.