### PR TITLE
Improve error info when no HTTP_X_FORWARDED_HOST

### DIFF
--- a/lib/Dancer2/Core/Request.pm
+++ b/lib/Dancer2/Core/Request.pm
@@ -187,7 +187,11 @@ sub host {
     my ($self) = @_;
 
     if ( $self->is_behind_proxy ) {
-        my @hosts = split /\s*,\s*/, $self->env->{HTTP_X_FORWARDED_HOST}, 2;
+        my $env_host = $self->env->{HTTP_X_FORWARDED_HOST}
+            or croak "No HTTP_X_FORWARDED_HOST received from proxy. "
+                ."It's possible that either this request or an earlier "
+                ."request by another client were made using HTTP/1.0.";
+        my @hosts = split /\s*,\s*/, $env_host, 2;
         return $hosts[0];
     } else {
         return $self->env->{'HTTP_HOST'};


### PR DESCRIPTION
If behind_proxy is set but no HTTP_X_FORWARDED_HOST header is received (such as if the proxy's request was from a client using HTTP/1.0), then Dancer dies with a rather mysterious "Use of uninitialized value in split" error message. This patch improves the error message to help with
debugging.

Incidentally, this problem is confounded when subsequent requests are made from the proxy (even with HTTP/1.1) as the environment variables have already been set. I'm not sure whether this requires a
further patch? If not, this patch at least makes it easier to fix the problem.