### PR TITLE
fix PUT request with JSON array in body

### DIFF
--- a/lib/Dancer2/Core/Request.pm
+++ b/lib/Dancer2/Core/Request.pm
@@ -275,7 +275,7 @@ sub deserialize {
     # returns characters and skipping the decode op in the setter ensures
     # that numerical data "stays" numerical; decoding an SV that is an IV
     # converts that to a PVIV. Some serializers are picky (JSON)..
-    $self->{_body_params} = $data;
+    $self->{_body_params} = ref $data eq 'HASH' ? $data : {};
     $self->_build_params();
 
     return $data;

--- a/t/issues/gh-844.t
+++ b/t/issues/gh-844.t
@@ -1,0 +1,36 @@
+use strict;
+use warnings;
+use Test::More tests => 4;
+use Plack::Test;
+use HTTP::Request::Common;
+
+{
+    package App;
+    use Dancer2;
+    set serializer => 'JSON';
+
+    put '/data'   => sub { request->data   };
+    put '/params' => sub { request->params };
+}
+
+my $test = Plack::Test->create( App->to_app );
+
+is(
+    $test->request( PUT '/data', Content => '{"foo":"bar"}' )->content,
+    '{"foo":"bar"}'
+);
+
+is(
+    $test->request( PUT '/data', Content => '["foo","bar"]' )->content,
+    '["foo","bar"]'
+);
+
+is(
+    $test->request( PUT '/params', Content => '{"foo":"bar"}' )->content,
+    '{"foo":"bar"}'
+);
+
+is(
+    $test->request( PUT '/params', Content => '["foo","bar"]' )->content,
+    '{}'
+);


### PR DESCRIPTION
PUTting JSON array fails with internal server error because the deserialized
data are not key/value pairs and can not be merged to the request->params.

The data are available in request->data but only key/value pairs can be merged
to request->params.