### PR TITLE
Fix Travis-CI builds on perls < 5.14

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,9 +19,11 @@ notifications:
     use_notice: true
 
 install:
+#Safe fails to install due to failing tests since version 2.35 on perl < 5.14
+    - perl -E 'exit($] < 5.014)' || cpanm --no-skip-satisfied Safe || cpanm --no-skip-satisfied --notest Safe || { cat ~/.cpanm/build.log ; false ; }
 #Moo fails to install without Class::Method::Modifiers since 2012/10/19 
-    - cpanm --no-skip-satisfied Class::Method::Modifiers YAML::XS
-    - dzil authordeps --missing | cpanm  --no-skip-satisfied || { cat ~/.cpanm/build.log ; false ; }
+    - cpanm --no-skip-satisfied Class::Method::Modifiers YAML::XS || { cat ~/.cpanm/build.log ; false ; }
+    - dzil authordeps --missing | cpanm --no-skip-satisfied || { cat ~/.cpanm/build.log ; false ; }
     - dzil listdeps --author --missing | cpanm --no-skip-satisfied || { cat ~/.cpanm/build.log ; false ; }
 
 script:


### PR DESCRIPTION
Since the release of Safe-2.35 and version-0.9910 the Travis CI builds have been failing on perl 5.10 & 5.12.
This is due to failing tests during the install of Safe.
The only work-around I can see at present is to attempt an install of Safe, then if that fails try again without tests on those older perls.