### PR TITLE
Feature/http headers fast

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -63,7 +63,7 @@ POSIX = 0
 Config::Any = 0
 HTTP::Date = 0
 HTTP::Body = 0
-HTTP::Headers = 0
+HTTP::Headers::Fast = 0
 HTTP::Tiny = 0
 ; 3.13 has the URL safe variants
 MIME::Base64 = 3.13
@@ -120,6 +120,7 @@ Test::Fatal = 0
 HTTP::Body = 0
 Test::MockTime = 0
 Test::Memory::Cycle = 1.04
+HTTP::Headers = 0
 
 ; ; for maintainers, see with mst how to avoid these
 ; strictures = 0

--- a/lib/Dancer2/Core/Request.pm
+++ b/lib/Dancer2/Core/Request.pm
@@ -592,7 +592,7 @@ sub _init_request_headers {
     my $env = $self->env;
 
     $self->headers(
-        HTTP::Headers->new(
+        HTTP::Headers::Fast->new(
             map {
                 ( my $field = $_ ) =~ s/^HTTPS?_//;
                 ( $field => $env->{$_} );

--- a/lib/Dancer2/Core/Role/Headers.pm
+++ b/lib/Dancer2/Core/Role/Headers.pm
@@ -4,19 +4,19 @@ package Dancer2::Core::Role::Headers;
 
 use Moo::Role;
 use Dancer2::Core::Types;
-use HTTP::Headers;
+use HTTP::Headers::Fast;
 
 has headers => (
     is     => 'rw',
-    isa    => InstanceOf ['HTTP::Headers'],
+    isa    => InstanceOf ['HTTP::Headers::Fast'],
     lazy   => 1,
     coerce => sub {
         my ($value) = @_;
-        return $value if ref($value) eq 'HTTP::Headers';
-        HTTP::Headers->new( @{$value} );
+        return $value if ref($value) eq 'HTTP::Headers::Fast';
+        HTTP::Headers::Fast->new( @{$value} );
     },
     default => sub {
-        HTTP::Headers->new();
+        HTTP::Headers::Fast->new();
     },
     handles => [qw<header push_header>],
 );
@@ -52,9 +52,9 @@ L<Dancer2::Core::Response> and L<Dancer2::Core::Request> objects.
 
 =attr headers
 
-The attribute that store the headers in a L<HTTP::Headers> object.
+The attribute that store the headers in a L<HTTP::Headers::Fast> object.
 
-That attribute coerces from ArrayRef and defaults to an empty L<HTTP::Headers>
+That attribute coerces from ArrayRef and defaults to an empty L<HTTP::Headers::Fast>
 instance.
 
 =method header($name)

--- a/lib/Dancer2/Core/Role/Headers.pm
+++ b/lib/Dancer2/Core/Role/Headers.pm
@@ -5,6 +5,7 @@ package Dancer2::Core::Role::Headers;
 use Moo::Role;
 use Dancer2::Core::Types;
 use HTTP::Headers::Fast;
+use Scalar::Util qw(blessed);
 
 has headers => (
     is     => 'rw',
@@ -12,7 +13,9 @@ has headers => (
     lazy   => 1,
     coerce => sub {
         my ($value) = @_;
-        return $value if ref($value) =~ m/^HTTP::Headers(?:::Fast)?$/;
+        # HTTP::Headers::Fast reports that it isa 'HTTP::Headers',
+        # but there is no actual inheritance.
+        return $value if blessed($value) && $value->isa('HTTP::Headers');
         HTTP::Headers::Fast->new( @{$value} );
     },
     default => sub {

--- a/lib/Dancer2/Core/Role/Headers.pm
+++ b/lib/Dancer2/Core/Role/Headers.pm
@@ -8,11 +8,11 @@ use HTTP::Headers::Fast;
 
 has headers => (
     is     => 'rw',
-    isa    => InstanceOf ['HTTP::Headers::Fast'],
+    isa    => AnyOf[ InstanceOf ['HTTP::Headers::Fast'], InstanceOf ['HTTP::Headers'] ],
     lazy   => 1,
     coerce => sub {
         my ($value) = @_;
-        return $value if ref($value) eq 'HTTP::Headers::Fast';
+        return $value if ref($value) =~ m/^HTTP::Headers(?:::Fast)?$/;
         HTTP::Headers::Fast->new( @{$value} );
     },
     default => sub {

--- a/t/classes/Dancer2-Core-Role-Headers/with.t
+++ b/t/classes/Dancer2-Core-Role-Headers/with.t
@@ -21,7 +21,7 @@ subtest 'Default' => sub {
 subtest 'Set headers with object' => sub {
     plan tests => 4;
 
-    my $headers = HTTP::Headers->new();
+    my $headers = HTTP::Headers::Fast->new();
     isa_ok( $headers, 'HTTP::Headers' );
 
     $headers->header( 'Host' => 'Foo' );

--- a/t/classes/Dancer2-Core-Role-Headers/with.t
+++ b/t/classes/Dancer2-Core-Role-Headers/with.t
@@ -2,6 +2,9 @@ use strict;
 use warnings;
 use Test::More tests => 6;
 
+use HTTP::Headers;
+use HTTP::Headers::Fast;
+
 {
     package Object;
     use Moo;
@@ -19,17 +22,19 @@ subtest 'Default' => sub {
 };
 
 subtest 'Set headers with object' => sub {
-    plan tests => 4;
+    plan tests => 8;
 
-    my $headers = HTTP::Headers::Fast->new();
-    isa_ok( $headers, 'HTTP::Headers' );
+    for my $class ( 'HTTP::Headers', 'HTTP::Headers::Fast' ) {
+        my $headers = $class->new();
+        isa_ok( $headers, $class );
 
-    $headers->header( 'Host' => 'Foo' );
+        $headers->header( 'Host' => 'Foo' );
 
-    my $object = Object->new( headers => $headers );
-    isa_ok( $object, 'Object'  );
-    isa_ok( $object->headers, 'HTTP::Headers', 'headers' );
-    is( $object->header('Host'), 'Foo', 'Set headers correctly' );
+        my $object = Object->new( headers => $headers );
+        isa_ok( $object, 'Object'  );
+        isa_ok( $object->headers, $class, 'headers' );
+        is( $object->header('Host'), 'Foo', 'Set headers correctly' );
+    }
 };
 
 subtest 'Set headers with array' => sub {


### PR DESCRIPTION
Plack v1.0035+ changed from using HTTP::Headers to HTTP::Headers::Fast, breaking our test suite.
HTTP::Headers::Fast has the same interface as HTTP::Headers, is still pure perl, but faster. Lets use it too!

Change to using HTTP::Headers::Fast. But allow both HTTP::Headers::Fast or HTTP::Headers objects in Dancer2::Core::Role::Headers to maintain back-compat with older Plack versions.

Resolves #921.