### PR TITLE
Default session_dir is appdir/sessions

### DIFF
--- a/Changes
+++ b/Changes
@@ -3,6 +3,9 @@
     [ DOCUMENTATION ]
     * Sanitize Changes
 
+    [ BUG FIXES ]
+    * GH #926: Default session_dir is appdir/sessions (Sherwin Daganato, Henk van Oers)
+
 0.160003  2015-06-06 11:09:00+02:00 Europe/Amsterdam
 
     [ BUG FIXES ]

--- a/lib/Dancer2/Core/Role/SessionFactory/File.pm
+++ b/lib/Dancer2/Core/Role/SessionFactory/File.pm
@@ -25,7 +25,7 @@ requires '_freeze_to_handle';    # given handle and data, serialize it
 has session_dir => (
     is      => 'ro',
     isa     => Str,
-    default => sub { path( '.', 'sessions' ) },
+    default => sub { path( setting('appdir'), 'sessions' ) },
 );
 
 sub BUILD {


### PR DESCRIPTION
Just a bug.
Can be worked around by putting an explicit session_dir in config.yml
