### PR TITLE
Draw attention to precedence of parameter munging

### DIFF
--- a/lib/Dancer2/Manual.pod
+++ b/lib/Dancer2/Manual.pod
@@ -2530,7 +2530,16 @@ I<This method should be called from a route handler>.
 It's an alias for the L<Dancer2::Core::Request params
 accessor|Dancer2::Core::Request/"params($source)">. It returns a hash (in
 list context) or a hash reference (in scalar context) to all defined
-parameters. Check C<param> below to access quickly to a single parameter
+parameters.  
+
+By default, the values of C<POST> parameters overwrite the values of
+parameters defined by route declarations. Parameters defined by the route
+declarations overwrite query string parameters defined by C<GET> requests. See
+L<Dancer2::Core::Request params accessor|Dancer2::Core::Request/"params($source)">
+for optional arguments to C<params> to return values from specific
+sources (i.e., route, query string, post body).
+
+Check C<param> below to access quickly to a single parameter
 value.
 
 =head2 param


### PR DESCRIPTION
In lieu of lobbying that the precedence from highest to lowest be route, post, query string, here is some documentation for the Manual to call attention to this not-so-obvious behavior that may have curious side affects.

Namely, when a route is defined as /:foo/bar, the author may expect (reasonably), that param('foo') will equal ':foo' in the route.  In all cases where 'foo' has not been POSTed, this is true.  However, per Dancer2::Core::Request the data munging prefers the POST parameters which makes the route matching parameters reliable only for method dispatch and not as a named parameters in and of themselves.

@xsawyerx and @mickeyn, thanks for hearing my original plea at YAPC::NA to get the precedence modified. :)
