### PR TITLE
Replace Test::More diag with note for cleaner test output

### DIFF
--- a/t/classes/Dancer2-Core-Request/new.t
+++ b/t/classes/Dancer2-Core-Request/new.t
@@ -440,24 +440,24 @@ subtest 'is_$method (head/post/get/put/delete/patch' => sub {
 };
 
 subtest 'Parameters (body/query/route)' => sub {
-    diag $Dancer2::Core::Request::XS_URL_DECODE ?
+    note $Dancer2::Core::Request::XS_URL_DECODE ?
          'Running test with XS_URL_DECODE'      :
          'Running test without XS_URL_DECODE';
 
-    diag $Dancer2::Core::Request::XS_PARSE_QUERY_STRING ?
+    note $Dancer2::Core::Request::XS_PARSE_QUERY_STRING ?
          'Running test with XS_PARSE_QUERY_STRING'      :
          'Running test without XS_PARSE_QUERY_STRING';
 
     test_all_params;
 
     if ( $Dancer2::Core::Request::XS_PARSE_QUERY_STRING ) {
-        diag 'Running test without XS_PARSE_QUERY_STRING';
+        note 'Running test without XS_PARSE_QUERY_STRING';
         $Dancer2::Core::Request::XS_PARSE_QUERY_STRING = 0;
         test_all_params;
     }
 
     if ( $Dancer2::Core::Request::XS_URL_DECODE ) {
-        diag 'Running test without XS_URL_DECODE';
+        note 'Running test without XS_URL_DECODE';
         $Dancer2::Core::Request::XS_URL_DECODE = 0;
         test_all_params;
     }

--- a/t/config.yml
+++ b/t/config.yml
@@ -1,4 +1,5 @@
 log: "info"
+logger: "Note"
 
 plugins:
   "t::lib::FooPlugin":

--- a/t/hooks.t
+++ b/t/hooks.t
@@ -44,7 +44,7 @@ my $tests_flags = {};
         }
     };
 
-    get '/forward' => sub { print STDERR "About to forward!\n";forward '/' };
+    get '/forward' => sub { Test::More::note 'About to forward!'; forward '/' };
 
     get '/redirect' => sub { redirect '/' };
 

--- a/t/request.t
+++ b/t/request.t
@@ -238,18 +238,18 @@ sub run_test {
       'params are not touched';
 }
 
-diag "Run test with XS_URL_DECODE" if $Dancer2::Core::Request::XS_URL_DECODE;
-diag "Run test with XS_PARSE_QUERY_STRING"
+note "Run test with XS_URL_DECODE" if $Dancer2::Core::Request::XS_URL_DECODE;
+note "Run test with XS_PARSE_QUERY_STRING"
   if $Dancer2::Core::Request::XS_PARSE_QUERY_STRING;
 run_test();
 if ($Dancer2::Core::Request::XS_PARSE_QUERY_STRING) {
-    diag "Run test without XS_PARSE_QUERY_STRING";
+    note "Run test without XS_PARSE_QUERY_STRING";
     $Dancer2::Core::Request::XS_PARSE_QUERY_STRING = 0;
     $Dancer2::Core::Request::_count                = 1;
     run_test();
 }
 if ($Dancer2::Core::Request::XS_URL_DECODE) {
-    diag "Run test without XS_URL_DECODE";
+    note "Run test without XS_URL_DECODE";
     $Dancer2::Core::Request::XS_URL_DECODE = 0;
     $Dancer2::Core::Request::_count        = 1;
     run_test();

--- a/t/request_upload.t
+++ b/t/request_upload.t
@@ -174,18 +174,18 @@ SHOGUN6
     };
 }
 
-diag "Run test with XS_URL_DECODE" if $Dancer2::Core::Request::XS_URL_DECODE;
-diag "Run test with XS_PARSE_QUERY_STRING"
+note "Run test with XS_URL_DECODE" if $Dancer2::Core::Request::XS_URL_DECODE;
+note "Run test with XS_PARSE_QUERY_STRING"
   if $Dancer2::Core::Request::XS_PARSE_QUERY_STRING;
 run_test();
 if ($Dancer2::Core::Request::XS_PARSE_QUERY_STRING) {
-    diag "Run test without XS_PARSE_QUERY_STRING";
+    note "Run test without XS_PARSE_QUERY_STRING";
     $Dancer2::Core::Request::XS_PARSE_QUERY_STRING = 0;
     $Dancer2::Core::Request::_count                = 0;
     run_test();
 }
 if ($Dancer2::Core::Request::XS_URL_DECODE) {
-    diag "Run test without XS_URL_DECODE";
+    note "Run test without XS_URL_DECODE";
     $Dancer2::Core::Request::XS_URL_DECODE = 0;
     $Dancer2::Core::Request::_count        = 0;
     run_test();

--- a/t/serializer_mutable.t
+++ b/t/serializer_mutable.t
@@ -49,7 +49,7 @@ test_psgi $app, sub {
 
     {
         for my $format (keys %$d) {
-            diag("Format: $format");
+            note("Format: $format");
 
             my $s = $d->{$format};
 

--- a/t/session_object.t
+++ b/t/session_object.t
@@ -14,7 +14,7 @@ my $ENGINE = Dancer2::Session::Simple->new;
 my $CPRNG_AVAIL = try_load_class('Math::Random::ISAAC::XS')
   && try_load_class('Crypt::URandom');
 
-diag $CPRNG_AVAIL
+note $CPRNG_AVAIL
   ? "Crypto strength tokens"
   : "Default strength tokens";
 


### PR DESCRIPTION
Simple change to use `note` instead of `diag` in tests to produce cleaner non-verbose output.
Also set the default `Logger` in `t/config.yml` to `Note`. (At least now `Dancer2::Logger::Note` will also get used for some tests)