### PR TITLE
Bugfix/dispatcher scope cleanup

### DIFF
--- a/lib/Dancer2/Core/Dispatcher.pm
+++ b/lib/Dancer2/Core/Dispatcher.pm
@@ -42,7 +42,10 @@ sub dispatch {
             # the app raised a flag saying it couldn't match anything
             # which is different than "I matched and it's a 404"
             delete Dancer2->runner->{'internal_404'}
-                or return $response;
+                or do {
+                    delete Dancer2->runner->{'internal_request'};
+                    return $response;
+                };
         }
 
         # don't run anymore

--- a/t/scope_problems/dispatcher_internal_request.t
+++ b/t/scope_problems/dispatcher_internal_request.t
@@ -1,0 +1,32 @@
+use strict;
+use warnings;
+use Test::More;
+use Plack::Test;
+use HTTP::Request::Common qw/GET/;
+use Dancer2;
+
+{
+    package Test::App;
+    use Dancer2;
+
+    use Data::Dumper;
+    set behind_proxy => 1;
+    set views        => 't/views';
+
+    # The 'die' was causing the Runners' internal_request
+    # object to not get cleaned up when returning from dispatch.
+    hook before => sub { die "Nope, Nope, Nope" };
+
+    get '/' => sub {
+        send_error "Yes yes YES!";
+    };
+}
+
+my $test = Plack::Test->create(Dancer2->psgi_app);
+
+my $res = $test->request(GET '/');
+is( Dancer2->runner->{'internal_request'}, undef,
+    "Runner internal request cleaned up" );
+
+done_testing;
+


### PR DESCRIPTION
If `Dancer2::Core::Dispatcher` is being used to dispatch over multiple apps, the dispatcher wasn't always ensuring that the internal state got cleaned up.

This could be triggered by `die`ing in a route or hook (see included test), or if fatal warnings were enabled (see description in #915).  I suspect this will clean up some of the with_return scoping issues that reported late 2014 (which I can't find the issue / prs for).