### PR TITLE
Allow non-hashref parameters

### DIFF
--- a/lib/Dancer2/Core/Request.pm
+++ b/lib/Dancer2/Core/Request.pm
@@ -477,8 +477,11 @@ sub _build_params {
 
     # and merge everything
     $self->{_params} = {
-        %$previous,                %{ $self->_query_params || {} },
-        %{ $self->_route_params }, %{ $self->_body_params  || {} },
+        map +( ref $_ eq 'HASH' ? %{$_} : () ),
+        $previous,
+        $self->_query_params,
+        $self->_route_params,
+        $self->_body_params,
     };
 
 }

--- a/t/classes/Dancer2-Core-Request/serializers.t
+++ b/t/classes/Dancer2-Core-Request/serializers.t
@@ -1,0 +1,38 @@
+use strict;
+use warnings;
+use Test::More;
+use Plack::Test;
+use HTTP::Request::Common;
+use Class::Load 'try_load_class';
+
+try_load_class('CBOR::XS')
+    or plan skip_all => 'CBOR::XS is needed for this test';
+
+try_load_class('Dancer2::Serializer::CBOR')
+    or plan skip_all => 'Dancer2::Serializer::CBOR is needed for this test';
+
+{
+    package App; ## no critic
+    use Dancer2;
+    set serializer => 'CBOR';
+    post '/' => sub {
+        ::is_deeply( +{ params() }, +{}, 'Empty parameters' );
+        ::is( request->data, 'Foo', 'Correct data using request->data' );
+        return 'ok';
+    };
+}
+
+my $app = Plack::Test->create( App->to_app );
+my $res = $app->request(
+    POST '/',
+    Content => CBOR::XS::encode_cbor('Foo'),
+);
+
+ok( $res->is_success, 'Successful response' );
+is(
+    $res->content,
+    CBOR::XS::encode_cbor('ok'),
+    'Correct response',
+);
+
+done_testing();

--- a/t/classes/Dancer2-Core-Request/serializers.t
+++ b/t/classes/Dancer2-Core-Request/serializers.t
@@ -8,12 +8,16 @@ use Class::Load 'try_load_class';
 {
     package App::CBOR; ## no critic
     use Dancer2;
-    set serializer => 'CBOR';
-    post '/' => sub {
-        ::is_deeply( +{ params() }, +{}, 'Empty parameters' );
-        ::is( request->data, 'Foo', 'Correct data using request->data' );
-        return 'ok';
-    };
+
+    # postpone
+    sub setup {
+        set serializer => 'CBOR';
+        post '/' => sub {
+            ::is_deeply( +{ params() }, +{}, 'Empty parameters' );
+            ::is( request->data, 'Foo', 'Correct data using request->data' );
+            return 'ok';
+        };
+    }
 }
 
 subtest 'Testing with CBOR' => sub {
@@ -23,6 +27,7 @@ subtest 'Testing with CBOR' => sub {
     try_load_class('Dancer2::Serializer::CBOR')
         or plan skip_all => 'Dancer2::Serializer::CBOR is needed for this test';
 
+    App::CBOR->setup;
     my $app = Plack::Test->create( App::CBOR->to_app );
     my $res = $app->request(
         POST '/',


### PR DESCRIPTION
Until now parameters had to be a key=value, the way HTTP requires.
However, when using serializers, we might find ourselves receiving
serialized input that is not a hash reference. CBOR is an example
of such a serializer.

Up until now we would crash somewhere internally when trying to
deserialize it. This commit changes it to silently ignoring it,
providing empty parameter values (since there is no "key" to
associate it with), but still making the deserialized data
available in "request->data".

This issue was discussed at GH #740 as part of work to move
Dancer2::Core::Request to be based more on Plack::Request and
adding Hash::MultiValue parameters.

This test uses CBOR::XS and Dancer2::Serializer::CBOR but does
not require them.

This fixes GH #844.