### PR TITLE
Corrected link from Dancer2 Manual POD to params keyword.

### DIFF
--- a/lib/Dancer2/Manual.pod
+++ b/lib/Dancer2/Manual.pod
@@ -187,7 +187,7 @@ block provided should be executed.
 
 =head3 Retrieving request parameters
 
-The L<params|Dancer2/params> keyword returns a hashref of request
+The L<params|Dancer2::Manual/params> keyword returns a hashref of request
 parameters; these will be parameters supplied on the query string within
 the path itself (with named placeholders) and, for HTTP POST requests, the
 content of the POST body.


### PR DESCRIPTION
This is just to fix a link in the POD of Dancer2/lib/Dancer2/Manual.pod.