### PR TITLE
Feature/appdir sessions

### DIFF
--- a/lib/Dancer2/Core/App.pm
+++ b/lib/Dancer2/Core/App.pm
@@ -187,8 +187,10 @@ sub _build_session_engine {
 
     Scalar::Util::weaken( my $weak_self = $self );
 
+    # Note that engine options will replace the default session_dir (if provided).
     return $self->_factory->create(
         session         => $value,
+        session_dir     => path( $self->config->{appdir}, 'sessions' ),
         %{$engine_options},
         postponed_hooks => $self->postponed_hooks,
 

--- a/t/session_engines.t
+++ b/t/session_engines.t
@@ -6,13 +6,20 @@ use Plack::Test;
 use HTTP::Cookies;
 use HTTP::Request::Common;
 
-my @clients = qw(one two three);
+use File::Spec;
+use File::Basename 'dirname';
+
 my $SESSION_DIR;
+BEGIN {
+    $SESSION_DIR = File::Spec->catfile( dirname(__FILE__), 'sessions' );
+}
 
 {
     package App;
     use Dancer2;
     my @to_destroy;
+
+    set engines => { session => { YAML => { session_dir => $SESSION_DIR } } };
 
     hook 'engine.session.before_destroy' => sub {
         my $session = shift;
@@ -47,50 +54,64 @@ my $SESSION_DIR;
     );
 }
 
-my $test = Plack::Test->create( App->to_app );
 my $url  = "http://localhost";
+my $test = Plack::Test->create( App->to_app );
+my $app = Dancer2->runner->apps->[0];
 
-foreach my $client (@clients) {
-    my $jar = HTTP::Cookies->new;
+my @clients = qw(one two three);
 
-    subtest "[$client] Empty session" => sub {
-        my $res = $test->request( GET "$url/read_session" );
-        like $res->content, qr/name=''/,
-          "empty session for client $client";
-        $jar->extract_cookies($res);
-    };
+for my $engine ( qw(YAML Simple) ) {
+    # clear current session engine, and rebuild for the test
+    # This is *really* messy, playing in object hashrefs..
+    delete $app->{session_engine};
+    $app->config->{session} = $engine;
+    $app->session_engine; # trigger a build
 
-    subtest "[$client] set_session" => sub {
-        my $req = GET "$url/set_session/$client";
-        $jar->add_cookie_header($req);
-        my $res = $test->request($req);
-        ok( $res->is_success, "set_session for client $client" );
-        $jar->extract_cookies($res);
-    };
+    # run the tests for this engine
+    for my $client (@clients) {
+        my $jar = HTTP::Cookies->new;
 
-    subtest "[$client] session for client" => sub {
-        my $req = GET "$url/read_session";
-        $jar->add_cookie_header($req);
-        my $res = $test->request($req);
-        like $res->content, qr/name='$client'/,
-          "session looks good for client $client";
-        $jar->extract_cookies($res);
-    };
+        subtest "[$engine][$client] Empty session" => sub {
+            my $res = $test->request( GET "$url/read_session" );
+            like $res->content, qr/name=''/,
+              "empty session for client $client";
+            $jar->extract_cookies($res);
+        };
 
-    subtest "[$client] delete session" => sub {
-        my $req = GET "$url/clear_session";
-        $jar->add_cookie_header($req);
-        my $res = $test->request($req);
-        like $res->content, qr/cleared/, "deleted session key";
-    };
+        subtest "[$engine][$client] set_session" => sub {
+            my $req = GET "$url/set_session/$client";
+            $jar->add_cookie_header($req);
+            my $res = $test->request($req);
+            ok( $res->is_success, "set_session for client $client" );
+            $jar->extract_cookies($res);
+        };
 
-    subtest "[$client] cleanup" => sub {
-        my $req = GET "$url/cleanup";
-        $jar->add_cookie_header($req);
-        my $res = $test->request($req);
-        ok( $res->is_success, "cleanup done for $client" );
-        ok( $res->content, "session hook triggered" );
-    };
+        subtest "[$engine][$client] session for client" => sub {
+            my $req = GET "$url/read_session";
+            $jar->add_cookie_header($req);
+            my $res = $test->request($req);
+            like $res->content, qr/name='$client'/,
+              "session looks good for client $client";
+            $jar->extract_cookies($res);
+        };
+
+        subtest "[$engine][$client] delete session" => sub {
+            my $req = GET "$url/clear_session";
+            $jar->add_cookie_header($req);
+            my $res = $test->request($req);
+            like $res->content, qr/cleared/, "deleted session key";
+        };
+
+        subtest "[$engine][$client] cleanup" => sub {
+            my $req = GET "$url/cleanup";
+            $jar->add_cookie_header($req);
+            my $res = $test->request($req);
+            ok( $res->is_success, "cleanup done for $client" );
+            ok( $res->content, "session hook triggered" );
+        };
+    }
 }
+
+
 
 done_testing;


### PR DESCRIPTION
Make the default `session_dir => appdir/sessions`, as documented in all existing file-based session stores. Ref #926.

More importantly, adds tests for ::SessionFactory::File, which has somehow been removed.