### PR TITLE
Improve hook/route handling when content is already set in response

### DIFF
--- a/lib/Dancer2/Core/App.pm
+++ b/lib/Dancer2/Core/App.pm
@@ -1396,10 +1396,8 @@ sub _dispatch_route {
     return $response;
 }
 
-sub _add_content_to_response {
+sub _prep_response {
     my ( $self, $response, $content ) = @_;
-
-    defined $content or return $response;
 
     # The response object has no back references to the content or app
     # Update the default_content_type of the response if any value set in
@@ -1410,7 +1408,10 @@ sub _add_content_to_response {
         $response->default_content_type($ct);
     }
 
-    $response->content($content);
+    # if we were passed any content, set it in the response
+    defined $content && $response->content($content);
+    # finally encode the response content.
+    $response->encode_content;
     return $response;
 }
 

--- a/lib/Dancer2/Core/App.pm
+++ b/lib/Dancer2/Core/App.pm
@@ -1379,9 +1379,7 @@ sub _dispatch_route {
     my $response = $self->response;
 
     if ( $response->is_halted ) {
-        return $self->_add_content_to_response(
-            $response, $response->content,
-        );
+        return $self->_prep_response( $response );
     }
 
     $response = eval {

--- a/lib/Dancer2/Core/Route.pm
+++ b/lib/Dancer2/Core/Route.pm
@@ -135,14 +135,15 @@ sub execute {
 
     my $content = $self->code->( $app, @args );
 
-    # a user might have set the content in the response,
-    # so we ignore the return value and use that content instead
-    # but we only override if there was no object returned
+    # users may set content in the response. If the response has
+    # content, and the returned value from the route code is not
+    # an object (well, reference) we ignore the returned value
+    # and use the existing content in the response instead.
     $RESPONSE->has_content && !ref $content
-        and $content = $RESPONSE->content;
+        and return $app->_prep_response( $RESPONSE );
 
     my $type = blessed($content)
-        or return $app->_add_content_to_response( $RESPONSE, $content );
+        or return $app->_prep_response( $RESPONSE, $content );
 
     # Plack::Response: proper ArrayRef-style response
     $type eq 'Plack::Response'

--- a/t/route_response.t
+++ b/t/route_response.t
@@ -1,0 +1,43 @@
+use strict;
+use warnings;
+
+use Test::More;
+use Plack::Test;
+use HTTP::Request::Common;
+
+{
+    package RouteContentTest; ## no critic
+    use Dancer2;
+    set serializer => 'JSON';
+
+    hook before => sub {
+        return if request->dispatch_path eq '/content';
+        response->content({ foo => 'bar' });
+        response->halt;
+    };
+
+    get '/' => sub {1};
+
+    get '/content' => sub {
+        response->content({ foo => 'bar' });
+        return 'this is ignored';
+    };
+}
+
+my $test = Plack::Test->create( RouteContentTest->to_app );
+
+subtest "response set in before hook" => sub {
+    my $res = $test->request( GET '/' );
+    ok( $res->is_success, 'Successful request' );
+    is( $res->content, '{"foo":"bar"}', 'Correct content' );
+};
+
+subtest "response content set in route" => sub {
+    my $res = $test->request( GET '/content' );
+    ok( $res->is_success, 'Successful request' );
+    isnt( $res->content, 'this is ignored', 'route return value ignored' );
+    is( $res->content, '{"foo":"bar"}', 'Correct content' );
+};
+
+done_testing();
+


### PR DESCRIPTION
There were two cases where to copied the response content into a new var, only to set it straight back again into the response object. Apart from being loopy and unnecessary, when a serializer is defined, this would attempt to serialize the previously serialized content!

This Pr modifies the existing (private) method for preparing response content after hook and route execution, only setting response content if that is required, leaving existing content in the response alone. Fixes #944.