### PR TITLE
GH #947: Tests fail due to unescaped file paths in regex pattern

### DIFF
--- a/t/logger_console.t
+++ b/t/logger_console.t
@@ -19,7 +19,7 @@ for my $level (qw{core debug info warning error}) {
     # this test; however Capture::Tiny adds in several call frames
     # (see below) to capture the output, giving a reasonable caller
     # to test for
-    like $stderr, qr{$level in $file l. 15}, "$level message sent";
+    like $stderr, qr{$level in \Q$file\E l[.] 15}, "$level message sent";
 }
 done_testing;
 


### PR DESCRIPTION
On Windows, `\` is the directory separator. Therefore, when `t\logger_console.t` is interpolated into a regex pattern, it becomes `tlogger_console.t`,
causing the match, and consequently, the tests in that file to fail.

Even on other platforms, the regex contains two unescaped dots, which, strictly speaking, is not correct.

The solution is to use `\Q$file\E` when interpolating a variable `$file` in to a regex pattern, and use a literal dot in the line number expression.