### PR TITLE
Correctly handle multi byte unicode chars in param keys. Test the same.

### DIFF
--- a/lib/Dancer2/Core/Request.pm
+++ b/lib/Dancer2/Core/Request.pm
@@ -342,12 +342,7 @@ sub _decode {
     }
 
     if ( ref($h) eq 'HASH' ) {
-        while ( my ( $k, $v ) = each(%$h) ) {
-            my $decK = _decode($k);
-            $h->{$decK} = _decode($v);
-            delete $h->{$k} if $k ne $decK;
-        }
-        return $h;
+        return { map _decode($_), %$h };
     }
 
     if ( ref($h) eq 'ARRAY' ) {

--- a/lib/Dancer2/Core/Request.pm
+++ b/lib/Dancer2/Core/Request.pm
@@ -343,7 +343,9 @@ sub _decode {
 
     if ( ref($h) eq 'HASH' ) {
         while ( my ( $k, $v ) = each(%$h) ) {
-            $h->{$k} = _decode($v);
+            my $decK = _decode($k);
+            $h->{$decK} = _decode($v);
+            delete $h->{$k} if $k ne $decK;
         }
         return $h;
     }

--- a/t/request.t
+++ b/t/request.t
@@ -236,6 +236,17 @@ sub run_test {
     is $req->method, 'POST',      'method is changed';
     is_deeply scalar( $req->params ), { foo => 'bar', number => 42 },
       'params are not touched';
+
+    note "testing unicode params";
+    $env = {
+        'REQUEST_METHOD' => 'GET',
+        'REQUEST_URI'    => '/',
+        'PATH_INFO'      => '/',
+        'QUERY_STRING'   => "M%C3%BCller=L%C3%BCdenscheid",
+    };
+    $req = Dancer2::Core::Request->new( env => $env );
+    is_deeply scalar( $req->params ), { "M\N{U+00FC}ller", "L\N{U+00FC}denscheid" },
+      'multi byte unicode chars work in param keys and values';
 }
 
 note "Run test with XS_URL_DECODE" if $Dancer2::Core::Request::XS_URL_DECODE;


### PR DESCRIPTION
I did change the _decode() function to also decode hash keys and not only values. This seems to be how it should be at least for GET parameters. The function is also used for decoding other values though. I am not sure this change does not break any of those other uses. I would be grateful if someone with some deeper knowledge of Request.pm could have a look and verify I didn't break anything.