### PR TITLE
Removed redundant invocation of encode_content method:

### DIFF
--- a/lib/Dancer2/Core/App.pm
+++ b/lib/Dancer2/Core/App.pm
@@ -1408,8 +1408,6 @@ sub _prep_response {
 
     # if we were passed any content, set it in the response
     defined $content && $response->content($content);
-    # finally encode the response content.
-    $response->encode_content;
     return $response;
 }
 


### PR DESCRIPTION
There is no need to call encode_content on response object explicitly.
It's called in a hook around content invocation.