### PR TITLE
views use TT2's INCLUDE_PATH 

### DIFF
--- a/lib/Dancer2/Core/Role/Template.pm
+++ b/lib/Dancer2/Core/Role/Template.pm
@@ -6,7 +6,6 @@ use Dancer2::Core::Types;
 use Dancer2::FileUtils qw'path';
 use Carp 'croak';
 
-use Data::Dumper;
 use Moo::Role;
 with 'Dancer2::Core::Role::Engine';
 

--- a/lib/Dancer2/Template/TemplateToolkit.pm
+++ b/lib/Dancer2/Template/TemplateToolkit.pm
@@ -6,6 +6,7 @@ use Moo;
 use Carp qw/croak/;
 use Dancer2::Core::Types;
 use Dancer2::FileUtils qw'path';
+use Scalar::Util qw();
 use Template;
 
 with 'Dancer2::Core::Role::Template';
@@ -29,7 +30,8 @@ sub _build_engine {
     $tt_config{'END_TAG'} = $stop_tag
       if defined $stop_tag && $stop_tag ne '%]';
 
-    $tt_config{'INCLUDE_PATH'} ||= $self->views;
+    Scalar::Util::weaken( my $ttt = $self );
+    $tt_config{'INCLUDE_PATH'} ||= [ sub { [ $ttt->views ] } ];
 
     return Template->new(%tt_config);
 }

--- a/t/template.t
+++ b/t/template.t
@@ -132,4 +132,35 @@ subtest "modify views - absolute paths" => sub {
     );
 };
 
+{
+    package Baz;
+    use Dancer2;
+
+    set template => 'template_toolkit';
+
+    get '/set_views/**' => sub {
+        my ($view) = splat;
+        set views => join('/', @$view );
+    };
+
+    get '/:file' => sub {
+        template param('file');
+    };
+}
+
+subtest "modify views propogates to TT2 via dynamic INCLUDE_PATH" => sub {
+
+    my $test = Plack::Test->create( Baz->to_app );
+
+    my $res = $test->request( GET '/index' );
+    is $res->code, 200, 'got template from views';
+
+    # Change views - this is an existing test corpus..
+    $test->request( GET '/set_views/t/corpus/pretty' );
+
+    # Get another template that is known to exist in the test corpus
+    $res = $test->request( GET '/505' );
+    is $res->code, 200, 'got template from other view';
+};
+
 done_testing;

--- a/t/template_ext.t
+++ b/t/template_ext.t
@@ -2,9 +2,6 @@ use strict;
 use warnings;
 use Test::More;
 
-use File::Spec;
-use File::Basename 'dirname';
-
 eval { require Template; Template->import(); 1 }
   or plan skip_all => 'Template::Toolkit probably missing.';
 
@@ -19,17 +16,13 @@ set engines => {
 };
 set template => 'template_toolkit';
 
-my $views =
-  File::Spec->rel2abs( File::Spec->catfile( dirname(__FILE__), 'views' ) );
-
 my $tt = engine('template');
 isa_ok( $tt, 'Dancer2::Template::TemplateToolkit' );
 is( $tt->default_tmpl_ext, 'foo',
     "Template extension is 'foo' as configured",
 );
 
-is( $tt->view_pathname('foo'),
-    File::Spec->catfile( $views, 'foo.foo' ),
+is( $tt->view_pathname('foo'), 'foo.foo' ,
     "view('foo') gives filename with right extension as configured",
 );
 


### PR DESCRIPTION
Previously we were usually passing absolute paths for templates (and have ABSOLUTE => 1 set) when rendering output with TemplateToolkit, which worked for most use-cases.

However, as reported in #951 (with further discussion on IRC), if you set a path 'fragment' for a view, such as
```
  set views => 'foobar';
```
The both Dancer2::Template::TemplateToolkit and TT2's code for handling multiple INCLUDE_PATHs were *both* concatenating the views directory with the template name to be rendered. (i.e. looking for a template like `foobar/foobar/index.tt`).

This Pr updates the following to resolve #951
  1. Let TT2 do the template searching, ( override our default methods for `view_pathname` and `layout_pathname` ), and
  2. Sets the default INCLUDE_PATH given to TT2 to be a coderef, allowing the `views` setting to be modified at runtime.
