### PR TITLE
Bugfix: request scoping when rendering error templates

### DIFF
--- a/lib/Dancer2/Core/App.pm
+++ b/lib/Dancer2/Core/App.pm
@@ -1416,6 +1416,9 @@ sub response_internal_error {
 
     # warn "got error: $error";
 
+    local $Dancer2::Core::Route::REQUEST  = $self->request;
+    local $Dancer2::Core::Route::RESPONSE = $self->response;
+
     return Dancer2::Core::Error->new(
         app       => $self,
         status    => 500,
@@ -1427,6 +1430,9 @@ sub response_not_found {
     my ( $self, $request ) = @_;
 
     $self->set_request($request);
+
+    local $Dancer2::Core::Route::REQUEST  = $self->request;
+    local $Dancer2::Core::Route::RESPONSE = $self->response;
 
     my $response = Dancer2::Core::Error->new(
         app    => $self,

--- a/lib/Dancer2/Core/Error.pm
+++ b/lib/Dancer2/Core/Error.pm
@@ -270,6 +270,7 @@ sub _build_content {
                 }
             );
         };
+        $@ && $self->app->engine('logger')->log( warning => $@ );
 
         # return rendered content unless there was an error.
         return $content if defined $content;
@@ -291,6 +292,7 @@ sub _build_content {
                 }
             );
         };
+        $@ && $self->app->engine('logger')->log( warning => $@ );
 
         # return rendered content unless there was an error.
         return $content if defined $content;

--- a/t/scope_problems/keywords_before_template_hook.t
+++ b/t/scope_problems/keywords_before_template_hook.t
@@ -1,0 +1,43 @@
+use strict;
+use warnings;
+use Test::More;
+use Plack::Test;
+use HTTP::Request::Common qw/GET/;
+use File::Basename 'dirname';
+use File::Spec;
+
+my $views;
+BEGIN {
+  $views = File::Spec->rel2abs( File::Spec->catfile( dirname(__FILE__), 'views' ) );
+}
+
+eval { require Template; Template->import(); 1 }
+    or plan skip_all => 'Template::Toolkit probably missing.';
+
+{
+    package Test::App;
+    use Dancer2;
+
+    set views => $views;
+    set logger => 'Note';
+    set template => 'template_toolkit';
+
+    hook before_template_render => sub {
+        my $tokens = shift;
+        var some_var => 21;  # var can only be used in a route handler..
+    };
+
+    get '/' => sub {
+        die "Yes yes YES!";
+    };
+}
+
+my $test = Plack::Test->create(Test::App->to_app);
+
+my $res = $test->request(GET '/');
+is($res->code, 500, "Got 500 response");
+like( $res->content, qr/This is a dummy error template/,
+    "with the template content" );
+
+done_testing;
+

--- a/t/scope_problems/views/500.tt
+++ b/t/scope_problems/views/500.tt
@@ -1,1 +1,1 @@
-This is a dummy template to demonstrate a with_return error
+This is a dummy error template


### PR DESCRIPTION
From #959: If a route `die`d and you have a `before_template_render` hook that used keywords that need to be used inside a route handler, then rendering custom error templates would also die, giving you the default error template. This was inconsistent with `send_error`, which did render the custom error template.

This was another scoping issue; when Dancer2::Core::App generates 500 or 404 errors, the localized REQUEST/RESPONSE were no longer set.

As a bonus, if the error templates fail to render, the errors are now logged, which will make future debugging _much_ easier.