### PR TITLE
Exceptions in before hooks renders custom error templates

### DIFF
--- a/lib/Dancer2/Core/App.pm
+++ b/lib/Dancer2/Core/App.pm
@@ -1375,7 +1375,9 @@ sub build_request {
 sub _dispatch_route {
     my ( $self, $route ) = @_;
 
-    $self->execute_hook( 'core.app.before_request', $self );
+    local $@;
+    eval { $self->execute_hook( 'core.app.before_request', $self ); 1; }
+        or return $self->response_internal_error($@);
     my $response = $self->response;
 
     if ( $response->is_halted ) {

--- a/lib/Dancer2/Core/App.pm
+++ b/lib/Dancer2/Core/App.pm
@@ -1384,12 +1384,7 @@ sub _dispatch_route {
 
     $response = eval {
         $route->execute($self)
-    } or do {
-        my $error = $@;
-        $self->log( error => "Route exception: $error" );
-        $self->execute_hook( 'core.app.route_exception', $self, $error );
-        return $self->response_internal_error($error);
-    };
+    } or return $self->response_internal_error($@);
 
     return $response;
 }
@@ -1414,7 +1409,8 @@ sub _prep_response {
 sub response_internal_error {
     my ( $self, $error ) = @_;
 
-    # warn "got error: $error";
+    $self->log( error => "Route exception: $error" );
+    $self->execute_hook( 'core.app.route_exception', $self, $error );
 
     return Dancer2::Core::Error->new(
         app       => $self,

--- a/lib/Dancer2/Core/Error.pm
+++ b/lib/Dancer2/Core/Error.pm
@@ -103,7 +103,7 @@ sub default_error_page {
 
     require Template::Tiny;
 
-    my $uri_base = $self->has_app ?
+    my $uri_base = $self->has_app && $self->app->has_request ?
         $self->app->request->uri_base : '';
 
     my $message = $self->message;

--- a/t/app.t
+++ b/t/app.t
@@ -11,6 +11,7 @@ use File::Spec;
 
 # our app/dispatcher object
 my $app = Dancer2::Core::App->new( name => 'main', );
+$app->setting( show_errors => 1 ); # enable show errors
 my $dispatcher = Dancer2::Core::Dispatcher->new( apps => [$app] );
 
 # first basic tests

--- a/t/issues/memleak/die_in_hooks.t
+++ b/t/issues/memleak/die_in_hooks.t
@@ -39,6 +39,7 @@ is( $called, 1, 'Memory cleaned' );
 # double check stderr
 #  '[App:21992] error @2015-03-03 16:39:07> Exception caught in 'core.app.before_request' filter: Hook error: whoops at t/issues/memleak/die_in_hooks.t line 25.
 #  at lib/Dancer2/Core/App.pm line 848. in (eval 117) l. 1
+#  at ...
 # '
 like(
     $stderr,
@@ -48,8 +49,7 @@ like(
         \QException caught in 'core.app.before_request' filter:\E \s
         \QHook error: whoops\E \s
         [^\n]+ \n \s*       # everything until newline + newline
-        at [^\n]+ \n        # another such line
-        $
+        at [^\n]+ \n        # another such line (there could be more)
     }x,
     'Correct error',
 );


### PR DESCRIPTION
Catch exceptions in `before` hooks, allowing any defined custom error templates (or `views/500.tt`) to be rendered (rather than the generic internal server error page). Resolves #961.

This also triggered an issue in Dancer2::Core::Error where we checked if the error had an app, and then called app->request->uri_base;  errors can have an app without a request object.. fixed that too. :)