### PR TITLE
Remove AutoPrereqs

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -23,11 +23,11 @@ add_files_in = README.mkdn
 
 [@Filter]
 -bundle = @Dancer
+-remove = AutoPrereqs
 -remove = GithubMeta
 -remove = ModuleBuild
 ; Required version of the bundle
 :version = 0.0007
-autoprereqs_skip = ^t::lib::|^t::app::|XS$
 
 ; -- static meta-information
 [MetaResources]

--- a/dist.ini
+++ b/dist.ini
@@ -83,6 +83,10 @@ parent = 0
 Template::Tiny = 0
 Class::Load = 0
 Return::MultiLevel = 0
+Import::Into = 0
+Safe::Isa = 0
+Hash::Merge::Simple = 0
+App::Cmd::Setup = 0
 
 [Prereqs / Recommends]
 ; Serializers
@@ -112,6 +116,7 @@ MIME::Types = 0
 
 ; -- test requirements
 [Prereqs / TestRequires]
+Template = 0
 Test::More = 0.92
 Capture::Tiny = 0.12
 ; This version of YAML is needed due to:
@@ -119,6 +124,7 @@ Capture::Tiny = 0.12
 YAML = 0.86
 Test::Fatal = 0
 HTTP::Body = 0
+HTTP::Cookies = 0
 HTTP::Headers = 0
 
 ; for maintainers, see with mst how to avoid these


### PR DESCRIPTION
`AutoPrereqs` is great for lazy developers, but can have some undesirable side-effects. #965 

Without it, dependencies need to be accurately maintained. This is where `Travis-CI` comes in handy. Any missing dependencies will be picked up right away (when a commit is pushed or pull request is sent).