### PR TITLE
Dancer2::Serializer::JSON: Improve Performance (#719)

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -54,6 +54,7 @@ Moo = 1.003000
 Moo::Role = 0
 Role::Tiny = 1.003000
 MooX::Types::MooseLike = 0
+MooX::Singleton = 0
 Carp = 0
 Exporter = 5.57
 Encode = 0

--- a/lib/Dancer2/Serializer/JSON.pm
+++ b/lib/Dancer2/Serializer/JSON.pm
@@ -5,17 +5,18 @@ use Moo;
 use JSON ();
 
 with 'Dancer2::Core::Role::Serializer';
+with 'MooX::Singleton';
 
 has '+content_type' => ( default => sub {'application/json'} );
 
 # helpers
 sub from_json {
-    my $s = Dancer2::Serializer::JSON->new;
+    my $s = Dancer2::Serializer::JSON->instance;
     $s->deserialize(@_);
 }
 
 sub to_json {
-    my $s = Dancer2::Serializer::JSON->new;
+    my $s = Dancer2::Serializer::JSON->instance;
     $s->serialize(@_);
 }
 


### PR DESCRIPTION
PerlDancer/Dancer2#719

Improving performance for JSON serialization of data structures in tight
loops by not instantiating a brand new serialization object every time
it's being invoked.

See benchmark at https://gist.github.com/iftekhar25/b1a5472b2d98155446f9