### PR TITLE
Bugfix #890: Apply host & port from App to Runner:

### DIFF
--- a/lib/Dancer2/Config.pod
+++ b/lib/Dancer2/Config.pod
@@ -114,7 +114,7 @@ your Dancer2 applications.
 
 =head2 Run mode and listening interface/port
 
-=head3 server (string)
+=head3 host (string)
 
 The IP address that the Dancer2 app should bind to.  Default is 0.0.0.0,
 i.e.  bind to all available interfaces.

--- a/lib/Dancer2/Core/App.pm
+++ b/lib/Dancer2/Core/App.pm
@@ -356,6 +356,12 @@ around _build_config => sub {
         $self->_validate_engine($_) for keys %{ $config->{'engines'} };
     }
 
+    my $runner = Dancer2::runner();
+    exists $config->{host}
+        and $runner->config->{host} = $config->{host};
+    exists $config->{port}
+        and $runner->config->{port} = $config->{port};
+
     return $config;
 };
 


### PR DESCRIPTION
Bug URL: https://github.com/PerlDancer/Dancer2/issues/890

The reason was Dancer2::Core::Runner has a seperate config which is not
affected by Dancer2::Core::App config and thus Runner used the default host and
port.

To solve this issue the host and port are updated in Dancer2::Core:Runner after
building config is finished in Dancer2::Core::App.

Also Dancer2::Config had the wrong setting name for the listening IP address
which is host, not server.