### PR TITLE
Streamline the (to|from)_(json|yaml|dumper) serialization helpers.

### DIFF
--- a/lib/Dancer2/Core/Role/Serializer.pm
+++ b/lib/Dancer2/Core/Role/Serializer.pm
@@ -4,6 +4,7 @@ package Dancer2::Core::Role::Serializer;
 use Moo::Role;
 use Try::Tiny;
 use Dancer2::Core::Types;
+use Scalar::Util 'blessed';
 
 with 'Dancer2::Core::Role::Engine';
 
@@ -40,14 +41,14 @@ around serialize => sub {
     $content && length $content > 0
         or return $content;
 
-    $self->execute_hook( 'engine.serializer.before', $content );
+    blessed $self && $self->execute_hook( 'engine.serializer.before', $content );
 
     my $data;
     try {
-        $data = $self->$orig($content, $options);
-        $self->execute_hook( 'engine.serializer.after', $data );
+        $data = $self->$orig( $content, $options );
+        blessed $self && $self->execute_hook( 'engine.serializer.after', $data );
     } catch {
-        $self->log_cb->( core => "Failed to serialize the request: $_" );
+        blessed $self && $self->log_cb->( core => "Failed to serialize the request: $_" );
     };
 
     return $data;

--- a/lib/Dancer2/Serializer/Dumper.pm
+++ b/lib/Dancer2/Serializer/Dumper.pm
@@ -12,15 +12,9 @@ with 'Dancer2::Core::Role::Serializer';
 has '+content_type' => ( default => sub {'text/x-data-dumper'} );
 
 # helpers
-sub from_dumper {
-    my $s = Dancer2::Serializer::Dumper->new;
-    $s->deserialize(@_);
-}
+sub from_dumper { __PACKAGE__->deserialize(@_) }
 
-sub to_dumper {
-    my $s = Dancer2::Serializer::Dumper->new;
-    $s->serialize(@_);
-}
+sub to_dumper { __PACKAGE__->serialize(@_) }
 
 # class definition
 sub serialize {

--- a/lib/Dancer2/Serializer/JSON.pm
+++ b/lib/Dancer2/Serializer/JSON.pm
@@ -10,15 +10,9 @@ with 'Dancer2::Core::Role::Serializer';
 has '+content_type' => ( default => sub {'application/json'} );
 
 # helpers
-sub from_json {
-    my $s = Dancer2::Serializer::JSON->new;
-    $s->deserialize(@_);
-}
+sub from_json { __PACKAGE__-> deserialize(@_) }
 
-sub to_json {
-    my $s = Dancer2::Serializer::JSON->new;
-    $s->serialize(@_);
-}
+sub to_json { __PACKAGE__->serialize(@_) }
 
 # class definition
 sub serialize {

--- a/lib/Dancer2/Serializer/JSON.pm
+++ b/lib/Dancer2/Serializer/JSON.pm
@@ -3,6 +3,7 @@ package Dancer2::Serializer::JSON;
 
 use Moo;
 use JSON ();
+use Scalar::Util 'blessed';
 
 with 'Dancer2::Core::Role::Serializer';
 
@@ -23,7 +24,7 @@ sub to_json {
 sub serialize {
     my ( $self, $entity, $options ) = @_;
 
-    my $config = $self->config;
+    my $config = blessed $self ? $self->config : {};
 
     foreach (keys %$config) {
         $options->{$_} = $config->{$_} unless exists $options->{$_};

--- a/lib/Dancer2/Serializer/YAML.pm
+++ b/lib/Dancer2/Serializer/YAML.pm
@@ -5,22 +5,15 @@ use Moo;
 use Carp 'croak';
 use Encode;
 use Class::Load 'load_class';
+
 with 'Dancer2::Core::Role::Serializer';
 
 has '+content_type' => ( default => sub {'text/x-yaml'} );
 
 # helpers
-sub from_yaml {
-    my ($yaml) = @_;
-    my $s = Dancer2::Serializer::YAML->new;
-    $s->deserialize($yaml);
-}
+sub from_yaml { __PACKAGE__->deserialize(@_) }
 
-sub to_yaml {
-    my ($data) = @_;
-    my $s = Dancer2::Serializer::YAML->new;
-    $s->serialize($data);
-}
+sub to_yaml { __PACKAGE__->serialize(@_) }
 
 # class definition
 sub BUILD { load_class('YAML') }


### PR DESCRIPTION
The (to|from)_(json|yaml|dumper) helpers all create a new serializer
object and call (de)serialize on it. If you trace the actual calls, this
is roughly (pseudo code for serialize):

```
  Serializer->new->serialize(@_);
  # around modifier
  $self->execute_hook;
  original $self->serialize(...)
  $self->config;  (JSON only)
  do the serialization
  $self->log_cb if serialization failed.
```

However, as we have a new serializer object, there are no hooks, there
is no config, and the default lob_cb is `sub{1}`. ie. we make a lot of
method calls that do nothing after the expense of generating the
serializer object itself.

Instead, add logical checks that ensures that those methods only
get called if $self is blessed. This does not interfere with serializing
content at the end of a route, and allows (de)serialize to be called as
a class method. Resolves #719 and is an alternate to #969.

Another benefit is that serialization fails when called as a class
method will no longer be trapped and silently ignored, possibly resolving #644
and alternative to #647.
