### PR TITLE
Use $^V for version in template token, not $]:

### DIFF
--- a/lib/Dancer2/Core/Role/Template.pm
+++ b/lib/Dancer2/Core/Role/Template.pm
@@ -172,7 +172,7 @@ sub _prepare_tokens_options {
 
     # these are the default tokens provided for template processing
     $tokens ||= {};
-    $tokens->{perl_version}   = $];
+    $tokens->{perl_version}   = $^V;
     $tokens->{dancer_version} = Dancer2->VERSION;
 
     $tokens->{settings} = $self->settings;
@@ -238,7 +238,7 @@ Any template receives the following tokens, by default:
 
 =item * C<perl_version>
 
-Current version of perl, effectively C<$]>.
+Current version of perl, effectively C<$^V>.
 
 =item * C<dancer_version>
 

--- a/t/template_default_tokens.t
+++ b/t/template_default_tokens.t
@@ -31,7 +31,7 @@ my $views =
 }
 
 my $version = Dancer2->VERSION;
-my $expected = "perl_version: $]
+my $expected = "perl_version: $^V
 dancer_version: ${version}
 settings.foo: in settings
 params.foo: 42


### PR DESCRIPTION
From perlvar:

       $OLD_PERL_VERSION
       $]      See "$^V" for a more modern representation of the Perl version
               that allows accurate string comparisons.

Before:

    5.018002

After:

    v5.18.2