### PR TITLE
Captures should always return empty hashref:

### DIFF
--- a/lib/Dancer2/Core/Request.pm
+++ b/lib/Dancer2/Core/Request.pm
@@ -326,7 +326,7 @@ sub params {
     }
 }
 
-sub captures { shift->params->{captures} }
+sub captures { shift->params->{captures} || {} }
 
 sub splat { @{ shift->params->{splat} || [] } }
 


### PR DESCRIPTION
captures() keyword would return undef if there were no captures.
That's bad. It should be consistent and always return hashref.