### PR TITLE
Provide keywords for Hash::MultiValue parameters

### DIFF
--- a/lib/Dancer2/Core/App.pm
+++ b/lib/Dancer2/Core/App.pm
@@ -1123,7 +1123,7 @@ sub make_forward_to {
 
     $env->{PATH_INFO} = $url;
 
-    my $new_request = Dancer2::Core::Request->new( env => $env, body_is_parsed => 1 );
+    my $new_request = Dancer2::Core::Request->new( env => $env, body_params => {} );
     my $new_params = _merge_params( scalar( $request->params ), $params || {} );
 
     exists $options->{method} and

--- a/lib/Dancer2/Core/App.pm
+++ b/lib/Dancer2/Core/App.pm
@@ -1258,6 +1258,7 @@ DISPATCH:
                 or next ROUTE;
 
             $request->_set_route_params($match);
+            $request->_set_route_parameters($match);
 
             # Add session to app *if* we have a session and the request
             # has the appropriate cookie header for _this_ app.

--- a/lib/Dancer2/Core/DSL.pm
+++ b/lib/Dancer2/Core/DSL.pm
@@ -79,6 +79,9 @@ sub dsl_keywords {
         options              => { is_global => 1 },
         param                => { is_global => 0 },
         params               => { is_global => 0 },
+        query_parameters     => { is_global => 0 },
+        body_parameters      => { is_global => 0 },
+        route_parameters     => { is_global => 0 },
         pass                 => { is_global => 0 },
         patch                => { is_global => 1 },
         path                 => { is_global => 1 },
@@ -369,6 +372,10 @@ sub splat { $Dancer2::Core::Route::REQUEST->splat }
 sub params { shift; $Dancer2::Core::Route::REQUEST->params(@_); }
 
 sub param { shift; $Dancer2::Core::Route::REQUEST->param(@_); }
+
+sub query_parameters { shift; $Dancer2::Core::Route::REQUEST->query_parameters(@_); }
+sub body_parameters  { shift; $Dancer2::Core::Route::REQUEST->body_parameters(@_);  }
+sub route_parameters { shift; $Dancer2::Core::Route::REQUEST->route_parameters(@_); }
 
 sub redirect { shift->app->redirect(@_) }
 

--- a/lib/Dancer2/Core/Request.pm
+++ b/lib/Dancer2/Core/Request.pm
@@ -124,11 +124,6 @@ sub _body_params {
         : _decode( $self->{'_http_body'}->param );
 }
 
-sub _set_body_params {
-    my ( $self, $params ) = @_;
-    $self->{_body_params} = _decode( $params );
-}
-
 sub _query_params { $_[0]->{'_query_params'} }
 
 sub _set_query_params {

--- a/lib/Dancer2/Core/Request.pm
+++ b/lib/Dancer2/Core/Request.pm
@@ -356,7 +356,7 @@ sub _set_route_parameters {
     my ( $self, $params ) = @_;
     # remove reserved splat parameter name
     # you should access splat parameters using splat() keyword
-    delete $params->{'splat'};
+    delete @{$params}{qw<splat captures>};
     $self->{'route_parameters'} = Hash::MultiValue->from_mixed( %{$params} );
 }
 

--- a/lib/Dancer2/Core/Request.pm
+++ b/lib/Dancer2/Core/Request.pm
@@ -354,6 +354,9 @@ sub route_parameters { $_[0]->{'route_parameters'} ||= Hash::MultiValue->new }
 
 sub _set_route_parameters {
     my ( $self, $params ) = @_;
+    # remove reserved splat parameter name
+    # you should access splat parameters using splat() keyword
+    delete $params->{'splat'};
     $self->{'route_parameters'} = Hash::MultiValue->from_mixed( %{$params} );
 }
 

--- a/lib/Dancer2/Core/Request.pm
+++ b/lib/Dancer2/Core/Request.pm
@@ -194,7 +194,7 @@ sub deserialize {
     $body && length $body > 0
         or return;
 
-    my $data = $serializer->deserialize($self->body);
+    my $data = $serializer->deserialize($body);
     return if !defined $data;
 
     # Set _body_params directly rather than using the setter. Deserializiation

--- a/lib/Dancer2/Core/Request.pm
+++ b/lib/Dancer2/Core/Request.pm
@@ -98,7 +98,7 @@ sub var {
 sub set_path_info { $_[0]->env->{'PATH_INFO'} = $_[1] }
 
 # XXX: incompatible with Plack::Request
-sub body { $_[0]->{'body'} || $_[0]->_read_to_end }
+sub body { $_[0]->{'body'} ||= $_[0]->_read_to_end }
 
 sub id { $_id }
 

--- a/lib/Dancer2/Core/Request.pm
+++ b/lib/Dancer2/Core/Request.pm
@@ -73,6 +73,9 @@ sub new {
       HTTP::Body->new( $self->content_type || '', $self->content_length );
     $self->{_http_body}->cleanup(1);
 
+    $opts{'body_params'}
+        and $self->{'_body_params'} = $opts{'body_params'};
+
     $self->data;      # Deserialize body
     $self->_build_uploads();
 
@@ -116,12 +119,7 @@ sub _body_params {
     # make sure body is parsed
     $self->body;
 
-    # XXX: Do we really need to check body_is_parsed
-    # once the body is set? -- SX
-    $self->{'_body_params'} ||=
-        $self->body_is_parsed
-        ? {}
-        : _decode( $self->{'_http_body'}->param );
+    $self->{'_body_params'} ||= _decode( $self->{'_http_body'}->param );
 }
 
 sub _query_params { $_[0]->{'_query_params'} }
@@ -141,8 +139,6 @@ sub _set_route_params {
 
 # XXX: incompatible with Plack::Request
 sub uploads { $_[0]->{'uploads'} }
-
-sub body_is_parsed { $_[0]->{'body_is_parsed'} || 0 }
 
 sub is_behind_proxy { $_[0]->{'is_behind_proxy'} || 0 }
 
@@ -771,10 +767,21 @@ It uses the environment hash table given to build the request object:
 
     Dancer2::Core::Request->new( env => $env );
 
-Two additional parameters for instantiation are C<body_is_parsed> boolean
-(indicating if the request should avoid parsing the body again), and
-C<serializer> which can provide a serializer object to work with when
-reading the request body.
+There are two additional parameters for instantiation:
+
+=over 4
+
+=item * serializer
+
+A serializer object to work with when reading the request body.
+
+=item * body_params
+
+Provide body parameters.
+
+Used internally when we need to avoid parsing the body again.
+
+=back
 
 =method param($key)
 

--- a/lib/Dancer2/Core/Request.pm
+++ b/lib/Dancer2/Core/Request.pm
@@ -66,7 +66,15 @@ sub new {
     $self->{'vars'}            = {};
     $self->{'is_behind_proxy'} = !!$opts{'is_behind_proxy'};
 
-    $self->init;
+    # parameters
+    $self->{_chunk_size}       = 4096;
+    $self->{_read_position}    = 0;
+    $self->{_http_body} =
+      HTTP::Body->new( $self->content_type || '', $self->content_length );
+    $self->{_http_body}->cleanup(1);
+
+    $self->data;      # Deserialize body
+    $self->_build_uploads();
 
     return $self;
 }
@@ -209,20 +217,6 @@ sub is_patch  { $_[0]->method eq 'PATCH' }
 # public interface compat with CGI.pm objects
 sub request_method { $_[0]->method }
 sub input_handle { $_[0]->env->{'psgi.input'} }
-
-sub init {
-    my ($self) = @_;
-
-    $self->{_chunk_size}    = 4096;
-    $self->{_read_position} = 0;
-
-    $self->{_http_body} =
-      HTTP::Body->new( $self->content_type || '', $self->content_length );
-    $self->{_http_body}->cleanup(1);
-
-    $self->data;      # Deserialize body
-    $self->_build_uploads();
-}
 
 sub to_string {
     my ($self) = @_;

--- a/t/dsl/parameters.t
+++ b/t/dsl/parameters.t
@@ -1,0 +1,167 @@
+use strict;
+use warnings;
+use utf8;
+use Test::More;
+use Plack::Test;
+use HTTP::Request::Common;
+
+subtest 'Query parameters' => sub {
+    {
+        package App::Basic; ## no critic
+        use Dancer2;
+        use Encode 'encode_utf8';
+        get '/' => sub {
+            my $params = query_parameters;
+            ::isa_ok(
+                $params,
+                'Hash::MultiValue',
+                'parameters keyword',
+            );
+
+            ::is( $params->get('foo'), 'bar', 'Got single value' );
+            ::is(
+                $params->get('bar'),
+                'quux',
+                'Got single value from multi key',
+            );
+
+            ::is_deeply(
+                [ $params->get_all('bar') ],
+                ['baz', 'quux'],
+                'Got multi value from multi key',
+            );
+
+            ::is(
+                $params->get('baz'),
+                encode_utf8('הלו'),
+                'HMV interface returns decoded values',
+            );
+
+            ::is(
+                params->{'baz'},
+                'הלו',
+                'Regular interface returns encoded values'
+            );
+        };
+    }
+
+    my $app = Plack::Test->create( App::Basic->to_app );
+    my $res = $app->request( GET '/?foo=bar&bar=baz&bar=quux&baz=הלו' );
+    ok( $res->is_success, 'Successful request' );
+};
+
+subtest 'Body parameters' => sub {
+    {
+        package App::Body; ## no critic
+        use Dancer2;
+        post '/' => sub {
+            my $params = body_parameters;
+            ::isa_ok(
+                $params,
+                'Hash::MultiValue',
+                'parameters keyword',
+            );
+ 
+            ::is( $params->get('foo'), 'bar', 'Got single value' );
+            ::is(
+                $params->get('bar'),
+                'quux',
+                'Got single value from multi key',
+            );
+
+            my $z = [ $params->get_all('bar') ];
+            ::is_deeply(
+                [ $params->get_all('bar') ],
+                ['baz', 'quux'],
+                'Got multi value from multi key',
+            );
+        };
+    }
+
+    my $app = Plack::Test->create( App::Body->to_app );
+    my $res = $app->request(
+        POST '/', Content => [ foo => 'bar', bar => 'baz', bar => 'quux' ]
+    );
+    ok( $res->is_success, 'Successful request' );
+};
+
+subtest 'Body parameters with serialized data' => sub {
+    {
+        package App::Body::JSON; ## no critic
+        use Dancer2;
+        set serializer => 'JSON';
+        post '/' => sub {
+            my $params = body_parameters;
+            ::isa_ok(
+                $params,
+                'Hash::MultiValue',
+                'parameters keyword',
+            );
+
+            ::is( $params->get('foo'), 'bar', 'Got single value' );
+            ::is(
+                $params->get('bar'),
+                'quux',
+                'Got single value from multi key',
+            );
+
+            my $z = [ $params->get_all('bar') ];
+            ::is_deeply(
+                [ $params->get_all('bar') ],
+                ['baz', 'quux'],
+                'Got multi value from multi key',
+            );
+
+            return { ok => 1 };
+        };
+    }
+
+    my $app = Plack::Test->create( App::Body::JSON->to_app );
+    my $res = $app->request(
+        POST '/', Content => '{"foo":"bar","bar":["baz","quux"]}'
+    );
+    ok( $res->is_success, 'Successful request' );
+};
+
+subtest 'Route parameters' => sub {
+    {
+        package App::Route; ## no critic
+        use Dancer2;
+        get '/:foo' => sub {
+            my $params = route_parameters;
+            ::isa_ok(
+                $params,
+                'Hash::MultiValue',
+                'parameters keyword',
+            );
+
+            ::is( $params->get('foo'), 'bar', 'Got keyed value' );
+        };
+
+        get '/:name/:value' => sub {
+            my $params = route_parameters;
+            ::isa_ok(
+                $params,
+                'Hash::MultiValue',
+                'parameters keyword returns Hash::MultiValue object',
+            );
+
+            ::is( $params->get('name'), 'foo', 'Got first value' );
+            ::is( $params->get('value'), 'bar', 'Got second value' );
+        };
+    }
+
+    my $app = Plack::Test->create( App::Route->to_app );
+
+    {
+        my $res = $app->request( GET '/bar' );
+        ok( $res->is_success, 'Successful request' );
+    }
+
+    {
+        my $res = $app->request( GET '/foo/bar' );
+        ok( $res->is_success, 'Successful request' );
+    }
+};
+
+done_testing();

--- a/tools/perf.pl
+++ b/tools/perf.pl
@@ -44,10 +44,10 @@ my $req = GET '/';
 
 sub check_app {
     my ( $number, $app ) = @_;
-    print STDERR "Checking $app... ";
+    print STDERR "Checking Dancer $number... ";
 
     my $res = $app->request($req);
-    if ( $res->content == "ok$app" ) {
+    if ( $res->content eq "ok$number" ) {
         print STDERR "Good!\n";
     } else {
         print STDERR "Bad!\n";
@@ -79,8 +79,8 @@ if ( $opts{'profile'} ) {
         initial_runs         => 20,
     );
 
-    check_app( 1 => $app1 );
-    check_app( 2 => $app2 );
+    check_app( 1 => $test_app1 );
+    check_app( 2 => $test_app2 );
 
     $bench->add_instances(
         Dumbbench::Instance::PerlSub->new(
@@ -113,7 +113,7 @@ if ( $opts{'profile'} ) {
     my $test_app2 = Plack::Test->create($app2);
     my $req = GET '/';
 
-    check_app( 2 => $app2 );
+    check_app( 2 => $test_app2 );
 
     $bench->add_instances(
         Dumbbench::Instance::PerlSub->new(


### PR DESCRIPTION
Finally it's landed.

This PR provides three new keywords:

    query_parameters
    body_parameters
    route_parameters

It returns a `Hash::MultiValue` object which you can use in order to get values without worrying about context.

    GET /?foo=bar&foo=baz

    get '/' => sub {
        # BEFORE:
        my $foo = params('query')->{'foo');
        ref $foo eq 'ARRAY' and $foo = $foo->[ $#foo ]; # we have to normalize $foo - yuck!

        # AFTER:
        my $foo = query_parameters->get('foo'); # always a single value
        my @foo = query_parameters->get_all('foo'); # always array, even if only one value
    };

<3

The reason we introduce these keywords instead of a `parameters` keyword is that we want users to make sure they know where they get the parameters and don't accidentally have overwritten merged parameters from multiple sources (and have to know how they are merged).

This handles the following tickets: #739, #740.