### PR TITLE
Add option for providing skeleton

### DIFF
--- a/lib/Dancer2/CLI/Command/gen.pm
+++ b/lib/Dancer2/CLI/Command/gen.pm
@@ -27,7 +27,7 @@ sub opt_spec {
             { default => '.' } ],
         [ 'overwrite|o',     'overwrite existing files' ],
         [ 'no-check|x',      'don\'t check latest Dancer2 version (requires internet)' ],
-        [ 'skel|s=s',      'skeleton directory' ],
+        [ 'skel|s=s',        'skeleton directory' ],
     );
 }
 
@@ -49,8 +49,10 @@ sub validate_args {
     -d $path or $self->usage_error("directory '$path' does not exist");
     -w $path or $self->usage_error("directory '$path' is not writeable");
 
-    my $skel_path = $opt->{skel};
-    -d $skel_path or $self->usage_error("skeleton directory '$skel_path' not found");
+    if ($opt->{skel}) {
+        my $skel_path = $opt->{skel};
+        -d $skel_path or $self->usage_error("skeleton directory '$skel_path' not found");
+    }
 
 }
 
@@ -182,7 +184,6 @@ sub _create_manifest {
     my ($files, $dir) = @_;
 
     my $manifest_name = catfile($dir, 'MANIFEST');
-    -e $manifest_name or (warn "skeleton has no MANIFEST file" and return);
     open(my $manifest, '>', $manifest_name) or die $!;
     print $manifest "MANIFEST\n";
 
@@ -202,7 +203,6 @@ sub _add_to_manifest_skip {
     my $dir = shift;
 
     my $filename = catfile($dir, 'MANIFEST.SKIP');
-    -e $filename or (warn "skeleton has no MANIFEST file" and return);
     open my $fh, '>>', $filename or die $!;
     print {$fh} "^$dir-\n";
     close $fh;

--- a/lib/Dancer2/CLI/Command/gen.pm
+++ b/lib/Dancer2/CLI/Command/gen.pm
@@ -27,6 +27,7 @@ sub opt_spec {
             { default => '.' } ],
         [ 'overwrite|o',     'overwrite existing files' ],
         [ 'no-check|x',      'don\'t check latest Dancer2 version (requires internet)' ],
+        [ 'skel|s=s',      'skeleton directory' ],
     );
 }
 
@@ -47,6 +48,10 @@ sub validate_args {
     my $path = $opt->{path};
     -d $path or $self->usage_error("directory '$path' does not exist");
     -w $path or $self->usage_error("directory '$path' is not writeable");
+
+    my $skel_path = $opt->{skel};
+    -d $skel_path or $self->usage_error("skeleton directory '$skel_path' not found");
+
 }
 
 sub execute {
@@ -54,7 +59,7 @@ sub execute {
     $self->_version_check() unless $opt->{'no_check'};
 
     my $dist_dir = $ENV{DANCER2_SHARE_DIR} || dist_dir('Dancer2');
-    my $skel_dir = catdir($dist_dir, 'skel');
+    my $skel_dir = $opt->{skel} || catdir($dist_dir, 'skel');
     -d $skel_dir or die "$skel_dir doesn't exist";
 
     my $app_name = $opt->{application};
@@ -177,6 +182,7 @@ sub _create_manifest {
     my ($files, $dir) = @_;
 
     my $manifest_name = catfile($dir, 'MANIFEST');
+    -e $manifest_name or (warn "skeleton has no MANIFEST file" and return);
     open(my $manifest, '>', $manifest_name) or die $!;
     print $manifest "MANIFEST\n";
 
@@ -196,6 +202,7 @@ sub _add_to_manifest_skip {
     my $dir = shift;
 
     my $filename = catfile($dir, 'MANIFEST.SKIP');
+    -e $filename or (warn "skeleton has no MANIFEST file" and return);
     open my $fh, '>>', $filename or die $!;
     print {$fh} "^$dir-\n";
     close $fh;

--- a/lib/Dancer2/Manual.pod
+++ b/lib/Dancer2/Manual.pod
@@ -76,7 +76,14 @@ It creates a directory named after the name of the app, along with a
 configuration file, a views directory (where your templates and layouts
 will live), an environments directory (where environment-specific
 settings live), a module containing the actual guts of your application, and
-a script to start it
+a script to start it. A default skeleton is used to bootstrap the new
+application, the option C<-s> can be used to provide another skeleton,
+for example:
+
+    $ dancer2 -a mywebapp -s ~/mydancerskel
+
+For an example of a skeleton directory check the default one available in
+the C<share/> directory of your Dancer2 distribution.
 
 Because Dancer2 is a L<PSGI> web application framework, you can use the
 C<plackup> tool (provided by L<Plack>) for launching the application:


### PR DESCRIPTION
This option allows having custom skeleton directories for new applications. Although it's a very simple solution it can save a lot of work for anyone that creates a lot of applications and has to make the same changes every time (eg. use template toolkit instead of simple templates, add bootstrap).