### PR TITLE
Deprecate (by warning) ':splat' and ':captures' named placeholders

### DIFF
--- a/lib/Dancer2/Core/Route.pm
+++ b/lib/Dancer2/Core/Route.pm
@@ -4,6 +4,7 @@ package Dancer2::Core::Route;
 use Moo;
 use Dancer2::Core::Types;
 use Carp 'croak';
+use List::Util 'first';
 use Scalar::Util 'blessed';
 
 our ( $REQUEST, $RESPONSE, $RESPONDER, $WRITER );
@@ -212,6 +213,12 @@ sub _build_regexp_from_string {
     if ( $string =~ /:/ ) {
         @params = $string =~ /:([^\/\.\?]+)/g;
         if (@params) {
+            first { $_ eq 'splat' } @params
+                and warn q{Named placeholder 'splat' is deprecated};
+
+            first { $_ eq 'captures' } @params
+                and warn q{Named placeholder 'captures' is deprecated};
+
             $string =~ s!(:[^\/\.\?]+)!(?#token)([^/]+)!g;
             $capture = 1;
         }

--- a/t/classes/Dancer2-Core-Route/deprecated_param_keys.t
+++ b/t/classes/Dancer2-Core-Route/deprecated_param_keys.t
@@ -1,0 +1,34 @@
+use strict;
+use warnings;
+use Test::More;
+use Capture::Tiny 0.12 'capture_stderr';
+BEGIN { use_ok('Dancer2::Core::Route') }
+
+like(
+    capture_stderr {
+        Dancer2::Core::Route->new(
+            regexp => '/:splat',
+            code   => sub {1},
+            method => 'get',
+        );
+    },
+    qr{^Named placeholder 'splat' is deprecated},
+    'Find deprecation of :splat',
+);
+
+SKIP: {
+    skip 'Need perl >= 5.10', 1 unless $] >= 5.010;
+    like(
+        capture_stderr {
+            Dancer2::Core::Route->new(
+                regexp => '/:captures',
+                code   => sub {1},
+                method => 'get',
+            );
+        },
+        qr{^Named placeholder 'captures' is deprecated},
+        'Find deprecation of :captures',
+    );
+}
+
+done_testing;


### PR DESCRIPTION
Both the 'splat' and the 'captures' variables are saved in the
route parameters hash. This means that if someone provides a route
path that contains those words, it might override it (depending
on the merging order). In either way, one parameter might override
the other.

    # curl 0:3000/hello/world
    get '/*/:splat' => sub {
        my @splat = splat;
        my $param = params('route')->{'splat'};

        # @splat = ( "hello" )
        # $param = [ "hello" ]
    };

For now we're just warning, but this will die at some point.