### PR TITLE
Route parameters should overwrite all other merged variables

### DIFF
--- a/lib/Dancer2/Core/Request.pm
+++ b/lib/Dancer2/Core/Request.pm
@@ -387,8 +387,8 @@ sub _build_params {
         map +( ref $_ eq 'HASH' ? %{$_} : () ),
         $previous,
         $get_params,
-        $self->_route_params,
         $self->_body_params,
+        $self->_route_params,
     };
 
 }

--- a/t/issues/gh-931.t
+++ b/t/issues/gh-931.t
@@ -1,0 +1,75 @@
+# this test checks the order of parameters precedence
+# we run a few request to a route
+# first we check that the route parameters have precedence
+# then we check that the body parameters have the next
+# and finally, when others aren't available, query parameters
+use strict;
+use warnings;
+use Test::More;
+use Plack::Test;
+use HTTP::Request::Common;
+
+{
+    package App; ## no critic
+    use Dancer2;
+
+    sub query_ok {
+        ::is(
+            params('query')->{'var'},
+            'QueryVar',
+            'Query variable exists',
+        );
+    }
+
+    sub body_ok {
+        ::is(
+            params('body')->{'var'},
+            'BodyVar',
+            'Body variable exists',
+        );
+    }
+
+    sub route_ok {
+        ::is(
+            params('route')->{'var'},
+            'RouteVar',
+            'Route variable exists',
+        );
+    }
+
+    post '/:var' => sub {
+        query_ok();
+        body_ok();
+        route_ok();
+
+        ::is(
+            params->{'var'},
+            'RouteVar',
+            'Route variable wins',
+        );
+
+    };
+
+    post '/' => sub {
+        query_ok();
+        body_ok();
+
+        ::is(
+            params->{'var'},
+            'BodyVar',
+            'Body variable wins',
+        );
+    };
+}
+
+my $test = Plack::Test->create( App->to_app );
+
+subtest 'Route takes precedence over all other parameters' => sub {
+    $test->request( POST '/RouteVar?var=QueryVar', [ var => 'BodyVar' ] );
+};
+
+subtest 'When route parameters not available, POST takes precedence' => sub {
+    $test->request( POST '/?var=QueryVar', [ var => 'BodyVar' ] );
+};
+
+done_testing();


### PR DESCRIPTION
When merging variables, body parameters overwrite query paraemeters,
but they would both overwrite the route parameters.

This commit makes sure (and adds a test to make sure) that route
parameters will not be overwritten.

This addresses GH #931, except it doesn't allow the query
parameters to overwrite the body.

Seems like Express.js does Query > Body, and Rails does Body > Query
and it's probably - if anything - not RFC compliant to begin with.