### PR TITLE
Fix warning "Odd number of elements in anonymous hash" (loses params)

### DIFF
--- a/lib/Dancer2/Core/Request.pm
+++ b/lib/Dancer2/Core/Request.pm
@@ -342,7 +342,7 @@ sub _decode {
     }
 
     if ( ref($h) eq 'HASH' ) {
-        return { map _decode($_), %$h };
+        return { map _decode($_) // undef, %$h };
     }
 
     if ( ref($h) eq 'ARRAY' ) {


### PR DESCRIPTION
If a route with an optional argument was called without the argument, eg.
```
get "/app/?:arg?"
```
was called as
```
GET /app
```
a warning "Odd number of elements in anonymous hash at .../Dancer2/Core/Request.pm line 345." was produced. This was caused by _decode on undef returned a null and the result is parsed in list context. This trivial change prevents this from occurring.

This also causes the params hash to be mangled. Eg.
```
get "/app/:a/:b/?:b?"
```
Called as
```
GET /app/1/2
```
has a high chance of losing params a and b. So any API implemented using optional params is probably affected.



