### PR TITLE
Add missing semicolon in docs example

### DIFF
--- a/lib/Dancer2/Manual.pod
+++ b/lib/Dancer2/Manual.pod
@@ -463,7 +463,7 @@ be processed, they are passed the tokens hash which they can alter.
     hook before_template_render => sub {
         my $tokens = shift;
         $tokens->{foo} = 'bar';
-    }
+    };
 
 The tokens hash will then be passed to the template with all the
 modifications performed by the hook. This is a good way to setup some


### PR DESCRIPTION
Add a missing semicolon in a documentation hook example.