### PR TITLE
Add error handling for delayed responses

### DIFF
--- a/lib/Dancer2/Core/App.pm
+++ b/lib/Dancer2/Core/App.pm
@@ -889,7 +889,11 @@ sub send_file {
                 [ $res->status, $res->headers_to_array, $fh ]
             );
         };
+
+        Scalar::Util::weaken( my $weak_self = $self );
+
         $response = Dancer2::Core::Response::Delayed->new(
+            error_cb => sub { $weak_self->logger_engine->log(@_) },
             cb       => $cb,
             request  => $Dancer2::Core::Route::REQUEST,
             response => $Dancer2::Core::Route::RESPONSE,

--- a/lib/Dancer2/Core/App.pm
+++ b/lib/Dancer2/Core/App.pm
@@ -893,7 +893,7 @@ sub send_file {
         Scalar::Util::weaken( my $weak_self = $self );
 
         $response = Dancer2::Core::Response::Delayed->new(
-            error_cb => sub { $weak_self->logger_engine->log(@_) },
+            error_cb => sub { $weak_self->logger_engine->log( warning => @_ ) },
             cb       => $cb,
             request  => $Dancer2::Core::Route::REQUEST,
             response => $Dancer2::Core::Route::RESPONSE,

--- a/lib/Dancer2/Core/Response/Delayed.pm
+++ b/lib/Dancer2/Core/Response/Delayed.pm
@@ -23,18 +23,28 @@ has cb => (
     required => 1,
 );
 
+has error_cb => (
+    is        => 'ro',
+    isa       => CodeRef,
+    predicate => '_has_error_cb',
+);
+
 sub is_halted()  {0}
 sub has_passed() {0}
 
 sub to_psgi {
     my $self = shift;
+
     return sub {
         my $responder = shift;
 
-        local $Dancer2::Core::Route::REQUEST   = $self->request;
-        local $Dancer2::Core::Route::RESPONSE  = $self->response;
-        local $Dancer2::Core::Route::RESPONDER = $responder;
+        local $Dancer2::Core::Route::REQUEST       = $self->request;
+        local $Dancer2::Core::Route::RESPONSE      = $self->response;
+        local $Dancer2::Core::Route::RESPONDER     = $responder;
         local $Dancer2::Core::Route::WRITER;
+
+        local $Dancer2::Core::Route::ERROR_HANDLER =
+            $self->_has_error_cb ? $self->error_cb : undef;
 
         $self->cb->();
     };
@@ -52,7 +62,29 @@ __END__
         request   => Dancer2::Core::Request->new(...),
         response  => Dancer2::Core::Response->new(...),
         cb        => sub {...},
+
+        # optional error handling
+        error_cb  => sub {
+            my ($error) = @_;
+            ...
+        },
     );
+
+    # or in an app
+    get '/' => sub {
+        # delayed response:
+        delayed {
+            # streaming content
+            content "data";
+            content "more data";
+
+            # close user connection
+            done;
+        } on_error => sub {
+            my ($error) = @_;
+            warning 'Failed to stream to user: ' . request->remote_address;
+        };
+    };
 
 =head1 DESCRIPTION
 
@@ -81,6 +113,11 @@ when the delayed response has been created.
 =head2 cb
 
 The code that will be run asynchronously.
+
+=head2 error_cb
+
+A callback for handling errors. This callback receives the error as its
+first (and currently only) parameter.
 
 =head1 METHODS
 

--- a/lib/Dancer2/Core/Route.pm
+++ b/lib/Dancer2/Core/Route.pm
@@ -6,7 +6,7 @@ use Dancer2::Core::Types;
 use Carp 'croak';
 use Scalar::Util 'blessed';
 
-our ( $REQUEST, $RESPONSE, $RESPONDER, $WRITER );
+our ( $REQUEST, $RESPONSE, $RESPONDER, $WRITER, $ERROR_HANDLER );
 
 has method => (
     is       => 'ro',

--- a/lib/Dancer2/Manual.pod
+++ b/lib/Dancer2/Manual.pod
@@ -322,7 +322,7 @@ set the content all at once, if you prefer.
         delayed {
             add_header 'X-Foo' => 'Bar';
 
-            # optionally flush headers
+            # flush headers (in case of streaming)
             flush;
 
             # send content to the user
@@ -341,9 +341,8 @@ set the content all at once, if you prefer.
         };
     };
 
-If you do not flush the response status and the headers manually (using the
-C<flush> keyword), they will be flushed as soon as you set the content for
-the first time using the C<content> keyword.
+If you are streaming (calling C<content> several times), you must call
+C<flush> first. If you're sending only once, you don't need to call C<flush>.
 
 Here is an example of using delayed responses with L<AnyEvent>:
 
@@ -355,7 +354,7 @@ Here is an example of using delayed responses with L<AnyEvent>:
     get '/drums' => sub {
         delayed {
             print "Stretching...\n";
-            flush;
+            flush; # necessary, since we're streaming
 
             $timers{'Snare'} = AE::timer 1, 1, delayed {
                 $timers{'HiHat'} ||= AE::timer 0, 0.5, delayed {

--- a/lib/Dancer2/Manual.pod
+++ b/lib/Dancer2/Manual.pod
@@ -379,6 +379,30 @@ Here is an example of using delayed responses with L<AnyEvent>:
         };
     };
 
+If an error happens during a write operation, a warning will be issued
+to the logger.
+
+You can handle the error yourself by providing an C<on_error> handler:
+
+    get '/' => sub {
+        delayed {
+            flush;
+            content "works";
+
+            # ... user disconnected here ...
+
+            content "fails";
+
+            # ... error triggered ...
+
+            done; # doesn't even get run
+        } on_error => sub {
+            # delayed{} not needed, DSL already available
+            my ($error) = @_;
+            # do something with $error
+        };
+    };
+
 =head2 Action Skipping
 
 An action can choose not to serve the current request and ask Dancer2 to


### PR DESCRIPTION
GH #941 mentions callbacks for delayed responses. Currently the
biggest one is error handling. This is what this commit adds.

It does this by introducing another argument to the "delayed"
keyword, "on_error".

    get '/' => sub {
        delayed {

        } on_error => sub {

        };
    };

The "on_error" option receives a sub. Since the "delayed" request
is already done within the context of a delayed response, there's
no need to use "delayed" again in the sub, just providing a regular
callback instead.

The tests don't fully work since the development server, for some
still unbeknownst reason, doesn't actually crash after we close
the socket and write again. In Twiggy it does. You can use this
test script which uses Twiggy:

    use strict;
    use warnings;
    my $caught_error;

    {
        package App::ErrorHandler; ## no critic
        use Dancer2;
        use AnyEvent;
        get '/log' => sub {
            delayed {
                flush;
                content "ping\n";
                done;
                content "failure\n";
            };
        };

        get '/cb' => sub {
            delayed {
                flush;
                content "ping\n";
                done;
                content "failure\n";
            } on_error => sub {
                my $caught_error = shift;
                core "Failed to stream to user: " . request->remote_address;
                1;
            };
        };
    }

    App::ErrorHandler->to_app;

Original tests marked as TODO until they work.