### PR TITLE
Fix/no stack trace on client error

### DIFF
--- a/lib/Dancer2/Core/Error.pm
+++ b/lib/Dancer2/Core/Error.pm
@@ -106,10 +106,12 @@ sub default_error_page {
     my $uri_base = $self->has_app && $self->app->has_request ?
         $self->app->request->uri_base : '';
 
+    # GH#1001 stack trace if show_errors is true and this is a 'server' error (5xx)
+    my $show_fullmsg = $self->show_errors && $self->status =~ /^5/;
     my $opts = {
         title    => $self->title,
         charset  => $self->charset,
-        content  => $self->show_errors ? $self->full_message : $self->message || 'Wooops, something went wrong',
+        content  => $show_fullmsg ? $self->full_message : $self->message || 'Wooops, something went wrong',
         version  => Dancer2->VERSION,
         uri_base => $uri_base,
     };

--- a/lib/Dancer2/Manual.pod
+++ b/lib/Dancer2/Manual.pod
@@ -684,8 +684,9 @@ If such a file exists, it's used to report the error, otherwise, a default
 error page will be rendered on the fly.
 
 Note that in order to provide more informative diagnostics, the default
-error page will override the error-code HTML files when B<show_errors>
-is set to true. For more information see L<Dancer2::Config>.
+error page will override the error-code HTML files for errors with a C<5xx>
+status when B<show_errors> is set to true. For more information see
+L<Dancer2::Config>.
 
 =head2 Execution Errors
 

--- a/share/skel/environments/development.yml
+++ b/share/skel/environments/development.yml
@@ -14,7 +14,7 @@ log: "core"
 # should Dancer2 consider warnings as critical errors?
 warnings: 1
 
-# should Dancer2 show a stacktrace when an error is caught?
+# should Dancer2 show a stacktrace when an 5xx error is caught?
 # if set to yes, public/500.html will be ignored and either
 # views/500.tt, 'error_template' template, or a default error template will be used.
 show_errors: 1

--- a/t/dsl/error_template.t
+++ b/t/dsl/error_template.t
@@ -26,6 +26,7 @@ use HTTP::Request::Common;
     package StandardError;
 
     use Dancer2;
+    set show_errors => 1;
 
     get '/no_template' => sub {
         send_error "oopsie", 404;
@@ -70,6 +71,7 @@ subtest "/no_template" => sub {
     is $res->code, 404, 'send_error sets the status to 404';
     like $res->content, qr{<h1>Error 404 - Not Found</h1>},
       'Error message looks good';
+    unlike $res->content, qr{Stack}, 'Error contains no stack trace';
 };
 
 done_testing;


### PR DESCRIPTION
Only show the "full" error message (stack trace, env, etc.) if `show_errors` is true AND the error status is `5xx`. Resolves #1001.