### PR TITLE
Corrected name of Pod to Dancer2::Manual::Deployment.

### DIFF
--- a/lib/Dancer2/Manual/Deployment.pod
+++ b/lib/Dancer2/Manual/Deployment.pod
@@ -1,4 +1,4 @@
-# PODNAME: Dancer::Deployment
+# PODNAME: Dancer2::Manual::Deployment
 # ABSTRACT: common ways to put your Dancer app into use
 
 __END__


### PR DESCRIPTION
As stated in https://github.com/PerlDancer/Dancer2/issues/1000, this file was incorrectly named Dancer::Deployment. Fixed.