### PR TITLE
Introduce ':nopragmas' import option

### DIFF
--- a/lib/Dancer2.pm
+++ b/lib/Dancer2.pm
@@ -24,12 +24,18 @@ sub import {
     my ( $class,  @args   ) = @_;
     my ( $caller, $script ) = caller;
 
-    $_->import::into($caller) for qw(strict warnings utf8);
-
     my @final_args;
+    my $clean_import;
     foreach my $arg (@args) {
+        # ignore, no longer necessary
+        # in the future these will warn as deprecated
         grep +( $arg eq $_ ), qw<:script :syntax :tests>
             and next;
+
+        if ( $arg eq ':nopragmas' ) {
+            $clean_import++;
+            next;
+        }
 
         if ( substr( $arg, 0, 1 ) eq '!' ) {
             push @final_args, $arg, 1;
@@ -37,6 +43,9 @@ sub import {
             push @final_args, $arg;
         }
     }
+
+    $clean_import
+        or $_->import::into($caller) for qw<strict warnings utf8>;
 
     scalar @final_args % 2
       and die q{parameters must be key/value pairs or '!keyword'};

--- a/lib/Dancer2/Manual.pod
+++ b/lib/Dancer2/Manual.pod
@@ -2151,9 +2151,9 @@ I<not> create an application with the name C<MyApp::Private>.
 =item * B<:nopragmas>
 
 By default L<Dancer2> will import three pragmas: L<strict>, L<warnings>,
-and L<utf8>. If you would like to have full control over the imported
-pragmas, instead of Dancer2 importing them, you can add B<:nopragmas> to
-the importing flags, in which case Dancer2 will not import any pragmas:
+and L<utf8>. If you require control over the imported pragmas, you can add
+B<:nopragmas> to the importing flags, in which case Dancer2 will not import
+any pragmas:
 
     use Dancer2 ':nopragmas';
     # now add pragmas yourself

--- a/lib/Dancer2/Manual.pod
+++ b/lib/Dancer2/Manual.pod
@@ -2148,6 +2148,19 @@ C<appname> tag; e.g.
 The above would add the C<bar> route to the MyApp application. Dancer2 will
 I<not> create an application with the name C<MyApp::Private>.
 
+=item * B<:nopragmas>
+
+By default L<Dancer2> will import three pragmas: L<strict>, L<warnings>,
+and L<utf8>. If you would like to have full control over the imported
+pragmas, instead of Dancer2 importing them, you can add B<:nopragmas> to
+the importing flags, in which case Dancer2 will not import any pragmas:
+
+    use Dancer2 ':nopragmas';
+    # now add pragmas yourself
+    use strict;
+    use warnings;
+    no warnings 'experimental::smartmatch'; # for example
+
 =back
 
 When you C<use Dancer2>, you get an C<import> method added into the current

--- a/lib/Dancer2/Manual.pod
+++ b/lib/Dancer2/Manual.pod
@@ -2155,11 +2155,13 @@ and L<utf8>. If you require control over the imported pragmas, you can add
 B<:nopragmas> to the importing flags, in which case Dancer2 will not import
 any pragmas:
 
-    use Dancer2 ':nopragmas';
-    # now add pragmas yourself
     use strict;
     use warnings;
-    no warnings 'experimental::smartmatch'; # for example
+    no warnings 'experimental::smartmatch'; # for example...
+    use Dancer2 ':nopragmas'; # do not touch the existing pragmas
+
+This way importing C<Dancer2> does not change the existing pragmas setup
+you have.
 
 =back
 

--- a/t/classes/Dancer2/import-pragmas.t
+++ b/t/classes/Dancer2/import-pragmas.t
@@ -1,0 +1,17 @@
+use strict;
+use Test::More tests => 1;
+
+{
+    package App::NoWarnings; ## no critic
+    use Dancer2 ':nopragmas';
+
+    local $@ = undef;
+    my $got_warning;
+
+    local $SIG{'__WARN__'} = sub {
+        $got_warning++;
+    };
+
+    eval 'my $var; my $var;'; ## no critic
+    ::is( $got_warning, undef, 'warnings pragma not activated' );
+}


### PR DESCRIPTION
On a discussion on p5p, the idea of Dancer, Moose, et. al. clobbering
the caller has been raised as an issue. The best way to deal with
this is having the modules provide an ability to not import pragmas
into the caller.

Instead of "no_warnings" configuration options (like in Dancer 1)
or specific import flags for controlling specific pragmas and how
they are imported, we introduce a specific flag for cleaning all
pragmas, and the user controls what to do.

    use Dancer2 ':nopragmas'; # no pragmas, only syntax

This *might* seem similar to 'use Dancer2 ':syntax'" but the concept
of *that* was to prevent the creation of a server. In Dancer2, since
we're using Plack, this is superfluous. Instead, the ':nopragmas'
makes it clear what the distinction is.