### PR TITLE
Change default cookie name from 'dancer.session' to 'dancer2.session'.

### DIFF
--- a/lib/Dancer2/Core/Role/SessionFactory.pm
+++ b/lib/Dancer2/Core/Role/SessionFactory.pm
@@ -42,7 +42,7 @@ has log_cb => (
 has cookie_name => (
     is      => 'ro',
     isa     => Str,
-    default => sub {'dancer.session'},
+    default => sub {'dancer2.session'},
 );
 
 has cookie_domain => (
@@ -261,7 +261,7 @@ configuration. See L<Dancer2::Config/Session-engine>.
 
 The name of the cookie to create for storing the session key
 
-Defaults to C<dancer.session>
+Defaults to C<dancer2.session>
 
 =attr cookie_domain
 

--- a/t/error.t
+++ b/t/error.t
@@ -23,7 +23,7 @@ my $env = {
     SERVER_PROTOCOL   => 'HTTP/1.1',
     REMOTE_ADDR       => '127.0.0.1',
     HTTP_COOKIE =>
-      'dancer.session=1234; fbs_102="access_token=xxxxxxxxxx%7Cffffff"',
+      'dancer2.session=1234; fbs_102="access_token=xxxxxxxxxx%7Cffffff"',
     HTTP_X_FORWARDED_FOR => '127.0.0.2',
     REMOTE_HOST     => 'localhost',
     HTTP_USER_AGENT => 'Mozilla',


### PR DESCRIPTION
I'm not sure this is a bug per se, but since so many other things were
renamed to be Dancer2, the cookie name seemed like an oversight. For the
sake of being consistent, I changed the name.

This discussion prompted the change:
http://paste.perldancer.org/1kccHcbfIsYNX

In this case, there was a Dancer1 and Dancer2 app on the same host using
the default cookie, and inadvertently ended up sharing the same cookies
(not desirable). Racke posted a solid workaround, but this seemed like
something we should also fix.