### PR TITLE
views do NOT use TT2's INCLUDE_PATH directive

### DIFF
--- a/lib/Dancer2/Core/Role/Template.pm
+++ b/lib/Dancer2/Core/Role/Template.pm
@@ -6,7 +6,6 @@ use Dancer2::Core::Types;
 use Dancer2::FileUtils qw'path';
 use Carp 'croak';
 
-use Data::Dumper;
 use Moo::Role;
 with 'Dancer2::Core::Role::Engine';
 

--- a/lib/Dancer2/Template/TemplateToolkit.pm
+++ b/lib/Dancer2/Template/TemplateToolkit.pm
@@ -28,8 +28,6 @@ sub _build_engine {
     $tt_config{'END_TAG'} = $stop_tag
       if defined $stop_tag && $stop_tag ne '%]';
 
-    $tt_config{'INCLUDE_PATH'} ||= $self->views;
-
     return Template->new(%tt_config);
 }
 

--- a/t/template.t
+++ b/t/template.t
@@ -132,4 +132,35 @@ subtest "modify views - absolute paths" => sub {
     );
 };
 
+{
+    package Baz;
+    use Dancer2;
+
+    set template => 'template_toolkit';
+
+    get '/set_views/**' => sub {
+        my ($view) = splat;
+        set views => join('/', @$view );
+    };
+
+    get '/:file' => sub {
+        template param('file');
+    };
+}
+
+subtest "modify views propogates to TT2 via dynamic INCLUDE_PATH" => sub {
+
+    my $test = Plack::Test->create( Baz->to_app );
+
+    my $res = $test->request( GET '/index' );
+    is $res->code, 200, 'got template from views';
+
+    # Change views - this is an existing test corpus..
+    $test->request( GET '/set_views/t/corpus/pretty' );
+
+    # Get another template that is known to exist in the test corpus
+    $res = $test->request( GET '/505' );
+    is $res->code, 200, 'got template from other view';
+};
+
 done_testing;


### PR DESCRIPTION
Previously we were (usually) passing absolute paths for templates (and have ABSOLUTE => 1 set) when rendering output with TemplateToolkit, which worked for most use-cases.

However, as reported in #951 (with further discussion on IRC), if you set a path 'fragment' for a view, such as

```
  set views => 'foobar';
```

The both Dancer2::Template::TemplateToolkit and TT2's code for handling multiple INCLUDE_PATHs were both concatenating the views directory with the template name to be rendered. (i.e. looking for a template like foobar/foobar/index.tt).

Alternate (and simpler) approach to solve #951 (and PR #955) - don't set INCLUDE_PATH and let D2 to the path concatenation.
