### PR TITLE
Forward crashes with serializer JSON

### DIFF
--- a/lib/Dancer2/Core/App.pm
+++ b/lib/Dancer2/Core/App.pm
@@ -1126,6 +1126,7 @@ sub make_forward_to {
     my $env = { %{ $request->env } };
 
     $env->{PATH_INFO} = $url;
+    delete($env->{CONTENT_LENGTH});
 
     my $new_request = Dancer2::Core::Request->new( env => $env, body_params => {} );
     my $new_params = _merge_params( scalar( $request->params ), $params || {} );

--- a/t/request_make_forward_to.t
+++ b/t/request_make_forward_to.t
@@ -1,0 +1,38 @@
+use strict;
+use warnings;
+use Test::More tests=>1;
+use Plack::Test;
+use HTTP::Request::Common;
+use JSON;
+
+{
+
+    package ContentLengthTestApp;
+    use Dancer2;
+    set serializer => 'JSON';
+
+    post '/foo' => sub {
+        forward('/not_authorized');
+    };
+
+    any '/not_authorized' => sub {
+        status 401;
+        { access => 'denied' };
+    };
+}
+
+{
+    my $url  = 'http://localhost';
+    my $test = Plack::Test->create( ContentLengthTestApp->to_app );
+
+    my $response = $test->request(
+        POST(
+            '/foo',
+            Content =>
+                encode_json( { target => [ 'foo', 'bar' ] } ),
+        )
+    );
+
+    is( $response->code, 401, 'Access denied to unauthorized merge' );
+
+}


### PR DESCRIPTION
By cloning the request into a new request in line 1130 of Dancer2::Core::App a pointer to HTTP::Message::PSGI::$input, a function with a filehandle, becomes stale.
Upon second read no data is returned by the function, but the content length indicates not all was read: an error is generated.

    Route exception: Bad Content-Length: maybe client disconnect?

By deleting the CONTENT_LENGTH header on cloning, this is circumvented.