### PR TITLE
Add Digest::SHA to prereqs

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -55,6 +55,7 @@ Moo::Role = 0
 Role::Tiny = 2.000000
 MooX::Types::MooseLike = 0
 Carp = 0
+Digest::SHA = 0
 Exporter = 5.57
 Encode = 0
 File::Basename = 0


### PR DESCRIPTION
Dancer2::Core::Role::SessionFactory depends on Digest::SHA, which was
added to core in perl v5.9.3. Explicitly add it as a dependency for perl
5.8.x support.