### PR TITLE
Small cleanups to the request class

### DIFF
--- a/lib/Dancer2/Core/Request.pm
+++ b/lib/Dancer2/Core/Request.pm
@@ -365,8 +365,6 @@ sub body_parameters {
     $self->{'plack.request.body'}
         and return $self->{'plack.request.body'};
 
-    my $env = $self->env;
-
     # handle case of serializer
     if ( my $data = $self->deserialize ) {
         return Hash::MultiValue->from_mixed(

--- a/lib/Dancer2/Core/Request.pm
+++ b/lib/Dancer2/Core/Request.pm
@@ -77,9 +77,8 @@ sub new {
     $opts{'body_params'}
         and $self->{'_body_params'} = $opts{'body_params'};
 
-    # parsing body for HMV first
+    # parsing body for HMV first (also deserializes body)
     $self->body_parameters;
-    $self->data;      # Deserialize body
     $self->_build_uploads();
 
     return $self;


### PR DESCRIPTION
Two small cleanups:
 * remove an unused var
 * no need to explicitly call `$self->data` within new() as the `body_parameters` method has already done it (one line before).
