### PR TITLE
Allow before_serializer to set content (using the alias in @_)

### DIFF
--- a/lib/Dancer2/Core/Response.pm
+++ b/lib/Dancer2/Core/Response.pm
@@ -107,12 +107,14 @@ has content => (
 around content => sub {
     my ( $orig, $self, $content ) = @_;
 
-    @_ == 2 and return $self->$orig;
+    $self->serializer
+        and $content = $self->serialize($content);
+
+    $content or return $self->$orig;
 
     $self->serializer
         or return $self->$orig( $self->encode_content($content) );
 
-    $content = $self->serialize($content);
     $self->is_encoded(1); # All serializers return byte strings
     return $self->$orig( defined $content ? $content : '' );
 };

--- a/lib/Dancer2/Core/Role/Hookable.pm
+++ b/lib/Dancer2/Core/Role/Hookable.pm
@@ -96,10 +96,11 @@ sub has_hook {
 
 # Execute the hook at the given position
 sub execute_hook {
-    my ( $self, $name, @args ) = @_;
+    my $self = shift;
+    my $name = shift;
 
-    croak "execute_hook needs a hook name"
-      if !defined $name || !length($name);
+    $name and !ref $name
+        or croak "execute_hook needs a hook name";
 
     $name = $self->hook_aliases->{$name}
       if exists $self->hook_aliases->{$name};
@@ -111,7 +112,7 @@ sub execute_hook {
       $self->log( core => "Entering hook $name" );
 
     for my $hook ( @{ $self->hooks->{$name} } ) {
-        $hook->(@args);
+        $hook->(@_);
     }
 }
 

--- a/lib/Dancer2/Core/Role/Serializer.pm
+++ b/lib/Dancer2/Core/Role/Serializer.pm
@@ -37,10 +37,9 @@ has content_type => (
 around serialize => sub {
     my ( $orig, $self, $content, $options ) = @_;
 
-    $content && length $content > 0
-        or return $content;
-
     blessed $self && $self->execute_hook( 'engine.serializer.before', $content );
+
+    $content or return $content;
 
     my $data;
     eval {
@@ -130,4 +129,3 @@ serializer.
 
 The deserialize method receives encoded bytes and must therefore
 handle any decoding required.
-

--- a/t/hooks.t
+++ b/t/hooks.t
@@ -158,7 +158,7 @@ subtest 'Request hooks' => sub {
 
     is( $tests_flags->{before_request},     1,     "before_request was called" );
     is( $tests_flags->{after_request},      1,     "after_request was called" );
-    is( $tests_flags->{before_serializer},  1, "before_serializer was called" );
+    is( $tests_flags->{before_serializer},  3, "before_serializer was called" );
     is( $tests_flags->{after_serializer},   1, "after_serializer was called" );
     is( $tests_flags->{before_file_render}, undef, "before_file_render undef" );
 
@@ -174,11 +174,6 @@ subtest 'Request hooks' => sub {
     );
 
     note 'Serializer hooks';
-    is(
-        $tests_flags->{before_serializer},
-        $tests_flags->{after_serializer},
-        'before_serializer not called because content was empty',
-    );
 
     $test->request( GET '/forward' );
     is(
@@ -189,7 +184,7 @@ subtest 'Request hooks' => sub {
 
     my $res = $test->request( GET '/json' );
     is( $res->content, '["foo",42,"added_in_hook",1]', 'Response serialized' );
-    is( $tests_flags->{before_serializer}, 3, 'before_serializer was called' );
+    is( $tests_flags->{before_serializer}, 10, 'before_serializer was called' );
     is( $tests_flags->{after_serializer},  3, 'after_serializer was called' );
     is( $tests_flags->{before_file_render}, undef, "before_file_render undef" );
 };


### PR DESCRIPTION
To make it even more meaningful, this change also makes sure
before_serializer will always be called when 'serializer' is
set.

The check against the content being empty is done after the
before_serializer hook is called.

I also altered the checks against the content's length.
It's likely that such check will produce warnings in future
Perl versions, as this will check length of stringified refs
when content is a ref (very common).