### PR TITLE
Added DSL keyword request_data.

### DIFF
--- a/lib/Dancer2/Core/DSL.pm
+++ b/lib/Dancer2/Core/DSL.pm
@@ -433,7 +433,10 @@ sub route_parameters { shift; $Dancer2::Core::Route::REQUEST->route_parameters(@
 
 sub request_data {
     my $req = $Dancer2::Core::Route::REQUEST;
-    return ( $req->serializer ? $req->data : $req->body );
+    return $req->data if $req->serializer;
+    $req->_body_params;
+    return $req->{_body_params} if keys %{ $req->{_body_params} };
+    return $req->body;
 }
 
 sub redirect { shift->app->redirect(@_) }

--- a/lib/Dancer2/Core/DSL.pm
+++ b/lib/Dancer2/Core/DSL.pm
@@ -99,6 +99,7 @@ sub dsl_keywords {
         put                  => { is_global => 1 },
         redirect             => { is_global => 0 },
         request              => { is_global => 0 },
+        request_data         => { is_global => 0 },
         request_header       => { is_global => 0 },
         response             => { is_global => 0 },
         response_header      => { is_global => 0 },
@@ -429,6 +430,11 @@ sub param { shift; $Dancer2::Core::Route::REQUEST->param(@_); }
 sub query_parameters { shift; $Dancer2::Core::Route::REQUEST->query_parameters(@_); }
 sub body_parameters  { shift; $Dancer2::Core::Route::REQUEST->body_parameters(@_);  }
 sub route_parameters { shift; $Dancer2::Core::Route::REQUEST->route_parameters(@_); }
+
+sub request_data {
+    my $req = $Dancer2::Core::Route::REQUEST;
+    return ( $req->serializer ? $req->data : $req->body );
+}
 
 sub redirect { shift->app->redirect(@_) }
 

--- a/lib/Dancer2/Core/DSL.pm
+++ b/lib/Dancer2/Core/DSL.pm
@@ -431,13 +431,7 @@ sub query_parameters { shift; $Dancer2::Core::Route::REQUEST->query_parameters(@
 sub body_parameters  { shift; $Dancer2::Core::Route::REQUEST->body_parameters(@_);  }
 sub route_parameters { shift; $Dancer2::Core::Route::REQUEST->route_parameters(@_); }
 
-sub request_data {
-    my $req = $Dancer2::Core::Route::REQUEST;
-    return $req->data if $req->serializer;
-    $req->_body_params;
-    return $req->{_body_params} if keys %{ $req->{_body_params} };
-    return $req->body;
-}
+sub request_data { shift; $Dancer2::Core::Route::REQUEST->body_data(@_); }
 
 sub redirect { shift->app->redirect(@_) }
 

--- a/lib/Dancer2/Core/Request.pm
+++ b/lib/Dancer2/Core/Request.pm
@@ -742,6 +742,15 @@ If you need to access the body of the request, you have to use this accessor and
 should not try to read C<psgi.input> by hand. C<Dancer2::Core::Request>
 already did it for you and kept the raw body untouched in there.
 
+=method body_data
+
+Returns the body of the request in data form, making it possible to distinguish
+between C<body_parameters>, a representation of Web parameters
+(L<Hash::MultiValue>) and other forms of content.
+
+If a serializer is set, this is the deserialized request body. Otherwise this is
+the decoded body parameters (if any), or the body content itself.
+
 =method content
 
 Returns the undecoded byte string POST body.

--- a/lib/Dancer2/Core/Request.pm
+++ b/lib/Dancer2/Core/Request.pm
@@ -745,7 +745,7 @@ already did it for you and kept the raw body untouched in there.
 =method body_data
 
 Returns the body of the request in data form, making it possible to distinguish
-between C<body_parameters>, a representation of Web parameters
+between C<body_parameters>, a representation of the request parameters
 (L<Hash::MultiValue>) and other forms of content.
 
 If a serializer is set, this is the deserialized request body. Otherwise this is

--- a/lib/Dancer2/Core/Request.pm
+++ b/lib/Dancer2/Core/Request.pm
@@ -609,6 +609,14 @@ sub _set_route {
 
 sub route { $_[0]->{'route'} }
 
+sub body_data {
+    my $self = shift;
+    return $self->data if $self->serializer;
+    $self->_body_params;
+    return $self->{_body_params} if keys %{ $self->{_body_params} };
+    return $self->body;
+}
+
 1;
 
 __END__

--- a/lib/Dancer2/Manual.pod
+++ b/lib/Dancer2/Manual.pod
@@ -2714,6 +2714,14 @@ Returns a L<Hash::MultiValue> object from the body parameters.
         my @all_names = body_parameters->get_all('name');
     };
 
+=head2 request_data
+
+Returns the request's body in data form
+(in case a serializer is set, it will be in deserialized).
+
+This allows us to distinguish between C<body_parameters>, a representation
+of Web parameters (L<Hash::MultiValue>) and other forms of content.
+
 =head2 pass
 
 I<This method should be called from a route handler>.

--- a/lib/Dancer2/Manual.pod
+++ b/lib/Dancer2/Manual.pod
@@ -2720,7 +2720,7 @@ Returns the request's body in data form
 (in case a serializer is set, it will be in deserialized).
 
 This allows us to distinguish between C<body_parameters>, a representation
-of Web parameters (L<Hash::MultiValue>) and other forms of content.
+of request parameters (L<Hash::MultiValue>) and other forms of content.
 
 =head2 pass
 

--- a/t/dsl/request_data.t
+++ b/t/dsl/request_data.t
@@ -1,0 +1,51 @@
+use strict;
+use warnings;
+use Test::More;
+use Plack::Test;
+use HTTP::Request::Common;
+
+subtest 'request data basic' => sub {
+    {
+        package App::Body::Str; ## no critic
+        use Dancer2;
+
+        post '/' => sub {
+            my $data = request_data;
+            ::is(
+                $data,
+                'a string body',
+                'string content ok'
+            );
+        };
+    }
+
+    my $app = Plack::Test->create( App::Body::Str->to_app );
+    my $res = $app->request( POST '/', Content_Type => 'text/plain', Content => "a string body" );
+    ok( $res->is_success, 'Successful request' );
+};
+
+subtest 'request data serialized' => sub {
+    {
+        package App::Body::JSON; ## no critic
+        use Dancer2;
+
+        set serializer => 'JSON';
+
+        post '/' => sub {
+            my $data = request_data;
+            ::is_deeply(
+                $data,
+                { body => { is => [ "json" ] } },
+                'json content ok'
+            );
+
+            return +{ ok => 1 };
+        };
+    }
+
+    my $app = Plack::Test->create( App::Body::JSON->to_app );
+    my $res = $app->request( POST '/', Content_Type => 'application/json', Content => '{"body":{"is":["json"]}}' );
+    ok( $res->is_success, 'Successful request' );
+};
+
+done_testing();


### PR DESCRIPTION
`request_data` will return the body of the request in either its
plain (body) form or deserialized (data) form.

This is needed as body_parameters is now a HMV which is suited
to represent parameters and not other forms of data.

Example:
In an app with a JSON serializer, we cannot use body_parameters
to distinguish between a body like '{"data":[]}' and '{}'.
