### PR TITLE
Make sure '$@' can be used as an argument to execute_hook

### DIFF
--- a/lib/Dancer2/Core/Role/Hookable.pm
+++ b/lib/Dancer2/Core/Role/Hookable.pm
@@ -96,8 +96,7 @@ sub has_hook {
 
 # Execute the hook at the given position
 sub execute_hook {
-    my $self = shift;
-    my $name = shift;
+    my ($self, $name, @args) = @_;
 
     $name and !ref $name
         or croak "execute_hook needs a hook name";
@@ -112,7 +111,7 @@ sub execute_hook {
       $self->log( core => "Entering hook $name" );
 
     for my $hook ( @{ $self->hooks->{$name} } ) {
-        $hook->(@_);
+        $hook->(@args);
     }
 }
 


### PR DESCRIPTION
In a plugin I had

````
eval { # something }
if ($@) {
  $dsl->execute_hook('jwt_exception' => $@);
};
`````
and with current version, the hook code receives an empty string. But if I do

````
eval { # something }
if ($@) {
  my $x = $@;
  $dsl->execute_hook('jwt_exception' => $x);
};
`````
it will work. The hook will receive $@ contents.

This patches fixes this. But not sure if it will break the functionality added in this commit -- https://github.com/PerlDancer/Dancer2/commit/8e86ce682f2b4699451a3e8c025f7045f6bbe4da
