### PR TITLE
Bugfix/zero response

### DIFF
--- a/lib/Dancer2/Core/Response.pm
+++ b/lib/Dancer2/Core/Response.pm
@@ -179,9 +179,12 @@ sub to_psgi {
     Plack::Util::status_with_no_entity_body($status)
         and return [ $status, $self->headers_to_array($headers), [] ];
 
+    my $content = $self->content;
     # It is possible to have no content and/or no content type set
-    # e.g. if all routes 'pass'. Apply defaults here..
-    my $content = defined $self->content ? $self->content : '';
+    # e.g. if all routes 'pass'. Set the default value for the content
+    # (an empty string), allowing serializer hooks to be triggered
+    # as they may change the content..
+    $content = $self->content('') if ! defined $content;
 
     if ( !$headers->header('Content-Length')    &&
          !$headers->header('Transfer-Encoding') &&

--- a/lib/Dancer2/Core/Response.pm
+++ b/lib/Dancer2/Core/Response.pm
@@ -105,18 +105,19 @@ has content => (
 );
 
 around content => sub {
-    my ( $orig, $self, $content ) = @_;
+    my ( $orig, $self ) = ( shift, shift );
 
+    # called as getter?
+    @_ or return $self->$orig;
+
+    # No serializer defined; encode content
     $self->serializer
-        and $content = $self->serialize($content);
+        or return $self->$orig( $self->encode_content(@_) );
 
-    $content or return $self->$orig;
-
-    $self->serializer
-        or return $self->$orig( $self->encode_content($content) );
-
+    # serialize content
+    my $serialized = $self->serialize(@_);
     $self->is_encoded(1); # All serializers return byte strings
-    return $self->$orig( defined $content ? $content : '' );
+    return $self->$orig( defined $serialized ? $serialized : '' );
 };
 
 has default_content_type => (

--- a/t/hooks.t
+++ b/t/hooks.t
@@ -36,11 +36,13 @@ my $tests_flags = {};
     get '/' => sub { +{ "ok" => 1 } };
 
     hook 'before_serializer' => sub {
-        my $data = shift;
+        my ($data) = @_;  # don't shift, want to alias..
         if ( ref $data eq 'ARRAY' ) {
             push( @{$data}, ( added_in_hook => 1 ) );
-        } else {
+        } elsif ( ref $data eq 'HASH' ) {
             $data->{'added_in_hook'} = 1;
+        } else {
+            $_[0] = +{ 'added_in_hook' => 1 };
         }
     };
 
@@ -49,6 +51,8 @@ my $tests_flags = {};
     get '/redirect' => sub { redirect '/' };
 
     get '/json' => sub { +[ foo => 42 ] };
+
+    get '/nothing' => sub { return };
 }
 
 {
@@ -184,9 +188,14 @@ subtest 'Request hooks' => sub {
 
     my $res = $test->request( GET '/json' );
     is( $res->content, '["foo",42,"added_in_hook",1]', 'Response serialized' );
-    is( $tests_flags->{before_serializer}, 3, 'before_serializer was called' );
-    is( $tests_flags->{after_serializer},  3, 'after_serializer was called' );
+    is( $tests_flags->{before_serializer}, 4, 'before_serializer was called' );
+    is( $tests_flags->{after_serializer},  4, 'after_serializer was called' );
     is( $tests_flags->{before_file_render}, undef, "before_file_render undef" );
+
+    $res = $test->request( GET '/nothing' );
+    is( $res->content, '{"added_in_hook":1}', 'Before hook modified content' );
+    is( $tests_flags->{before_serializer}, 5, 'before_serializer was called with no content' );
+    is( $tests_flags->{after_serializer},  5, 'after_serializer was called after content changes in hook' );
 };
 
 subtest 'file render hooks' => sub {

--- a/t/hooks.t
+++ b/t/hooks.t
@@ -158,7 +158,7 @@ subtest 'Request hooks' => sub {
 
     is( $tests_flags->{before_request},     1,     "before_request was called" );
     is( $tests_flags->{after_request},      1,     "after_request was called" );
-    is( $tests_flags->{before_serializer},  3, "before_serializer was called" );
+    is( $tests_flags->{before_serializer},  1, "before_serializer was called" );
     is( $tests_flags->{after_serializer},   1, "after_serializer was called" );
     is( $tests_flags->{before_file_render}, undef, "before_file_render undef" );
 
@@ -184,7 +184,7 @@ subtest 'Request hooks' => sub {
 
     my $res = $test->request( GET '/json' );
     is( $res->content, '["foo",42,"added_in_hook",1]', 'Response serialized' );
-    is( $tests_flags->{before_serializer}, 10, 'before_serializer was called' );
+    is( $tests_flags->{before_serializer}, 3, 'before_serializer was called' );
     is( $tests_flags->{after_serializer},  3, 'after_serializer was called' );
     is( $tests_flags->{before_file_render}, undef, "before_file_render undef" );
 };

--- a/t/response.t
+++ b/t/response.t
@@ -57,4 +57,9 @@ $r =
   Dancer2::Core::Response->new( content => "foo", status => "not_modified" );
 is $r->status, 304;
 
+# test setting content as "0"
+$r = Dancer2::Core::Response->new( content => "foo" );
+$r->content("0");
+is $r->content, "0";
+
 done_testing;


### PR DESCRIPTION
The change to allow `before_serializer` hooks in commit 5697359 introduced a side effect for any code "getting" the response content. This reverts the changes to the `around content` modifier made in that commit, resolving #1079 (while keeping @ambs test from #1080).

However this undoes desired functionality from #1053 for a `before_serializer` being able to change the response content in the case when no route returns content for the response. To trigger the serializer hooks in this case, set the response content attribute to the default (an empty string) when constructing the PSGI response (rather than inject the empty string in the PSGI response as done previously).

( I'm keeping @mickeyn to his word for removing that around modifier )