### PR TITLE
Return route objects when defining new ones

### DIFF
--- a/lib/Dancer2/Core/App.pm
+++ b/lib/Dancer2/Core/App.pm
@@ -1019,6 +1019,8 @@ sub add_route {
     my $method = $route->method;
 
     push @{ $self->routes->{$method} }, $route;
+
+    return $route;
 }
 
 sub route_exists {

--- a/lib/Dancer2/Core/DSL.pm
+++ b/lib/Dancer2/Core/DSL.pm
@@ -231,7 +231,7 @@ sub _normalize_route {
     # @_ = ( REGEXP, CODE )
     @args{qw/regexp options code/} = @_ == 3 ? @_ : ( $_[0], {}, $_[1] );
 
-    $app->add_route( %args, method => $_ ) for @{$methods};
+    return map $app->add_route( %args, method => $_ ), @{$methods};
 }
 
 #

--- a/t/dsl/route_retvals.t
+++ b/t/dsl/route_retvals.t
@@ -1,0 +1,15 @@
+use strict;
+use warnings;
+use Dancer2;
+use Test::More ();
+
+my @routes = get '/' => sub {1};
+Test::More::is( scalar @routes, 2, 'Two routes available' );
+foreach my $route (@routes) {
+    Test::More::isa_ok( $route, 'Dancer2::Core::Route' );
+}
+
+Test::More::is( $routes[0]->method, 'get', 'Created GET route' );
+Test::More::is( $routes[1]->method, 'head', 'Created HEAD route too' );
+
+Test::More::done_testing;


### PR DESCRIPTION
This commit adds the ability to receive all the route objects
created with the call to the DSL that creates them.

This is helpful if you want to know which objects you just
created. An example could be a plugin that creates a route (or
receives a route created) and wants to inspect it or alter it.

Future thoughts:

* What if we had hooks for route creation?
* What if routes had unique IDs?