### PR TITLE
Be more accurate in regexp parsing

### DIFF
--- a/lib/Dancer2/Core/Route.pm
+++ b/lib/Dancer2/Core/Route.pm
@@ -96,7 +96,7 @@ sub match {
 
     # regex comments are how we know if we captured a token,
     # splat or a megasplat
-    my @token_or_splat = $self->regexp =~ /\(\?#(token|(?:mega)?splat+)\)/g;
+    my @token_or_splat = $self->regexp =~ /\(\?#(token|(?:mega)?splat)\)/g;
     if (@token_or_splat) {
         # our named tokens
         my @tokens = @{ $self->_params };

--- a/lib/Dancer2/Core/Route.pm
+++ b/lib/Dancer2/Core/Route.pm
@@ -96,7 +96,7 @@ sub match {
 
     # regex comments are how we know if we captured a token,
     # splat or a megasplat
-    my @token_or_splat = $self->regexp =~ /\(\?#([token|(?:mega)?splat]+)\)/g;
+    my @token_or_splat = $self->regexp =~ /\(\?#(token|(?:mega)?splat+)\)/g;
     if (@token_or_splat) {
         # our named tokens
         my @tokens = @{ $self->_params };


### PR DESCRIPTION
The current regexp match in a route was checking for a comment
with single characters that compose the words "token", "splat",
and "megasplat". What we want is to match them *exactly*.

I'm assuming the brackets for character classes ("[]") were an
oversight.

Tests all still pass.