### PR TITLE
Fix/tt2 relative paths

### DIFF
--- a/lib/Dancer2/Core/Error.pm
+++ b/lib/Dancer2/Core/Error.pm
@@ -68,9 +68,9 @@ sub _build_error_template {
 
     # look for a template named after the status number.
     # E.g.: views/404.tt  for a TT template
+    my $engine = $self->app->template_engine;
     return $self->status
-      if -f $self->app->template_engine
-          ->view_pathname( $self->status );
+      if $engine->pathname_exists( $engine->view_pathname( $self->status ) );
 
     return;
 }

--- a/lib/Dancer2/Core/Role/Template.pm
+++ b/lib/Dancer2/Core/Role/Template.pm
@@ -108,6 +108,11 @@ sub layout_pathname {
     );
 }
 
+sub pathname_exists {
+    my ( $self, $pathname ) = @_;
+    return -f $pathname;
+}
+
 sub render_layout {
     my ( $self, $layout, $tokens, $content ) = @_;
 
@@ -307,6 +312,14 @@ Returns the full path to the requested view.
 =method layout_pathname($layout)
 
 Returns the full path to the requested layout.
+
+=method pathname_exists($pathname)
+
+Returns true if the requested pathname exists. Can be used for either views
+or layouts:
+
+    $self->pathname_exists( $self->view_pathname( 'some_view' ) );
+    $self->pathname_exists( $self->layout_pathname( 'some_layout' ) );
 
 =method render_layout($layout, \%tokens, \$content)
 

--- a/lib/Dancer2/Handler/AutoPage.pm
+++ b/lib/Dancer2/Handler/AutoPage.pm
@@ -42,7 +42,7 @@ sub code {
 
         my $view_path = $template->view_pathname($page);
 
-        if ( !-f $view_path ) {
+        if ( ! $template->pathname_exists( $view_path ) ) {
             $app->response->has_passed(1);
             return;
         }

--- a/lib/Dancer2/Template/TemplateToolkit.pm
+++ b/lib/Dancer2/Template/TemplateToolkit.pm
@@ -28,6 +28,8 @@ sub _build_engine {
     $tt_config{'END_TAG'} = $stop_tag
       if defined $stop_tag && $stop_tag ne '%]';
 
+    $tt_config{'INCLUDE_PATH'} ||= $self->views;
+
     return Template->new(%tt_config);
 }
 

--- a/lib/Dancer2/Template/TemplateToolkit.pm
+++ b/lib/Dancer2/Template/TemplateToolkit.pm
@@ -74,6 +74,17 @@ sub layout_pathname {
     );
 }
 
+sub pathname_exists {
+    my ( $self, $pathname ) = @_;
+    my $rc = 0;
+    try {
+        # dies if pathname can not be found via TT2's INCLUDE_PATH search
+        $self->engine->service->context->template( $pathname );
+        $rc = 1;
+    }
+    return $rc;
+}
+
 1;
 
 __END__

--- a/lib/Dancer2/Template/TemplateToolkit.pm
+++ b/lib/Dancer2/Template/TemplateToolkit.pm
@@ -6,6 +6,7 @@ use Moo;
 use Carp qw/croak/;
 use Dancer2::Core::Types;
 use Dancer2::FileUtils qw'path';
+use Scalar::Util qw();
 use Template;
 
 with 'Dancer2::Core::Role::Template';
@@ -29,7 +30,12 @@ sub _build_engine {
     $tt_config{'END_TAG'} = $stop_tag
       if defined $stop_tag && $stop_tag ne '%]';
 
-    $tt_config{'INCLUDE_PATH'} ||= $self->views;
+    Scalar::Util::weaken( my $ttt = $self );
+    my $include_path = $self->config->{include_path};
+    $tt_config{'INCLUDE_PATH'} ||= [
+        ( defined $include_path ? $include_path : () ),
+        sub { [ $ttt->views ] },
+    ];
 
     return Template->new(%tt_config);
 }

--- a/t/corpus/pretty/relative.tt
+++ b/t/corpus/pretty/relative.tt
@@ -1,0 +1,3 @@
+Template [% component.name %]
+
+[% INCLUDE 505.tt %]

--- a/t/template.t
+++ b/t/template.t
@@ -159,7 +159,7 @@ subtest "modify views propogates to TT2 via dynamic INCLUDE_PATH" => sub {
     $test->request( GET '/set_views/t/corpus/pretty' );
 
     # Get another template that is known to exist in the test corpus
-    $res = $test->request( GET '/505' );
+    $res = $test->request( GET '/relative.tt' );
     is $res->code, 200, 'got template from other view';
 };
 

--- a/t/template_ext.t
+++ b/t/template_ext.t
@@ -2,9 +2,6 @@ use strict;
 use warnings;
 use Test::More;
 
-use File::Spec;
-use File::Basename 'dirname';
-
 eval { require Template; Template->import(); 1 }
   or plan skip_all => 'Template::Toolkit probably missing.';
 
@@ -19,17 +16,13 @@ set engines => {
 };
 set template => 'template_toolkit';
 
-my $views =
-  File::Spec->rel2abs( File::Spec->catfile( dirname(__FILE__), 'views' ) );
-
 my $tt = engine('template');
 isa_ok( $tt, 'Dancer2::Template::TemplateToolkit' );
 is( $tt->default_tmpl_ext, 'foo',
     "Template extension is 'foo' as configured",
 );
 
-is( $tt->view_pathname('foo'),
-    File::Spec->catfile( $views, 'foo.foo' ),
+is( $tt->view_pathname('foo'), 'foo.foo' ,
     "view('foo') gives filename with right extension as configured",
 );
 


### PR DESCRIPTION
Fix for the Dancer2::Template::TemplateToolkit to allow both relative `views` and the further processing of relative templates.

Rough summary: let TT2 use its INCLUDE_PATH searching mechanisms to do any path concatenation and tests for template existence. Without this, any 'relative' templates will not be found when using INCLUDE or PROCESS directives.

Reverts the code change from #1037 (but keep the tests from that PR).

Adds the commits from #955 that build a dynamic INCLUDE_PATH generator for the TT2 object. 

An additional configuration option is added (not in #955), allowing an extra `include_path` (note the lower case) to be prepended to the list of paths added to the INCLUDE_PATH of the TT2 object. By adding in an (absolute) path for `include_path` into, say your production environment's config should mitigate some deployment options not behaving when relative views are used (in development).
Note that this isn't documented - but then again, none of the TemplateToolkit config options seem to be documents (or my search foo is lacking tonight). 

Refactor the test for a view or layout `pathname` existing into a new method. The default is still
a simple `-f $pathname` test.  D2::Template::TemplateToolkit overrides this, delegating the test to the current Template::Context. This allows
  * relative paths for views, and further templates to be processed that are relative to that. (resolving #1093)
  * allows the use Template::Provider classes that pull templates from other data sources (like S3 or a database).

This will also resolve #1075.