### PR TITLE
Perl58 fixes - gh1096 & 1097

### DIFF
--- a/lib/Dancer2/Core/Error.pm
+++ b/lib/Dancer2/Core/Error.pm
@@ -164,9 +164,12 @@ has serializer => (
     is        => 'ro',
     isa       => Sub::Quote::quote_sub(q{
         use Safe::Isa;
-        $_[0]
-            ? $_[0]->$_DOES('Dancer2::Core::Role::Serializer')
-            : 1;
+        # Perl5.8 not supported for $_DOES (yet) so use $_can + does
+        if ($_[0]) {
+            $_[0]->$_can('does')
+              && $_[0]->does('Dancer2::Core::Role::Serializer')
+              or die "does not have role Dancer2::Core::Role::Serializer";
+        }
     }),
     builder   => '_build_serializer',
 );

--- a/lib/Dancer2/Core/Response.pm
+++ b/lib/Dancer2/Core/Response.pm
@@ -25,8 +25,8 @@ has headers => (
     isa    => Sub::Quote::quote_sub(q{
         use Safe::Isa;
         $_[0]->$_isa('ARRAY')          ||
-        $_[0]->$_DOES('HTTP::Headers') ||
-        $_[0]->$_DOES('HTTP::Headers::Fast')
+        $_[0]->$_isa('HTTP::Headers') ||
+        $_[0]->$_isa('HTTP::Headers::Fast')
     }),
     lazy   => 1,
     coerce => sub {

--- a/lib/Dancer2/Core/Role/Logger.pm
+++ b/lib/Dancer2/Core/Role/Logger.pm
@@ -58,7 +58,10 @@ my $_levels = {
 has log_level => (
     is  => 'rw',
     isa => sub {
-        grep {/$_[0]/} keys %{$_levels};
+        grep {/$_[0]/} keys %{$_levels}
+          or die "log_level must be one of: ",
+          join(", ",
+            sort { $_levels->{$a} <=> $_levels->{$b} } keys %$_levels);
     },
     default => sub {'debug'},
 );

--- a/t/issues/gh-1098.t
+++ b/t/issues/gh-1098.t
@@ -1,0 +1,23 @@
+use Test::More tests => 5;
+use Test::Fatal;
+
+use Dancer2::Core::Error;
+use Dancer2::Core::Response;
+use Dancer2::Serializer::JSON;
+use JSON;
+
+is exception { Dancer2::Core::Error->new }, undef, "Error->new lived";
+
+like exception { Dancer2::Core::Error->new(show_errors => []) },
+  qr/not.+boolean/i, "Error->new(show_errors => []) died";
+
+is exception {
+    Dancer2::Core::Error->new(serializer => undef)
+}, undef, "Error->new(serializer => undef) lived";
+
+is exception {
+    Dancer2::Core::Error->new(serializer => Dancer2::Serializer::JSON->new)
+}, undef, "Error->new(serializer => Dancer2::Serializer::JSON->new) lived";
+
+like exception { Dancer2::Core::Error->new(serializer => JSON->new) },
+  qr/does not have role/, "Error->new(serializer => JSON->new) died";

--- a/t/issues/gh-1098.t
+++ b/t/issues/gh-1098.t
@@ -1,23 +1,65 @@
-use Test::More tests => 5;
+use Test::More tests => 2;
 use Test::Fatal;
 
 use Dancer2::Core::Error;
 use Dancer2::Core::Response;
 use Dancer2::Serializer::JSON;
+use HTTP::Headers::Fast;
 use JSON;
 
-is exception { Dancer2::Core::Error->new }, undef, "Error->new lived";
+subtest 'Core::Error serializer isa tests' => sub {
+    plan tests => 5;
 
-like exception { Dancer2::Core::Error->new(show_errors => []) },
-  qr/not.+boolean/i, "Error->new(show_errors => []) died";
+    is exception { Dancer2::Core::Error->new }, undef, "Error->new lived";
 
-is exception {
-    Dancer2::Core::Error->new(serializer => undef)
-}, undef, "Error->new(serializer => undef) lived";
+    like exception { Dancer2::Core::Error->new(show_errors => []) },
+    qr/not.+boolean/i, "Error->new(show_errors => []) died";
 
-is exception {
-    Dancer2::Core::Error->new(serializer => Dancer2::Serializer::JSON->new)
-}, undef, "Error->new(serializer => Dancer2::Serializer::JSON->new) lived";
+    is exception {
+        Dancer2::Core::Error->new(serializer => undef)
+    },
+    undef,
+    "Error->new(serializer => undef) lived";
 
-like exception { Dancer2::Core::Error->new(serializer => JSON->new) },
-  qr/does not have role/, "Error->new(serializer => JSON->new) died";
+    is exception {
+        Dancer2::Core::Error->new(serializer => Dancer2::Serializer::JSON->new)
+    },
+    undef,
+    "Error->new(serializer => Dancer2::Serializer::JSON->new) lived";
+
+    like exception { Dancer2::Core::Error->new(serializer => JSON->new) },
+    qr/does not have role/,
+    "Error->new(serializer => JSON->new) died";
+};
+
+subtest 'Core::Response headers isa tests' => sub {
+    plan tests => 5;
+
+    is exception { Dancer2::Core::Response->new },
+    undef, "Response->new lived";
+
+    is exception {
+        Dancer2::Core::Response->new(headers => [Header => 'Content'])
+    },
+    undef,
+    "Response->new( headers => [ Header => 'Content' ] ) lived";
+
+    is exception {
+        Dancer2::Core::Response->new(headers => HTTP::Headers->new)
+    },
+    undef,
+    "Response->new( headers => HTTP::Headers->new ) lived";
+
+    is exception {
+        Dancer2::Core::Response->new(headers => HTTP::Headers::Fast->new)
+    },
+    undef,
+    "Response->new( headers => HTTP::Headers::Fast->new ) lived";
+
+    like exception {
+        Dancer2::Core::Response->new(headers => JSON->new)
+    },
+    qr/coercion.+failed.+not.+array/i,
+    "Response->new( headers => JSON->new ) died";
+};
+

--- a/t/issues/gh-1098.t
+++ b/t/issues/gh-1098.t
@@ -1,4 +1,4 @@
-use Test::More tests => 2;
+use Test::More tests => 3;
 use Test::Fatal;
 
 use Dancer2::Core::Error;
@@ -63,3 +63,25 @@ subtest 'Core::Response headers isa tests' => sub {
     "Response->new( headers => JSON->new ) died";
 };
 
+subtest 'Core::Role::Logger log_level isa tests' => sub {
+    plan tests => 1 + 6 + 1;
+
+    {
+        package TestLogger;
+        use Moo;
+        with 'Dancer2::Core::Role::Logger';
+        sub log { }
+    }
+
+    is exception { TestLogger->new }, undef, "Logger->new lived";
+
+    my @levels = qw/core debug info warn warning error/;
+    foreach my $level (@levels) {
+        is exception { TestLogger->new(log_level => $level) }, undef,
+          "Logger->new(log_level => $level) lives";
+    }
+
+    like exception { TestLogger->new(log_level => 'BadLevel') },
+      qr/isa.+failed.+must be one of: core/,
+      "Logger->new(log_level => 'BadLevel') died";
+};


### PR DESCRIPTION
Perl v5.8 fixes and isa fixes

- skip named capture tests on Perl <v5.10
- stop using Safe::Isa's $_DOES
- some isa checks did not die on failure