### PR TITLE
Check `no_server_tokens` in config file, fixes GH #1046:

### DIFF
--- a/lib/Dancer2/Core/App.pm
+++ b/lib/Dancer2/Core/App.pm
@@ -348,6 +348,7 @@ around _build_config => sub {
 sub _build_response {
     my $self = shift;
     return Dancer2::Core::Response->new(
+        server_tokens => !$self->config->{'no_server_tokens'},
         $self->has_serializer_engine
             ? ( serializer => $self->serializer_engine )
             : (),

--- a/lib/Dancer2/Core/Response.pm
+++ b/lib/Dancer2/Core/Response.pm
@@ -104,6 +104,12 @@ has content => (
     clearer   => 'clear_content',
 );
 
+has server_tokens => (
+    is      => 'ro',
+    isa     => Bool,
+    default => sub {1},
+);
+
 around content => sub {
     my ( $orig, $self ) = ( shift, shift );
 
@@ -170,8 +176,8 @@ sub new_from_array {
 sub to_psgi {
     my ($self) = @_;
 
-    Dancer2::runner()->config->{'no_server_tokens'}
-        or $self->header( 'Server' => "Perl Dancer2 " . Dancer2->VERSION );
+    $self->server_tokens
+        and $self->header( 'Server' => "Perl Dancer2 " . Dancer2->VERSION );
 
     my $headers = $self->headers;
     my $status  = $self->status;

--- a/t/issues/gh-1046/config.yml
+++ b/t/issues/gh-1046/config.yml
@@ -1,0 +1,1 @@
+no_server_tokens: 1

--- a/t/issues/gh-1046/gh-1046.t
+++ b/t/issues/gh-1046/gh-1046.t
@@ -1,0 +1,23 @@
+use strict;
+use warnings;
+use Test::More;
+use Plack::Test;
+use HTTP::Request::Common;
+
+{
+    ## no critic
+    package App;
+    use Dancer2;
+    get '/' => sub {1};
+}
+
+my $test = Plack::Test->create( App->to_app );
+my $res  = $test->request( GET '/' );
+
+is(
+    $res->headers->header('Server'),
+    undef,
+    'Server header not available',
+);
+
+done_testing;


### PR DESCRIPTION
GH #1046 raises the issue that the `no_server_tokens` configuration option was not picked up by the application and it would still add the tokens header.

This was caused by checking the Runner for the option (which it does try to set), but ignoring the configuration which is loaded by the config.

Now we're sending the new response object a boolean representing whether to add this special additional header. I don't like it very much for several reasons, but it seems the optimal solution. Said reasons:

1. What if you're using something else to construct the headers? You might not get this one.

2. Since there is no clear way to simply automatically add headers that aren't determined from the response object, we have to create a special attribute for only one specific case, which kind of sucks and is not really scalable.

However, this really is a special case because it's the one extra header we have that has nothing to do with a response, but is determined by the outside world (in this case a configuration option).

Further thoughts:

We used to have Config class (which D1 still has) but it caused more problems since it was a global and applications aren't global and can have different configurations. I'm not sure there's anything to be done to make the configuration more decoupled and cleaner.

The Runner has some defaults without reading the configuration file and the App then reads the configuration file and merges it with the configuration from the Runner as the `settings` method.

1. This means that we keep reading the configuration when someone accesses the `settings` method, which might be correct because then the config can change.

2. The ConfigReader role provides a `settings` attribute which we override. The DSL updates the `config` attribute. This is all pretty weird. That means they can be out of sync and while some components get one, the others might get the other.

Not really sure what to do about this, but not urgent, so meh.