### PR TITLE
FileUtils::normalize_path should handle more than 2 concurrent '..'

### DIFF
--- a/lib/Dancer2/FileUtils.pm
+++ b/lib/Dancer2/FileUtils.pm
@@ -79,8 +79,7 @@ sub normalize_path {
     }x;
 
     $path =~ s{/\./}{/}g;
-    $path =~ s{$seqregex}{}g;
-    $path =~ s{$seqregex}{};
+    while ( $path =~ s{$seqregex}{} ) {}
 
     #see https://rt.cpan.org/Public/Bug/Display.html?id=80077
     $path =~ s{^//}{/};

--- a/lib/Dancer2/FileUtils.pm
+++ b/lib/Dancer2/FileUtils.pm
@@ -7,7 +7,6 @@ use warnings;
 use File::Basename ();
 use File::Spec;
 use Carp;
-use Cwd 'realpath';
 
 use Exporter 'import';
 our @EXPORT_OK = qw(

--- a/t/file_utils.t
+++ b/t/file_utils.t
@@ -2,7 +2,7 @@ use strict;
 use warnings;
 use utf8;
 
-use Test::More tests => 20;
+use Test::More tests => 25;
 use Test::Fatal;
 use File::Spec;
 BEGIN { @File::Spec::ISA = ("File::Spec::Unix") }
@@ -39,6 +39,11 @@ my $paths = [
    [ '/foo/./bar/'  => '/foo/bar/' ],
    [ '/foo/../bar' => '/bar' ],
    [ '/foo/bar/..'  => '/foo/' ],
+   [ '/a/b/c/d/A/B/C' => '/a/b/c/d/A/B/C' ],
+   [ '/a/b/c/d/../A/B/C' => '/a/b/c/A/B/C' ],
+   [ '/a/b/c/d/../../A/B/C' => '/a/b/A/B/C' ],
+   [ '/a/b/c/d/../../../A/B/C' => '/a/A/B/C' ],
+   [ '/a/b/c/d/../../../../A/B/C' => '/A/B/C' ], 
 ];
 
 for my $case ( @$paths ) {


### PR DESCRIPTION
This is a fix taken from Dancer1:

https://github.com/PerlDancer/Dancer/commit/399bd509c9875423d70ea668095bf2a3bef02ee2

Closes #1102

Also remove `use Cwd` since we don't make use of it anywhere.