### PR TITLE
Correct Try Block & Template Issues

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -88,6 +88,8 @@ Import::Into = 0
 Safe::Isa = 0
 Hash::Merge::Simple = 0
 App::Cmd::Setup = 0
+; Used in Dancer::Template::TemplateToolkit
+Try::Tiny = 0
 
 [Prereqs / Recommends]
 ; Serializers

--- a/lib/Dancer2/Handler/AutoPage.pm
+++ b/lib/Dancer2/Handler/AutoPage.pm
@@ -42,6 +42,10 @@ sub code {
 
         my $view_path = $template->view_pathname($page);
 
+        # Remove preceeding slash so that Template::TemplateToolkit
+        # works correctly.
+        s|^/|| for $view_path, $page;
+
         if ( ! $template->pathname_exists( $view_path ) ) {
             $app->response->has_passed(1);
             return;

--- a/lib/Dancer2/Template/TemplateToolkit.pm
+++ b/lib/Dancer2/Template/TemplateToolkit.pm
@@ -8,6 +8,7 @@ use Dancer2::Core::Types;
 use Dancer2::FileUtils qw'path';
 use Scalar::Util qw();
 use Template;
+use Try::Tiny;
 
 with 'Dancer2::Core::Role::Template';
 
@@ -81,7 +82,7 @@ sub pathname_exists {
         # dies if pathname can not be found via TT2's INCLUDE_PATH search
         $self->engine->service->context->template( $pathname );
         $rc = 1;
-    }
+    };
     return $rc;
 }
 


### PR DESCRIPTION
We've found routes through auto_page to throw 500 errors.

We tracked these issues down first to the `try {}` block in `Dancer2::Template::TemplateToolkit` missing its semicolon and `use Try::Tiny`.

After correcting this we found the paths from `Dancer2::Handler::AutoPage` need their preceding `/` removed to succeed for the template calls to function.  It is entirely possible a better solution needs to be found for 'Make AutoPage work w/ ::Template::TemplateToolkit' that works for all the templating engines. 