### PR TITLE
Bugfix/autopage template toolkit

### DIFF
--- a/lib/Dancer2.pm
+++ b/lib/Dancer2.pm
@@ -286,6 +286,7 @@ things:
     Jonathan Scott Duff
     Julien Fiegehenn
     Julio Fraire
+    Kaitlyn Parkhurst (SYMKAT)
     kbeyazli
     Keith Broughton
     lbeesley

--- a/lib/Dancer2/Handler/AutoPage.pm
+++ b/lib/Dancer2/Handler/AutoPage.pm
@@ -40,6 +40,8 @@ sub code {
             return;
         }
 
+        # remove leading '/', ensuring paths relative to the view
+        $page =~ s{^/}{};
         my $view_path = $template->view_pathname($page);
 
         if ( ! $template->pathname_exists( $view_path ) ) {

--- a/lib/Dancer2/Template/TemplateToolkit.pm
+++ b/lib/Dancer2/Template/TemplateToolkit.pm
@@ -76,13 +76,11 @@ sub layout_pathname {
 
 sub pathname_exists {
     my ( $self, $pathname ) = @_;
-    my $rc = 0;
-    try {
+    eval {
         # dies if pathname can not be found via TT2's INCLUDE_PATH search
         $self->engine->service->context->template( $pathname );
-        $rc = 1;
-    }
-    return $rc;
+    };
+    return $@ ? 0 : 1;
 }
 
 1;

--- a/lib/Dancer2/Template/TemplateToolkit.pm
+++ b/lib/Dancer2/Template/TemplateToolkit.pm
@@ -76,11 +76,13 @@ sub layout_pathname {
 
 sub pathname_exists {
     my ( $self, $pathname ) = @_;
-    eval {
+    local $@;
+    my $rc = eval {
         # dies if pathname can not be found via TT2's INCLUDE_PATH search
         $self->engine->service->context->template( $pathname );
+        1;
     };
-    return $@ ? 0 : 1;
+    return $rc;
 }
 
 1;

--- a/t/auto_page.t
+++ b/t/auto_page.t
@@ -10,18 +10,25 @@ use HTTP::Request::Common;
     use Dancer2;
 
     set auto_page => 1;
-    engine('template')->views('t/views');
-    engine('template')->layout('main');
+    set views     => 't/views';
+    set layout    => 'main';
 }
 
-my $app = AutoPageTest->to_app;
-is( ref $app, 'CODE', 'Got app' );
 
-test_psgi $app, sub {
-    my $cb = shift;
+my @engines = ('tiny');
+eval {require Template; Template->import(); push @engines, 'template_toolkit';};
+
+for my $tt_engine ( @engines ) {
+    # Change template engine and run tests
+    AutoPageTest::set( template => $tt_engine );
+    subtest "autopage with template $tt_engine" => \&run_tests;
+}
+
+sub run_tests {
+    my $test = Plack::Test->create( AutoPageTest->to_app );
 
     {
-        my $r = $cb->( GET '/auto_page' );
+        my $r = $test->request( GET '/auto_page' );
 
         is( $r->code, 200, 'Autopage found the page' );
         like(
@@ -32,7 +39,7 @@ test_psgi $app, sub {
     }
 
     {
-        my $r = $cb->( GET '/folder/page' );
+        my $r = $test->request( GET '/folder/page' );
 
         is( $r->code, 200, 'Autopage found the page under a folder' );
         like(
@@ -43,17 +50,17 @@ test_psgi $app, sub {
     }
 
     {
-        my $r = $cb->( GET '/non_existent_page' );
+        my $r = $test->request( GET '/non_existent_page' );
         is( $r->code, 404, 'Autopage doesnt try to render nonexistent pages' );
     }
 
     {
-        my $r = $cb->( GET '/layouts/main');
+        my $r = $test->request( GET '/layouts/main');
         is( $r->code, 404, 'Layouts are not served' );
     }
 
     {
-        my $r = $cb->( GET '/file.txt' );
+        my $r = $test->request( GET '/file.txt' );
         is( $r->code, 200, 'found file on public with autopage' );
         is(
             $r->content,
@@ -67,7 +74,6 @@ test_psgi $app, sub {
             'public served file as correct mime',
         );
     }
-
-};
+}
 
 done_testing;


### PR DESCRIPTION
Bugfixs for autopage when using the template_toolkit template engine.

  * Ensure pathname formed from joining of `views` to `request->path` do not have a double slash as a result of that join (See #1106)
  * Remove the use of `try`, replacing it with a simpler `eval`.
  * Better tests for autopage (will test the tiny and template_toolkit engine if available)

This is an alternative to #1105. @symkat++ for that Pr - it made isolating the problem much easier! :dancer:
