### PR TITLE
Remove logical tests of $@ as eval failures

### DIFF
--- a/lib/Dancer2/Core/Error.pm
+++ b/lib/Dancer2/Core/Error.pm
@@ -256,8 +256,10 @@ sub _build_content {
         # This may well be what caused the initial error, in which
         # case we fall back to static page if any error was thrown.
         # Note: this calls before/after render hooks.
-        my $content = eval {
-            $self->app->template(
+        local $@;
+        my $content;
+        eval {
+            $content = $self->app->template(
                 $self->template,
                 {   title     => $self->title,
                     content   => $self->message,
@@ -265,8 +267,8 @@ sub _build_content {
                     status    => $self->status,
                 }
             );
-        };
-        $@ && $self->app->engine('logger')->log( warning => $@ );
+            1;
+        } or $self->app->engine('logger')->log( warning => $@ );
 
         # return rendered content unless there was an error.
         return $content if defined $content;
@@ -278,8 +280,10 @@ sub _build_content {
     }
 
     if ($self->has_app && $self->app->config->{error_template}) {
-        my $content = eval {
-            $self->app->template(
+        local $@;
+        my $content;
+        eval {
+            $content = $self->app->template(
                 $self->app->config->{error_template},
                 {   title     => $self->title,
                     content   => $self->message,
@@ -287,8 +291,8 @@ sub _build_content {
                     status    => $self->status,
                 }
             );
-        };
-        $@ && $self->app->engine('logger')->log( warning => $@ );
+            1;
+        } or $self->app->engine('logger')->log( warning => $@ );
 
         # return rendered content unless there was an error.
         return $content if defined $content;
@@ -343,7 +347,9 @@ sub backtrace {
     return $message unless ( $file and $line );
 
     # file and line are located, let's read the source Luke!
-    my $fh = eval { open_file( '<', $file ) } or return $message;
+    local $@;
+    my $fh;
+    eval { $fh = open_file( '<', $file ); 1 } or return $message;
     my @lines = <$fh>;
     close $fh;
 

--- a/lib/Dancer2/Core/Hook.pm
+++ b/lib/Dancer2/Core/Hook.pm
@@ -29,9 +29,10 @@ has code => (
     coerce   => sub {
         my ($hook) = @_;
         sub {
+            local $@;
             my $res;
-            eval { $res = $hook->(@_) };
-            croak "Hook error: $@" if $@;
+            eval { $res = $hook->(@_); 1 }
+              or croak "Hook error: $@";
             return $res;
         };
     },

--- a/lib/Dancer2/Core/Role/ConfigReader.pm
+++ b/lib/Dancer2/Core/Role/ConfigReader.pm
@@ -201,13 +201,15 @@ sub load_config_file {
     my ( $self, $file ) = @_;
     my $config;
 
-    eval {
+    local $@;
+    my $fail = not eval {
         my @files = ($file);
         my $tmpconfig =
           Config::Any->load_files( { files => \@files, use_ext => 1 } )->[0];
         ( $file, $config ) = %{$tmpconfig} if defined $tmpconfig;
+        1;
     };
-    if ( my $err = $@ || ( !$config ) ) {
+    if ( $fail || ! $config ) {
         croak "Unable to parse the configuration file: $file: $@";
     }
 

--- a/lib/Dancer2/Core/Role/SessionFactory.pm
+++ b/lib/Dancer2/Core/Role/SessionFactory.pm
@@ -94,9 +94,9 @@ sub create {
     $self->execute_hook( 'engine.session.before_create', $session );
 
     # XXX why do we _flush now?  Seems unnecessary -- xdg, 2013-03-03
-    eval { $self->_flush( $session->id, $session->data ) };
-    croak "Unable to create a new session: $@"
-      if $@;
+    local $@;
+    eval { $self->_flush( $session->id, $session->data ); 1 }
+      or croak "Unable to create a new session: $@";
 
     $self->execute_hook( 'engine.session.after_create', $session );
     return $session;
@@ -153,9 +153,10 @@ sub retrieve {
 
     $self->execute_hook( 'engine.session.before_retrieve', $id );
 
-    my $data = eval { $self->_retrieve($id) };
-    croak "Unable to retrieve session with id '$id'"
-      if $@;
+    local $@;
+    my $data;
+    eval { $data = $self->_retrieve($id); 1 }
+      or croak "Unable to retrieve session with id '$id'";
 
     my %args = ( id => $id, );
 
@@ -178,9 +179,9 @@ sub destroy {
     my $id = $params{id};
     $self->execute_hook( 'engine.session.before_destroy', $id );
 
-    eval { $self->_destroy($id) };
-    croak "Unable to destroy session with id '$id': $@"
-      if $@;
+    local $@;
+    eval { $self->_destroy($id); 1 }
+     or croak "Unable to destroy session with id '$id': $@";
 
     $self->execute_hook( 'engine.session.after_destroy', $id );
     return $id;
@@ -193,9 +194,9 @@ sub flush {
     my $session = $params{session};
     $self->execute_hook( 'engine.session.before_flush', $session );
 
-    eval { $self->_flush( $session->id, $session->data ) };
-    croak "Unable to flush session: $@"
-      if $@;
+    local $@;
+    eval { $self->_flush( $session->id, $session->data ); 1 }
+      or croak "Unable to flush session: $@";
 
     $self->execute_hook( 'engine.session.after_flush', $session );
     return $session->id;

--- a/lib/Dancer2/Manual.pod
+++ b/lib/Dancer2/Manual.pod
@@ -1104,9 +1104,10 @@ the cookie (the session ID).
 
          # if we have a session cookie, try to retrieve the session
          if (defined $session_id) {
-             eval { $session = $engine->retrieve(id => $session_id) };
-             croak "Fail to retrieve session: $@"
-               if $@ && $@ !~ /Unable to retrieve session/;
+             local $@;
+             eval { $session = $engine->retrieve(id => $session_id); 1 };
+               or croak "Fail to retrieve session: $@"
+                 if $@ !~ /Unable to retrieve session/;
          }
 
          # create the session if none retrieved

--- a/lib/Dancer2/Template/Simple.pm
+++ b/lib/Dancer2/Template/Simple.pm
@@ -118,8 +118,8 @@ sub _find_value_from_token_name {
         }
         elsif ( ref($value) ) {
             local $@;
-            eval { $value = $value->$e };
-            $value = "" if $@;
+            eval { $value = $value->$e; 1 }
+              or $value = "";
         }
     }
     return $value;
@@ -129,8 +129,8 @@ sub _interpolate_value {
     my ($value) = @_;
     if ( ref($value) eq 'CODE' ) {
         local $@;
-        eval { $value = $value->() };
-        $value = "" if $@;
+        eval { $value = $value->(); 1 }
+          or $value = "";
     }
     elsif ( ref($value) eq 'ARRAY' ) {
         $value = "@{$value}";


### PR DESCRIPTION
Using a logical test of $@ after an `eval` is considered an antipattern.
Many of the uses of `eval` in the core had been reworked to no longer do
that, this commit cleans up the rest.

Also localizes $@ before every `eval`, ensuring we don't replace a previous
error message.