### PR TITLE
Convert named parameters to named captures in routes

### DIFF
--- a/lib/Dancer2/Core/Route.pm
+++ b/lib/Dancer2/Core/Route.pm
@@ -213,7 +213,7 @@ sub _build_regexp_from_string {
                 and warn q{Named placeholder 'captures' is deprecated};
 
             # Convert :name expressions to (?<name>[^/]+) named captures
-            $string =~ s!(:[^\/\.\?]+)!(?<$1>[^/]+)!g;
+            $string =~ s!:([^\/\.\?]+)!(?<$1>[^/]+)!g;
             $capture = 1;
         }
     }

--- a/lib/Dancer2/Core/Route.pm
+++ b/lib/Dancer2/Core/Route.pm
@@ -213,8 +213,6 @@ sub _build_regexp_from_string {
                 and warn q{Named placeholder 'captures' is deprecated};
 
             # Convert :name expressions to (?<name>[^/]+) named captures
-            # Convert :name(regexp) expressions to (?<name>regexp) named captures
-            $string =~ s!(:[^\/\.\?\(]+)\((.*?)\)!(?<\1>\2)!g; # This only allows simple regexp that don't contain ')'
             $string =~ s!(:[^\/\.\?]+)!(?<\1>[^/]+)!g;
             $capture = 1;
         }

--- a/lib/Dancer2/Core/Route.pm
+++ b/lib/Dancer2/Core/Route.pm
@@ -76,7 +76,6 @@ has _params => (
 
 sub match {
     my ( $self, $request ) = @_;
-    my %params;
 
     if ( $self->has_options ) {
         return unless $self->validate_options($request);
@@ -84,17 +83,11 @@ sub match {
 
     my @values = $request->dispatch_path =~ $self->regexp;
 
+    return unless @values;
+
     # if some named captures are found, return captures
     # no warnings is for perl < 5.10
-    if (my %captures =
-        do { no warnings; %+ }
-      )
-    {
-        %params = %captures;
-        return $self->_match_data( { %params, (captures => \%captures) } ) unless @values;
-    }
-
-    return unless @values;
+    my %captures = do { no warnings; %+ };
 
     # regex comments are how we know if we captured a token,
     # splat or a megasplat
@@ -109,9 +102,9 @@ sub match {
             push @splat, $values[$i];
         }
         return $self->_match_data( {
-            %params
-            ,(captures => \%params)
-            ,(splat => \@splat)x!! @splat,
+            %captures,
+            (splat => \@splat)x!! @splat,
+            (captures => \%captures)x!! %captures
         });
     }
 

--- a/lib/Dancer2/Core/Route.pm
+++ b/lib/Dancer2/Core/Route.pm
@@ -213,7 +213,7 @@ sub _build_regexp_from_string {
                 and warn q{Named placeholder 'captures' is deprecated};
 
             # Convert :name expressions to (?<name>[^/]+) named captures
-            $string =~ s!(:[^\/\.\?]+)!(?<\1>[^/]+)!g;
+            $string =~ s!(:[^\/\.\?]+)!(?<$1>[^/]+)!g;
             $capture = 1;
         }
     }


### PR DESCRIPTION
replaces :name parameters in routes to (?\<name>[^/]+) named captures.

Also allows :name(regex) parameters, converting them to (?\<name>regex) named captures.

All named captures are returned as params.
For backwards compatability, all named captures are also returned as captures. But captures now becomes deprecated.

Caveats:

* :name(regex) only allows limited regex that don't contain ')'
* this PR is completely untested and would require close scrutiny before merging.
* this is really intended as a point of discussion more than an actual patch.