### PR TITLE
Call engine.logger.* hooks around logging a message

### DIFF
--- a/lib/Dancer2/Core/Role/Logger.pm
+++ b/lib/Dancer2/Core/Role/Logger.pm
@@ -161,6 +161,14 @@ sub _serialize {
     ), @vars;
 }
 
+around 'log' => sub {
+    my ($orig, $self, @args) = @_;
+
+    $self->execute_hook( 'engine.logger.before', $self, @args );
+    $self->$orig( @args );
+    $self->execute_hook( 'engine.logger.after', $self, @args );
+};
+
 sub core {
     my ( $self, @args ) = @_;
     $self->_should('core') and $self->log( 'core', _serialize(@args) );

--- a/t/logger.t
+++ b/t/logger.t
@@ -63,6 +63,27 @@ subtest 'log level and capture' => sub {
     is_deeply $trap->read, [];
 };
 
+subtest 'logger enging hooks' => sub {
+    # before hook can change log level or message.
+    hook 'engine.logger.before' => sub {
+        my $logger = shift; # @_ = ( $level, @message_args )
+        $_[0] = 'panic';    # eg. log all messages at the 'panic' level
+    };
+
+    my $str = "Thou shalt not pass";
+    warning $str;
+    my $trap = dancer_app->engine('logger')->trapper;
+    my $msg  = $trap->read;
+    delete $msg->[0]{'formatted'};
+    is_deeply $msg,
+      [
+        {
+            level => "panic",
+            message => $str,
+        },
+    ];
+};
+
 subtest 'logger file' => sub {
     use Dancer2;
     use File::Temp qw/tempdir/;


### PR DESCRIPTION
The hook names were defined, but they were never called. 

Call them in an around modifier on the log method (similar to where session engine hooks are called). Either being lazy or wise; these hooks are passed the logging engine object, and all params to the log method.

Tests include an example of changing the log level before the message is passed to the logger.