### PR TITLE
Fix finding DSL when loading plugin module

### DIFF
--- a/lib/Dancer2/Plugin.pm
+++ b/lib/Dancer2/Plugin.pm
@@ -19,7 +19,6 @@ my $_on_import = {};
 
 sub register {
     my $plugin = caller;
-    my $caller = caller(1);
     my ( $keyword, $code, $options ) = @_;
     $options ||= { is_global => 1 };
 

--- a/lib/Dancer2/Plugin.pm
+++ b/lib/Dancer2/Plugin.pm
@@ -55,11 +55,9 @@ sub on_plugin_import(&) {
 
 sub register_plugin {
     my $plugin = caller;
-    my $caller = caller(1);
+    # if we can't find the DSL, we cant register the plugin
+    my $caller = _get_dsl() || return;
     my %params = @_;
-
-    # if the caller has no dsl method, we can't register the plugin
-    return if !$caller->can('dsl');
 
     # the plugin consumes the DSL role
     Moo::Role->apply_role_to_package( $plugin, 'Dancer2::Core::Role::DSL' );


### PR DESCRIPTION
If we load a plugin via Module::Runtime's use_module, the "caller" of our module isn't the app, but is instead Module::Runtime. To find the right DSL, we need to search up the call stack.

This manifested as a report against Import::Base: https://github.com/preaction/Import-Base/issues/27