### PR TITLE
Do not set wrong (character based) content-length in AutoPage handler

### DIFF
--- a/lib/Dancer2/Handler/AutoPage.pm
+++ b/lib/Dancer2/Handler/AutoPage.pm
@@ -50,7 +50,6 @@ sub code {
         }
 
         my $ct = $template->process( $page );
-        $app->response->header( 'Content-Length', length($ct) );
         return ( $app->request->method eq 'GET' ) ? $ct : '';
     };
 }

--- a/t/auto_page.t
+++ b/t/auto_page.t
@@ -12,6 +12,7 @@ use HTTP::Request::Common;
     set auto_page => 1;
     set views     => 't/views';
     set layout    => 'main';
+    set charset   => 'UTF-8';
 }
 
 
@@ -33,8 +34,26 @@ sub run_tests {
         is( $r->code, 200, 'Autopage found the page' );
         like(
             $r->content,
-            qr/---\nHey! This is Auto Page working/,
+            qr/---\nHey! This is Auto Page wörking/,
             '...with proper content',
+        );
+
+        is(
+            $r->headers->content_type,
+            'text/html',
+            'auto page has correct content type header',
+        );
+
+        is(
+            $r->headers->content_type_charset,
+            'UTF-8',
+            'auto page has correct charset in content type header',
+        );
+
+        is(
+            $r->headers->content_length,
+            98, # auto_page.tt+layouts/main.tt processed. ö has two bytes in UTF-8
+            'auto page has correct content length header',
         );
     }
 
@@ -71,7 +90,7 @@ sub run_tests {
         like(
             $r->headers->content_type,
             qr{text/plain},
-            'public served file as correct mime',
+            'public served file has correct content type header',
         );
     }
 }


### PR DESCRIPTION
Also added tests for correct content-length headers setting in case of non-ASCII output