### PR TITLE
Skip rendering of template by the autopage handler on HTTP methods other than GET

### DIFF
--- a/lib/Dancer2/Handler/AutoPage.pm
+++ b/lib/Dancer2/Handler/AutoPage.pm
@@ -49,8 +49,16 @@ sub code {
             return;
         }
 
-        my $ct = $template->process( $page );
-        return ( $app->request->method eq 'GET' ) ? $ct : '';
+        my $ct;
+
+        if ( $app->request->method eq 'GET' ) {
+            $ct = $template->process( $page );
+        }
+        else {
+            $ct = '';
+        }
+
+        return $ct;
     };
 }
 


### PR DESCRIPTION
Tiny optimization for autopage handler - it doesn't make sense to render the template and throw it away.
