### PR TITLE
Cleaner default error page

### DIFF
--- a/lib/Dancer2/Core/Error.pm
+++ b/lib/Dancer2/Core/Error.pm
@@ -155,7 +155,7 @@ has message => (
 sub full_message {
     my ($self) = @_;
     my $html_output = "<h2>" . $self->type . "</h2>";
-    $html_output .= $self->backtrace;
+    $html_output .= $self->error_context;
     $html_output .= $self->environment;
     return $html_output;
 }
@@ -320,7 +320,7 @@ sub throw {
     return $self->response;
 }
 
-sub backtrace {
+sub error_context {
     my ($self) = @_;
 
     my $message = $self->message;
@@ -330,64 +330,37 @@ sub backtrace {
     }
     $message ||= 'Wooops, something went wrong';
 
-    $message = '<pre class="error">' . _html_encode($message) . '</pre>';
+    my $html = '<pre class="error">' . _html_encode($message) . "</pre>\n";
 
     # the default perl warning/error pattern
-    my ( $file, $line ) = ( $message =~ /at (\S+) line (\d+)/ );
-
+    my ($file, $line) = $message =~ /at (\S+) line (\d+)/;
     # the Devel::SimpleTrace pattern
-    ( $file, $line ) = ( $message =~ /at.*\((\S+):(\d+)\)/ )
-      unless $file and $line;
+    ($file, $line) = $message =~ /at.*\((\S+):(\d+)\)/ unless $file and $line;
 
     # no file/line found, cannot open a file for context
-    return $message unless ( $file and $line );
+    return $html unless $file and $line;
 
     # file and line are located, let's read the source Luke!
-    my $fh = eval { open_file( '<', $file ) } or return $message;
+    my $fh = eval { open_file('<', $file) } or return $html;
     my @lines = <$fh>;
     close $fh;
 
-    my $backtrace = $message;
+    $html .= qq|<div class="title">$file around line $line</div>|;
 
-    $backtrace
-      .= qq|<div class="title">| . "$file around line $line" . "</div>";
+    # get 5 lines of context
+    my $start = $line - 5 > 1 ? $line - 5 : 1;
+    my $stop = $line + 5 < @lines ? $line + 5 : @lines;
 
-    $backtrace .= qq|<pre class="content">|;
+    $html .= qq|<pre class="content"><table class="context">\n|;
+    for my $l ($start .. $stop) {
+        chomp $lines[$l - 1];
 
-    $line--;
-    my $start = ( ( $line - 3 ) >= 0 ) ? ( $line - 3 ) : 0;
-    my $stop =
-      ( ( $line + 3 ) < scalar(@lines) ) ? ( $line + 3 ) : scalar(@lines);
-
-    for ( my $l = $start; $l <= $stop; $l++ ) {
-        chomp $lines[$l];
-
-        if ( $l == $line ) {
-            $backtrace
-              .= qq|<span class="nu">|
-              . tabulate( $l + 1, $stop + 1 )
-              . qq|</span> <span style="color: red;">|
-              . _html_encode( $lines[$l] )
-              . "</span>\n";
-        }
-        else {
-            $backtrace
-              .= qq|<span class="nu">|
-              . tabulate( $l + 1, $stop + 1 )
-              . "</span> "
-              . _html_encode( $lines[$l] ) . "\n";
-        }
+        $html .= $l == $line ? '<tr class="errline">' : '<tr>';
+        $html .= "<th>$l</th><td>" . _html_encode($lines[$l - 1]) . "</td></tr>\n";
     }
-    $backtrace .= "</pre>";
+    $html .= "</table></pre>\n";
 
-    return $backtrace;
-}
-
-sub tabulate {
-    my ( $number, $max ) = @_;
-    my $len = length($max);
-    return $number if length($number) == $len;
-    return " $number";
+    return $html;
 }
 
 sub dumper {
@@ -549,18 +522,14 @@ Populates the content of the response with the error's information.
 If I<$response> is not given, acts on the I<app>
 attribute's response.
 
-=method backtrace
+=method error_context
 
-Create a backtrace of the code where the error is caused.
+Show the surrounding lines of context at the line where the error was thrown.
 
 This method tries to find out where the error appeared according to the actual
 error message (using the C<message> attribute) and tries to parse it (supporting
 the regular/default Perl warning or error pattern and the L<Devel::SimpleTrace>
 output) and then returns an error-highlighted C<message>.
-
-=method tabulate
-
-Small subroutine to help output nicer.
 
 =head2 dumper
 

--- a/share/skel/public/css/error.css
+++ b/share/skel/public/css/error.css
@@ -54,9 +54,23 @@ div.title {
     padding-left: 10px;
 }
 
-pre.content span.nu {
+table.context {
+    border-spacing: 0;
+}
+
+table.context th, table.context td {
+    padding: 0;
+}
+
+table.context th {
     color: #889;
-    margin-right: 10px;
+    font-weight: normal;
+    padding-right: 15px;
+    text-align: right;
+}
+
+.errline {
+    color: red;
 }
 
 pre.error {


### PR DESCRIPTION
- Cleaner, clearer display of the context of an error. Uses `table` instead of `pre` for formatting.
- Now shows 5 lines of context instead of *almost* 3. (Bug fixed)
- Renamed `backtrace` to `error_context` since it returns the context of the error not a backtrace.