### PR TITLE
Rework body param passing to be independent of Plack version.

### DIFF
--- a/lib/Dancer2/Core/Request.pm
+++ b/lib/Dancer2/Core/Request.pm
@@ -363,18 +363,19 @@ sub _set_route_parameters {
 
 sub body_parameters {
     my $self = shift;
-    $self->{'plack.request.body'}
-        and return $self->{'plack.request.body'};
+    $self->env->{'plack.request.body'}
+        and return $self->env->{'plack.request.body'};
 
     # handle case of serializer
     if ( my $data = $self->deserialize ) {
-        return Hash::MultiValue->from_mixed(
+        $self->env->{'plack.request.body'} = Hash::MultiValue->from_mixed(
             ref $data eq 'HASH' ? %{$data} : ()
         );
+        return $self->env->{'plack.request.body'};
     }
 
-    $self->_parse_request_body;
-    return $self->env->{'plack.request.body'};
+    # defer to (the overridden) Plack::Request->body_parameters
+    return $self->SUPER::body_parameters();
 }
 
 sub parameters {


### PR DESCRIPTION
The Plack 1.0040 TRIAL release breaks our body param passing; internally
Plack::Request altered the construction of $env->{plack.request.body}.

Calling the original `body_parameters` method from Plack::Request
(via SUPER) ensures this is always set up correctly, no matter what
version of Plack we are subclassing.