### PR TITLE
configuration bugfix + enhancement

### DIFF
--- a/lib/Dancer2/Core/Role/ConfigReader.pm
+++ b/lib/Dancer2/Core/Role/ConfigReader.pm
@@ -136,6 +136,8 @@ sub _build_config_files {
     for my $conf (keys %multiples) {
         warn "Used config file $conf, but also found and did NOT use these config files: @{$multiples{$conf}}";
     }
+
+    push @files, $ENV{DANCER_ALT_CONFIG}  if exists $ENV{DANCER_ALT_CONFIG};
     return \@files;
 }
 

--- a/lib/Dancer2/Core/Role/ConfigReader.pm
+++ b/lib/Dancer2/Core/Role/ConfigReader.pm
@@ -114,15 +114,24 @@ sub _build_config_files {
     my @exts = Config::Any->extensions;
 
     my @files;
+    my %multiples;
     for my $config ( [ $location, "config" ], 
                       [ $self->environments_location, $self->environment ] ) {
         my ($location, $filename) = @{$config};
+        my $found_config = 0;
         for my $ext (@exts) {
             my $path = path( $location, "$filename.$ext" );
             next if !-r $path;
-            push @files, $path;
-            last;
+            if ($found_config) {
+                push @{$multiples{$files[-1]}}, $path;
+            } else {
+                push @files, $path;
+                $found_config = 1;
+            }
         }
+    }
+    for my $conf (keys %multiples) {
+        warn "Used config file $conf, but also found and did NOT use these config files: @{$multiples{$conf}}";
     }
     return \@files;
 }

--- a/lib/Dancer2/Core/Role/ConfigReader.pm
+++ b/lib/Dancer2/Core/Role/ConfigReader.pm
@@ -118,7 +118,8 @@ sub _build_config_files {
     my @files;
     my %multiples;
     for my $config ( [ $location, "config" ], 
-                      [ $self->environments_location, $self->environment ] ) {
+                      [ $self->environments_location, $self->environment ],
+                      [ $self->environments_location, "my-" . $self->environment ] ) {
         my ($location, $filename) = @{$config};
         my $found_config = 0;
         for my $ext (@exts) {

--- a/lib/Dancer2/Core/Role/ConfigReader.pm
+++ b/lib/Dancer2/Core/Role/ConfigReader.pm
@@ -111,22 +111,20 @@ sub _build_config_files {
     # an undef location means no config files for the caller
     return [] unless defined $location;
 
-    my $running_env = $self->environment;
     my @exts = Config::Any->extensions;
+
     my @files;
-
-    foreach my $ext (@exts) {
-        foreach my $file ( [ $location, "config.$ext" ],
-            [ $self->environments_location, "$running_env.$ext" ] )
-        {
-            my $path = path( @{$file} );
+    for my $config ( [ $location, "config" ], 
+                      [ $self->environments_location, $self->environment ] ) {
+        my ($location, $filename) = @{$config};
+        for my $ext (@exts) {
+            my $path = path( $location, "$filename.$ext" );
             next if !-r $path;
-
             push @files, $path;
+            last;
         }
     }
-
-    return [ sort @files ];
+    return \@files;
 }
 
 sub _build_config {

--- a/lib/Dancer2/Core/Role/ConfigReader.pm
+++ b/lib/Dancer2/Core/Role/ConfigReader.pm
@@ -111,7 +111,9 @@ sub _build_config_files {
     # an undef location means no config files for the caller
     return [] unless defined $location;
 
-    my @exts = Config::Any->extensions;
+    my @exts = exists $ENV{DANCER_CONFIGFILE_EXT}
+             ? $ENV{DANCER_CONFIGFILE_EXT}
+             : Config::Any->extensions;
 
     my @files;
     my %multiples;


### PR DESCRIPTION
I've tried to keep the commits atomic so that they can be applied or not individually.  The first three commits are essentially for #1149.  To wit: 

* Once we find a config file in each of the main dir and in environments, don't use any others. (i.e. don't use both `config.ini` *and* `config.json` simultaneously if both files happen to be there.)
* Generate warnings if the user happens to have multiple config files in the main dir (e.g. both `config.json` and `config.yaml`) because in that situation, how is the user to know which was used?
* Let the user specify via an environment variable the configuration extension and only look for files with that extension.  However, there is no checking that this extension is a valid type that Config::Any understands.
* what started me looking at the config generation in the first place: at $work we have some developer configuration information that is common across all developers, but we also have some config info that's specific to each developer.  This commit allows for files such as `environments/my-development.yaml` for such cases.
