### PR TITLE
update pod noting that plugin's config is immutable after 1st read

### DIFF
--- a/lib/Dancer2/Plugin.pm
+++ b/lib/Dancer2/Plugin.pm
@@ -854,6 +854,29 @@ For example:
         from_config => sub { 'See ya!' },
     );
 
+=head3 Config becomes immutable
+
+The plugin's C<config> attribute is loaded lazily on the first call to
+C<config>. After this first call C<config> becomes immutable so you cannot
+do the following in a test:
+
+    use Dancer2;
+    use Dancer2::Plugin::FooBar;
+
+    set plugins => {
+        FooBar => {
+            wibble => 1,  # this is OK
+        },
+    };
+
+    flibble(45);          # plugin keyword called which causes config read
+    
+    set plugins => {
+        FooBar => {
+            wibble => 0,  # this will NOT change plugin config
+        },
+    };
+
 =head3 Accessing the parent Dancer app
 
 If the plugin is instantiated within a Dancer app, it'll be


### PR DESCRIPTION
Perhaps I've got the wrong end of the stick here but here is a simplified view of plugin2's config attribute from my view of the world. If this is correct then this needs adding since a number of plugin maintainers are used to altering config on the fly at runtime.