### PR TITLE
Bugfix/inconsistent megasplat split

### DIFF
--- a/Changes
+++ b/Changes
@@ -12,6 +12,13 @@
     * GH #1144: Change tt tags to span in skel (Jason Lewis)
     * GH #1046: "no_server_tokens" configuration option doesn't work.
       (Sawyer X)
+    # GH #1155, #1157: Fix megasplat value spliting when there are empty
+      trailing path segments. (Tatsuhiko Miyagawa, Russell Jenkins)
+      NOTE: Paths matching a megasplat that end with a '/' will now include
+      an empty string as the last value. For the route pattern '/foo/**',
+      the path '/foo/bar', the megasplat gives ['bar'], whereas '/foo/bar/'
+      now gives ['bar','']. Joining the array of megasplat values will now
+      always be the string matched against for the megasplit.
 
     [ DOCUMENTATION ]
     * GH #1119: Improve the deployment documentation. (Andrew Beverley)

--- a/lib/Dancer2.pm
+++ b/lib/Dancer2.pm
@@ -326,6 +326,7 @@ things:
     simbabque
     Slava Goltser
     Snigdha
+    Tatsuhiko Miyagawa
     Tina Müller
     Tom Hukins
     Upasana Shukla

--- a/lib/Dancer2/Core/Route.pm
+++ b/lib/Dancer2/Core/Route.pm
@@ -112,7 +112,9 @@ sub match {
 
             # megasplat values are split on '/'
             if ($token_or_splat[$i] eq 'megasplat') {
-                $values[$i] = [ split '/' => $values[$i] || '' ];
+                $values[$i] = [
+                    defined $values[$i] ? split( '/' , $values[$i], -1 ) : ()
+                ];
             }
             push @splat, $values[$i];
         }

--- a/t/classes/Dancer2-Core-Route/match.t
+++ b/t/classes/Dancer2-Core-Route/match.t
@@ -70,6 +70,16 @@ my @tests = (
         [ { splat => [ [ 'some', 'where' ], '42' ] }, 44 ]
     ],
 
+    # megasplat consistently handles multiple slashes
+    [   [ 'get', '/foo/**', sub {'45a'} ],
+        '/foo/bar///baz',
+        [ { splat => [ [ 'bar', '', '', 'baz' ] ] }, '45a' ]
+    ],
+    [   [ 'get', '/foo/**', sub {'45b'} ],
+        '/foo/bar///',  # empty trailing path segment
+        [ { splat => [ [ 'bar', '', '', '' ] ] }, '45b' ]
+    ],
+
     # Optional megasplat test - with a value...
     [   [ 'get', '/foo/?**?', sub {46} ],
         '/foo/bar/baz',
@@ -102,7 +112,7 @@ my @tests = (
 );
 
 
-plan tests => 100;
+plan tests => 110;
 
 for my $t (@tests) {
     my ( $route, $path, $expected ) = @$t;

--- a/t/dsl/parameters.t
+++ b/t/dsl/parameters.t
@@ -247,7 +247,7 @@ subtest 'Splat and megasplat route parameters' => sub {
 
             ::is_deeply(
                 [ splat ],
-                [ 'foo', ['baz'] ],
+                [ 'foo', ['baz', ''] ],
                 'Got splat values',
             );
         };


### PR DESCRIPTION
The string that a megasplat matched is split on `/`. Without setting an LIMIT for the split, empty trailing values get stripped. That is; for the route `/foo/**`, the paths `/foo/bar` and `/foo/bar/` were both matching and gave the splat as `['bar']`.

Or, if there were further trailing slashes in the path:
`/foo/bar///a`  gave  `['bar','','','a']` but
`/foo/bar///`   gave  `['bar']`.   How's that for inconsistent.

Adding a (negative) limit to the split on megasplat values so empty trailing values are kept, which allows you to join the arrayref of values together and get the original path again.

The above examples become:
`/foo/bar/`     giving `['bar','']`

`/foo/bar///a`  giving `['bar','','','a']`  #as before

`/foo/bar///`   giving `['bar','','', '']`

This is a subtle change in behaviour, which _may_ cause some Dancers issues if they are not aware of the change.
