### PR TITLE
Pod update: List apache modules with apachectl -M

### DIFF
--- a/lib/Dancer2/Manual/Deployment.pod
+++ b/lib/Dancer2/Manual/Deployment.pod
@@ -147,7 +147,8 @@ occasionally-used sites, as the application is not using resources when it is
 not being accessed. For anything more, you probably want to use FastCGI instead
 (see next section).
 
-To check what modules your server supports, type C<apache2 -l>.
+To list all currently loaded modules, type C<apachectl -M> (C<apache2ctl -M> on Debian/Ubuntu).
+
 
 =head3 As a FastCGI script
 


### PR DESCRIPTION
Hi,

Just started tinkering with Dancer2 :-)

apache -l will only list modules that are compiled into the server. It will not list shared modules.

I believe it is better to use apachectl -M in this example since it lists both static and shared modules.

Thanks,

Zoran