### PR TITLE
template and session engines receive incorect log_cb on build

### DIFF
--- a/lib/Dancer2/Core/App.pm
+++ b/lib/Dancer2/Core/App.pm
@@ -230,7 +230,7 @@ sub _build_session_engine {
         %{$engine_options},
         postponed_hooks => $self->postponed_hooks,
 
-        log_cb => sub { $weak_self->logger->log(@_) },
+        log_cb => sub { $weak_self->logger_engine->log(@_) },
     );
 }
 
@@ -263,7 +263,7 @@ sub _build_template_engine {
         %{$engine_attrs},
         postponed_hooks => $self->postponed_hooks,
 
-        log_cb => sub { $weak_self->logger->log(@_) },
+        log_cb => sub { $weak_self->logger_engine->log(@_) },
     );
 }
 


### PR DESCRIPTION
`sub _build_serializer_engine` already had the correct code:
```
    log_cb => sub { $weak_self->logger_engine->log(@_) },
```
but template and session were being built with:
```
    log_cb => sub { $weak_self->logger->log(@_) },
```