### PR TITLE
Pr/change skel template tag

### DIFF
--- a/lib/Dancer2/CLI/Command/gen.pm
+++ b/lib/Dancer2/CLI/Command/gen.pm
@@ -216,8 +216,8 @@ sub _add_to_manifest_skip {
 sub _process_template {
     my ($template, $tokens) = @_;
     my $engine = Dancer2::Template::Simple->new;
-    $engine->{start_tag} = '[%';
-    $engine->{stop_tag} = '%]';
+    $engine->{start_tag} = '[d2%';
+    $engine->{stop_tag} = '%2d]';
     return $engine->render(\$template, $tokens);
 }
 

--- a/share/skel/Makefile.PL
+++ b/share/skel/Makefile.PL
@@ -8,9 +8,9 @@ my $eumm_version = $ExtUtils::MakeMaker::VERSION;
 $eumm_version =~ s/_//;
 
 WriteMakefile(
-    NAME                => '[% appname %]',
+    NAME                => '[d2% appname %2d]',
     AUTHOR              => q{YOUR NAME <youremail@example.com>},
-    VERSION_FROM        => '[% appfile %]',
+    VERSION_FROM        => '[d2% appfile %2d]',
     ABSTRACT            => 'YOUR APPLICATION ABSTRACT',
     ($eumm_version >= 6.3001
       ? ('LICENSE'=> 'perl')
@@ -19,8 +19,8 @@ WriteMakefile(
     PREREQ_PM => {
         'Test::More' => 0,
         'YAML'       => 0,
-        'Dancer2'     => [% dancer_version %],
+        'Dancer2'     => [d2% dancer_version %2d],
     },
     dist                => { COMPRESS => 'gzip -9f', SUFFIX => 'gz', },
-    clean               => { FILES => '[% cleanfiles %]-*' },
+    clean               => { FILES => '[d2% cleanfiles %2d]-*' },
 );

--- a/share/skel/bin/+app.psgi
+++ b/share/skel/bin/+app.psgi
@@ -5,5 +5,5 @@ use warnings;
 use FindBin;
 use lib "$FindBin::Bin/../lib";
 
-use [% appname %];
-[% appname %]->to_app;
+use [d2% appname %2d];
+[d2% appname %2d]->to_app;

--- a/share/skel/config.yml
+++ b/share/skel/config.yml
@@ -3,7 +3,7 @@
 # all the settings in this file will be loaded at Dancer's startup.
 
 # Your application's name
-appname: "[% appname %]"
+appname: "[d2% appname %2d]"
 
 # The default layout to use for your application (located in
 # views/layouts/main.tt)

--- a/share/skel/cpanfile
+++ b/share/skel/cpanfile
@@ -1,4 +1,4 @@
-requires "Dancer2" => "[% dancer_version %]";
+requires "Dancer2" => "[d2% dancer_version %2d]";
 
 recommends "YAML"             => "0";
 recommends "URL::Encode::XS"  => "0";

--- a/share/skel/lib/AppFile.pm
+++ b/share/skel/lib/AppFile.pm
@@ -1,4 +1,4 @@
-package [% appname %];
+package [d2% appname %2d];
 use Dancer2;
 
 our $VERSION = '0.1';

--- a/share/skel/public/+dispatch.cgi
+++ b/share/skel/public/+dispatch.cgi
@@ -1,4 +1,4 @@
-[% perl_interpreter %]
+[d2% perl_interpreter %2d]
 BEGIN { $ENV{DANCER_APPHANDLER} = 'PSGI';}
 use Dancer2;
 use FindBin '$RealBin';

--- a/share/skel/public/+dispatch.fcgi
+++ b/share/skel/public/+dispatch.fcgi
@@ -1,4 +1,4 @@
-[% perl_interpreter %]
+[d2% perl_interpreter %2d]
 BEGIN { $ENV{DANCER_APPHANDLER} = 'PSGI';}
 use Dancer2;
 use FindBin '$RealBin';

--- a/share/skel/t/001_base.t
+++ b/share/skel/t/001_base.t
@@ -2,4 +2,4 @@ use strict;
 use warnings;
 
 use Test::More tests => 1;
-use_ok '[% appname %]';
+use_ok '[d2% appname %2d]';

--- a/share/skel/t/002_index_route.t
+++ b/share/skel/t/002_index_route.t
@@ -1,12 +1,12 @@
 use strict;
 use warnings;
 
-use [% appname %];
+use [d2% appname %2d];
 use Test::More tests => 2;
 use Plack::Test;
 use HTTP::Request::Common;
 
-my $app = [% appname %]->to_app;
+my $app = [d2% appname %2d]->to_app;
 is( ref $app, 'CODE', 'Got app' );
 
 my $test = Plack::Test->create($app);

--- a/share/skel/views/index.tt
+++ b/share/skel/views/index.tt
@@ -40,7 +40,7 @@
             <h3>Your application's environment</h3>
 
             <ul>
-                <li>Location: <span class="filepath">[% appdir %]</span></li>
+                <li>Location: <span class="filepath">[d2% appdir %2d]</span></li>
                 <li>Template engine: <span class="app-info"><% settings.template %></span></li>
                 <li>Logger: <span class="app-info"><% settings.logger %></span></li>
                 <li>Environment: <span class="app-info"><% settings.environment %></span></li>
@@ -80,7 +80,7 @@
                 </tr>
                 <tr>
                     <td>Appdir</td>
-                    <td><span class="filepath">[% appdir %]</span></td>
+                    <td><span class="filepath">[d2% appdir %2d]</span></td>
                 </tr>
                 <tr>
                     <td>Template engine</td>
@@ -128,7 +128,7 @@
               it's just here to help you get started. The template used to
               generate this content is located in
               <span class="filepath">views/index.tt</span>.
-              You can add some routes to <span class="filepath">[% appfile %]</span>.
+              You can add some routes to <span class="filepath">[d2% appfile %2d]</span>.
               </p>
             </li>
 

--- a/share/skel/views/layouts/main.tt
+++ b/share/skel/views/layouts/main.tt
@@ -3,7 +3,7 @@
 <head>
   <meta charset="<% settings.charset %>">
   <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=yes">
-  <title>[% appname %]</title>
+  <title>[d2% appname %2d]</title>
   <link rel="stylesheet" href="<% request.uri_base %>/css/style.css">
 
 <!-- Grab jQuery from a CDN, fall back to local if necessary -->


### PR DESCRIPTION
The tags used in the D2 skeleton app are `[% %]`.

This is a problem if you want to make your own skeleton for generating applications that use the TT2 `[% %]` style tags as they incorrectly get consumed by the generating process.

This changes the skeleleton's template tags to `[d2% %2d]` which will be less
likely to clash with tags in templating systems.

Note: this is only the tags used for generating the application. ie `dancer2 gen -a MyWeb::App`