### PR TITLE
Make template keyword global (GH #1159):

### DIFF
--- a/lib/Dancer2/Core/App.pm
+++ b/lib/Dancer2/Core/App.pm
@@ -774,10 +774,12 @@ sub template {
     my $template = $self->template_engine;
     $template->set_settings( $self->config );
 
+    # A session will not exist if there is no request (global keyword)
+    #
     # A session may exist but the route code may not have instantiated
     # the session object (sessions are lazy). If this is the case, do
     # that now, so the templates have the session data for rendering.
-    $self->has_session && ! $template->has_session
+    $self->has_request && $self->has_session && ! $template->has_session
         and $self->setup_session;
 
     # return content

--- a/lib/Dancer2/Core/DSL.pm
+++ b/lib/Dancer2/Core/DSL.pm
@@ -106,7 +106,7 @@ sub dsl_keywords {
         splat                => { is_global => 0 },
         start                => { is_global => 1 },
         status               => { is_global => 0 },
-        template             => { is_global => 0 },
+        template             => { is_global => 1 },
         to_app               => { is_global => 1 },
         to_dumper            => { is_global => 1 },
         to_json              => { is_global => 1 },

--- a/lib/Dancer2/Core/Role/Template.pm
+++ b/lib/Dancer2/Core/Role/Template.pm
@@ -180,14 +180,16 @@ sub _prepare_tokens_options {
     $tokens->{dancer_version} = Dancer2->VERSION;
     $tokens->{settings}       = $self->settings;
 
+    # no request when template is called as a global keyword
     if ( $self->has_request ) {
         $tokens->{request}  = $self->request;
         $tokens->{params}   = $self->request->params;
         $tokens->{vars}     = $self->request->vars;
-    }
 
-    $tokens->{session} = $self->session->data
-      if $self->has_session;
+        # a session can not exist if there is no request
+        $tokens->{session} = $self->session->data
+          if $self->has_session;
+    }
 
     return $tokens;
 }

--- a/lib/Dancer2/Core/Role/Template.pm
+++ b/lib/Dancer2/Core/Role/Template.pm
@@ -178,11 +178,13 @@ sub _prepare_tokens_options {
     $tokens ||= {};
     $tokens->{perl_version}   = $^V;
     $tokens->{dancer_version} = Dancer2->VERSION;
+    $tokens->{settings}       = $self->settings;
 
-    $tokens->{settings} = $self->settings;
-    $tokens->{request}  = $self->request;
-    $tokens->{params}   = $self->request->params;
-    $tokens->{vars}     = $self->request->vars;
+    if ( $self->has_request ) {
+        $tokens->{request}  = $self->request;
+        $tokens->{params}   = $self->request->params;
+        $tokens->{vars}     = $self->request->vars;
+    }
 
     $tokens->{session} = $self->session->data
       if $self->has_session;

--- a/t/template.t
+++ b/t/template.t
@@ -75,6 +75,10 @@ $tt->add_hook(
     Dancer2->runner->apps->[0]->set_template_engine($tt);
 
     get '/' => sub { template index => { var => 42 } };
+
+    # Call template as a global keyword
+    my $global= template( index => { var => 21 } );
+    get '/global' => sub { $global };
 }
 
 subtest 'template hooks' => sub {
@@ -98,6 +102,10 @@ content added in after_layout_render";
     my $test = Plack::Test->create( Bar->to_app );
     my $res = $test->request( GET '/' );
     is $res->content, $result, '[GET /] Correct content with template hooks';
+
+    $result =~ s/42/21/g;
+    $res = $test->request( GET '/global' );
+    is $res->content, $result, '[GET /global] Correct content with template hooks';
 };
 
 {


### PR DESCRIPTION
This makes sure the `template` keyword is available outside the request process. The request object (including the parameters and variables) will not be available during that `template` call.