### PR TITLE
Replace Class::Load with Module::Runtime

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -88,7 +88,6 @@ JSON = 0
 URI::Escape = 0
 parent = 0
 Template::Tiny = 0
-Class::Load = 0
 Return::MultiLevel = 0
 Import::Into = 0
 Safe::Isa = 0
@@ -118,7 +117,6 @@ Scope::Upper = 0
 ; Used by Dancer2::Session::YAML
 YAML = 0.86
 Fcntl = 0
-Class::Load::XS = 0
 MIME::Types = 0
 
 ; -- test requirements

--- a/lib/Dancer2.pm
+++ b/lib/Dancer2.pm
@@ -4,7 +4,7 @@ package Dancer2;
 use strict;
 use warnings;
 use List::Util  'first';
-use Class::Load 'load_class';
+use Module::Runtime 'use_module';
 use Import::Into;
 use Dancer2::Core;
 use Dancer2::Core::App;
@@ -85,7 +85,7 @@ sub import {
     $final_args{dsl} ||= $config_dsl;
 
     # load the DSL, defaulting to Dancer2::Core::DSL
-    load_class( $final_args{dsl} );
+    use_module( $final_args{'dsl'} );
     my $dsl = $final_args{dsl}->new( app => $app );
     $dsl->export_symbols_to( $caller, \%final_args );
 }
@@ -103,6 +103,7 @@ sub _set_import_method_to_caller {
     };
 
     {
+        ## no critic
         no strict 'refs';
         no warnings 'redefine';
         *{"${caller}::import"} = $import;

--- a/lib/Dancer2.pm
+++ b/lib/Dancer2.pm
@@ -85,8 +85,7 @@ sub import {
     $final_args{dsl} ||= $config_dsl;
 
     # load the DSL, defaulting to Dancer2::Core::DSL
-    use_module( $final_args{'dsl'} );
-    my $dsl = $final_args{dsl}->new( app => $app );
+    my $dsl = use_module( $final_args{dsl} )->new( app => $app );
     $dsl->export_symbols_to( $caller, \%final_args );
 }
 

--- a/lib/Dancer2/CLI/Command/gen.pm
+++ b/lib/Dancer2/CLI/Command/gen.pm
@@ -13,6 +13,7 @@ use File::Spec::Functions;
 use File::ShareDir 'dist_dir';
 use File::Basename qw/dirname basename/;
 use Dancer2::Template::Simple;
+use Module::Runtime 'require_module';
 
 my $SKEL_APP_FILE = 'lib/AppFile.pm';
 
@@ -91,7 +92,7 @@ sub execute {
     _create_manifest($files_to_copy, $app_path);
     _add_to_manifest_skip($app_path);
 
-    if ( ! eval { require YAML; 1; } ) {
+    if ( ! eval { require_module('YAML'); 1; } ) {
         print <<NOYAML;
 *****
 WARNING: YAML.pm is not installed.  This is not a full dependency, but is highly
@@ -112,7 +113,7 @@ NOYAML
 }
 
 sub version {
-    require Dancer2;
+    require_module('Dancer2');
     return Dancer2->VERSION;
 }
 

--- a/lib/Dancer2/CLI/Command/gen.pm
+++ b/lib/Dancer2/CLI/Command/gen.pm
@@ -13,7 +13,6 @@ use File::Spec::Functions;
 use File::ShareDir 'dist_dir';
 use File::Basename qw/dirname basename/;
 use Dancer2::Template::Simple;
-use Class::Load 'try_load_class';
 
 my $SKEL_APP_FILE = 'lib/AppFile.pm';
 
@@ -92,7 +91,7 @@ sub execute {
     _create_manifest($files_to_copy, $app_path);
     _add_to_manifest_skip($app_path);
 
-    if ( ! try_load_class('YAML') ) {
+    if ( ! eval { require YAML; 1; } ) {
         print <<NOYAML;
 *****
 WARNING: YAML.pm is not installed.  This is not a full dependency, but is highly

--- a/lib/Dancer2/CLI/Command/version.pm
+++ b/lib/Dancer2/CLI/Command/version.pm
@@ -4,6 +4,7 @@ package Dancer2::CLI::Command::version;
 use strict;
 use warnings;
 use App::Cmd::Setup -command;
+use Module::Runtime 'require_module';
 
 sub description { 'Display version of Dancer2' }
 
@@ -12,7 +13,7 @@ sub command_names {
 }
 
 sub execute {
-    require Dancer2;
+    require_module('Dancer2');
     print 'Dancer2 ' . Dancer2->VERSION . "\n";
     return 0;
 }

--- a/lib/Dancer2/Core/App.pm
+++ b/lib/Dancer2/Core/App.pm
@@ -9,7 +9,7 @@ use Return::MultiLevel ();
 use Safe::Isa;
 use Sub::Quote;
 use File::Spec;
-use Class::Load        qw/ load_class /;
+use Module::Runtime    'use_module';
 
 use Plack::Middleware::FixMissingBodyInRedirect;
 use Plack::Middleware::Head;
@@ -68,7 +68,7 @@ sub _with_plugin {
     }
 
     push @{ $self->plugins }, 
-         $plugin = load_class($plugin)->new( app => $self );
+         $plugin = use_module($plugin)->new( app => $self );
 
     return $plugin;
 }

--- a/lib/Dancer2/Core/DSL.pm
+++ b/lib/Dancer2/Core/DSL.pm
@@ -4,7 +4,6 @@ package Dancer2::Core::DSL;
 
 use Moo;
 use Carp;
-use Class::Load 'load_class';
 use Dancer2::Core::Hook;
 use Dancer2::FileUtils;
 use Dancer2::Core::Response::Delayed;

--- a/lib/Dancer2/Core/DSL.pm
+++ b/lib/Dancer2/Core/DSL.pm
@@ -4,6 +4,7 @@ package Dancer2::Core::DSL;
 
 use Moo;
 use Carp;
+use Module::Runtime 'require_module';
 use Dancer2::Core::Hook;
 use Dancer2::FileUtils;
 use Dancer2::Core::Response::Delayed;
@@ -447,37 +448,37 @@ sub mime {
 
 sub from_json {
     shift; # remove first element
-    require Dancer2::Serializer::JSON;
+    require_module('Dancer2::Serializer::JSON');
     Dancer2::Serializer::JSON::from_json(@_);
 }
 
 sub to_json {
     shift; # remove first element
-    require Dancer2::Serializer::JSON;
+    require_module('Dancer2::Serializer::JSON');
     Dancer2::Serializer::JSON::to_json(@_);
 }
 
 sub from_yaml {
     shift; # remove first element
-    require Dancer2::Serializer::YAML;
+    require_module('Dancer2::Serializer::YAML');
     Dancer2::Serializer::YAML::from_yaml(@_);
 }
 
 sub to_yaml {
     shift; # remove first element
-    require Dancer2::Serializer::YAML;
+    require_module('Dancer2::Serializer::YAML');
     Dancer2::Serializer::YAML::to_yaml(@_);
 }
 
 sub from_dumper {
     shift; # remove first element
-    require Dancer2::Serializer::Dumper;
+    require_module('Dancer2::Serializer::Dumper');
     Dancer2::Serializer::Dumper::from_dumper(@_);
 }
 
 sub to_dumper {
     shift; # remove first element
-    require Dancer2::Serializer::Dumper;
+    require_module('Dancer2::Serializer::Dumper');
     Dancer2::Serializer::Dumper::to_dumper(@_);
 }
 

--- a/lib/Dancer2/Core/Error.pm
+++ b/lib/Dancer2/Core/Error.pm
@@ -8,6 +8,7 @@ use Dancer2::Core::HTTP;
 use Data::Dumper;
 use Dancer2::FileUtils qw/path open_file/;
 use Sub::Quote;
+use Module::Runtime 'require_module';
 
 has app => (
     is        => 'ro',
@@ -100,7 +101,7 @@ sub _build_static_page {
 sub default_error_page {
     my $self = shift;
 
-    require Template::Tiny;
+    require_module('Template::Tiny');
 
     my $uri_base = $self->has_app && $self->app->has_request ?
         $self->app->request->uri_base : '';

--- a/lib/Dancer2/Core/Factory.pm
+++ b/lib/Dancer2/Core/Factory.pm
@@ -3,7 +3,7 @@ package Dancer2::Core::Factory;
 
 use Moo;
 use Dancer2::Core;
-use Class::Load 'try_load_class';
+use Module::Runtime 'use_module';
 use Carp 'croak';
 
 sub create {
@@ -13,8 +13,8 @@ sub create {
     $name = Dancer2::Core::camelize($name);
     my $component_class = "Dancer2::${type}::${name}";
 
-    my ( $ok, $error ) = try_load_class($component_class);
-    $ok or croak "Unable to load class for $type component $name: $error";
+    eval { use_module($component_class); 1; }
+        or croak "Unable to load class for $type component $name: $@";
 
     return $component_class->new(%options);
 }

--- a/lib/Dancer2/Core/MIME.pm
+++ b/lib/Dancer2/Core/MIME.pm
@@ -6,6 +6,7 @@ use Moo;
 
 use Plack::MIME;
 use Dancer2::Core::Types;
+use Module::Runtime 'require_module';
 
 # Initialise MIME::Types at compile time, to ensure it's done before
 # the fork in a preforking webserver like mod_perl or Starman. Not
@@ -13,7 +14,7 @@ use Dancer2::Core::Types;
 # as MIME::Types fails to load its mappings from the DATA handle. See
 # t/04_static_file/003_mime_types_reinit.t and GH#136.
 BEGIN {
-    if ( eval { require MIME::Types; 1; } ) {
+    if ( eval { require_module('MIME::Types'); 1; } ) {
         my $mime_types = MIME::Types->new(only_complete => 1);
         Plack::MIME->set_fallback(
             sub {

--- a/lib/Dancer2/Core/MIME.pm
+++ b/lib/Dancer2/Core/MIME.pm
@@ -4,7 +4,6 @@ package Dancer2::Core::MIME;
 
 use Moo;
 
-use Class::Load 'try_load_class';
 use Plack::MIME;
 use Dancer2::Core::Types;
 
@@ -14,7 +13,7 @@ use Dancer2::Core::Types;
 # as MIME::Types fails to load its mappings from the DATA handle. See
 # t/04_static_file/003_mime_types_reinit.t and GH#136.
 BEGIN {
-    if ( try_load_class('MIME::Types') ) {
+    if ( eval { require MIME::Types; 1; } ) {
         my $mime_types = MIME::Types->new(only_complete => 1);
         Plack::MIME->set_fallback(
             sub {

--- a/lib/Dancer2/Core/Request.pm
+++ b/lib/Dancer2/Core/Request.pm
@@ -12,6 +12,7 @@ use URI;
 use URI::Escape;
 use Safe::Isa;
 use Hash::MultiValue;
+use Module::Runtime 'require_module';
 
 use Dancer2::Core::Types;
 use Dancer2::Core::Request::Upload;
@@ -36,8 +37,8 @@ sub $_ { \$_[0]->env->{ 'HTTP_' . ( uc $_ ) } }
 _EVAL
 
 # check presence of XS module to speedup request
-our $XS_URL_DECODE         = eval { require URL::Encode::XS; 1; };
-our $XS_PARSE_QUERY_STRING = eval { require CGI::Deurl::XS;  1; };
+our $XS_URL_DECODE         = eval { require_module('URL::Encode::XS'); 1; };
+our $XS_PARSE_QUERY_STRING = eval { require_module('CGI::Deurl::XS');  1; };
 
 our $_id = 0;
 

--- a/lib/Dancer2/Core/Request.pm
+++ b/lib/Dancer2/Core/Request.pm
@@ -10,7 +10,6 @@ use Encode;
 use HTTP::Body;
 use URI;
 use URI::Escape;
-use Class::Load 'try_load_class';
 use Safe::Isa;
 use Hash::MultiValue;
 
@@ -37,8 +36,8 @@ sub $_ { \$_[0]->env->{ 'HTTP_' . ( uc $_ ) } }
 _EVAL
 
 # check presence of XS module to speedup request
-our $XS_URL_DECODE         = try_load_class('URL::Encode::XS');
-our $XS_PARSE_QUERY_STRING = try_load_class('CGI::Deurl::XS');
+our $XS_URL_DECODE         = eval { require URL::Encode::XS; 1; };
+our $XS_PARSE_QUERY_STRING = eval { require CGI::Deurl::XS;  1; };
 
 our $_id = 0;
 

--- a/lib/Dancer2/Core/Request/Upload.pm
+++ b/lib/Dancer2/Core/Request/Upload.pm
@@ -5,6 +5,7 @@ use Moo;
 
 use Carp;
 use File::Spec;
+use Module::Runtime 'require_module';
 
 use Dancer2::Core::Types;
 use Dancer2::FileUtils qw(open_file);
@@ -38,7 +39,7 @@ sub file_handle {
 
 sub copy_to {
     my ( $self, $target ) = @_;
-    require File::Copy;
+    require_module('File::Copy');
     File::Copy::copy( $self->tempname, $target );
 }
 
@@ -68,7 +69,7 @@ sub content {
 
 sub basename {
     my ($self) = @_;
-    require File::Basename;
+    require_module('File::Basename');
     File::Basename::basename( $self->filename );
 }
 

--- a/lib/Dancer2/Core/Role/ConfigReader.pm
+++ b/lib/Dancer2/Core/Role/ConfigReader.pm
@@ -7,6 +7,7 @@ use File::Spec;
 use Config::Any;
 use Hash::Merge::Simple;
 use Carp 'croak';
+use Module::Runtime 'require_module';
 
 use Dancer2::Core::Factory;
 use Dancer2::Core;
@@ -222,7 +223,7 @@ my $_normalizers = {
         my ($charset) = @_;
         return $charset if !length( $charset || '' );
 
-        require Encode;
+        require_module('Encode');
         my $encoding = Encode::find_encoding($charset);
         croak
           "Charset defined in configuration is wrong : couldn't identify '$charset'"

--- a/lib/Dancer2/Core/Role/SessionFactory.pm
+++ b/lib/Dancer2/Core/Role/SessionFactory.pm
@@ -10,6 +10,7 @@ use Dancer2::Core::Types;
 use Digest::SHA 'sha1';
 use List::Util 'shuffle';
 use MIME::Base64 'encode_base64url';
+use Module::Runtime 'require_module';
 
 sub hook_aliases { +{} }
 sub supported_hooks {
@@ -103,8 +104,8 @@ sub create {
 
 {
     my $COUNTER     = 0;
-    my $CPRNG_AVAIL = eval { require Math::Random::ISAAC::XS; 1; } &&
-                      eval { require Crypt::URandom; 1; };
+    my $CPRNG_AVAIL = eval { require_module('Math::Random::ISAAC::XS'); 1; } &&
+                      eval { require_module('Crypt::URandom'); 1; };
 
     # don't initialize until generate_id is called so the ISAAC algorithm
     # is seeded after any pre-forking

--- a/lib/Dancer2/Core/Role/SessionFactory.pm
+++ b/lib/Dancer2/Core/Role/SessionFactory.pm
@@ -5,7 +5,6 @@ use Moo::Role;
 with 'Dancer2::Core::Role::Engine';
 
 use Carp 'croak';
-use Class::Load 'try_load_class';
 use Dancer2::Core::Session;
 use Dancer2::Core::Types;
 use Digest::SHA 'sha1';
@@ -104,8 +103,8 @@ sub create {
 
 {
     my $COUNTER     = 0;
-    my $CPRNG_AVAIL = try_load_class('Math::Random::ISAAC::XS') &&
-                      try_load_class('Crypt::URandom');
+    my $CPRNG_AVAIL = eval { require Math::Random::ISAAC::XS; 1; } &&
+                      eval { require Crypt::URandom; 1; };
 
     # don't initialize until generate_id is called so the ISAAC algorithm
     # is seeded after any pre-forking

--- a/lib/Dancer2/Core/Runner.pm
+++ b/lib/Dancer2/Core/Runner.pm
@@ -3,6 +3,7 @@ package Dancer2::Core::Runner;
 
 use Moo;
 use Carp 'croak';
+use Module::Runtime 'require_module';
 use Dancer2::Core::MIME;
 use Dancer2::Core::Types;
 use Dancer2::Core::Dispatcher;
@@ -75,7 +76,7 @@ has timeout => (
 sub _build_server {
     my $self = shift;
 
-    require HTTP::Server::PSGI;
+    require_module('HTTP::Server::PSGI');
     HTTP::Server::PSGI->new(
         host            => $self->host,
         port            => $self->port,
@@ -110,7 +111,7 @@ sub BUILD {
 
     # Enable traces if set by ENV var.
     if (my $traces = $self->config->{traces} ) {
-        require Carp;
+        require_module('Carp');
         $Carp::Verbose = $traces ? 1 : 0;
     };
 

--- a/lib/Dancer2/Plugin.pm
+++ b/lib/Dancer2/Plugin.pm
@@ -7,6 +7,7 @@ use warnings;
 use Moo;
 use Carp;
 use List::Util qw/ reduce /;
+use Module::Runtime 'require_module';
 use Attribute::Handlers;
 use Scalar::Util;
 
@@ -317,7 +318,7 @@ sub _exporter_app {
 # a D2P2 class, with exported keywords
 sub _exporter_plugin {
     my $caller = shift;
-    require Dancer2::Core::DSL;
+    require_module('Dancer2::Core::DSL');
     my $keywords_list = join ' ', keys %{ Dancer2::Core::DSL->dsl_keywords };
 
     eval <<"END"; ## no critic

--- a/lib/Dancer2/Serializer/YAML.pm
+++ b/lib/Dancer2/Serializer/YAML.pm
@@ -4,7 +4,7 @@ package Dancer2::Serializer::YAML;
 use Moo;
 use Carp 'croak';
 use Encode;
-use Class::Load 'load_class';
+use Module::Runtime 'use_module';
 
 with 'Dancer2::Core::Role::Serializer';
 
@@ -16,7 +16,7 @@ sub from_yaml { __PACKAGE__->deserialize(@_) }
 sub to_yaml { __PACKAGE__->serialize(@_) }
 
 # class definition
-sub BUILD { load_class('YAML') }
+sub BUILD { use_module('YAML') }
 
 sub serialize {
     my ( $self, $entity ) = @_;

--- a/t/classes/Dancer2-Core-Request/serializers.t
+++ b/t/classes/Dancer2-Core-Request/serializers.t
@@ -3,7 +3,6 @@ use warnings;
 use Test::More;
 use Plack::Test;
 use HTTP::Request::Common;
-use Class::Load 'try_load_class';
 
 {
     package App::CBOR; ## no critic
@@ -21,10 +20,10 @@ use Class::Load 'try_load_class';
 }
 
 subtest 'Testing with CBOR' => sub {
-    try_load_class('CBOR::XS')
+    eval { require CBOR::XS; 1; }
         or plan skip_all => 'CBOR::XS is needed for this test';
 
-    try_load_class('Dancer2::Serializer::CBOR')
+    eval { require Dancer2::Serializer::CBOR; 1; }
         or plan skip_all => 'Dancer2::Serializer::CBOR is needed for this test';
 
     App::CBOR->setup;

--- a/t/deserialize.t
+++ b/t/deserialize.t
@@ -63,7 +63,7 @@ my $app = App->to_app;
 use utf8;
 use JSON;
 use Encode;
-use Class::Load 'load_class';
+use Module::Runtime 'use_module';
 
 note "Verify Serializers decode into characters"; {
     my $utf8 = '∮ E⋅da = Q,  n → ∞, ∑ f(i) = ∏ g(i)';
@@ -73,7 +73,7 @@ note "Verify Serializers decode into characters"; {
 
         for my $type ( qw/Dumper JSON YAML/ ) {
             my $class = "Dancer2::Serializer::$type";
-            load_class($class);
+            use_module($class);
 
             my $serializer = $class->new();
             my $body = $serializer->serialize({utf8 => $utf8});

--- a/t/hooks.t
+++ b/t/hooks.t
@@ -4,11 +4,10 @@ use Test::More;
 use File::Spec;
 use Plack::Test;
 use HTTP::Request::Common;
-use Class::Load 'try_load_class';
 use Capture::Tiny 0.12 'capture_stderr';
 use JSON;
 
-try_load_class('Template')
+eval { require Template; 1; }
     or plan skip_all => 'Template::Toolkit not present';
 
 my $tests_flags = {};

--- a/t/memory_cycles.t
+++ b/t/memory_cycles.t
@@ -2,10 +2,9 @@ use strict;
 use warnings;
 use Test::More;
 use Test::Fatal;
-use Class::Load 'try_load_class';
 use Plack::Test;
 
-try_load_class('Test::Memory::Cycle')
+eval { require Test::Memory::Cycle; 1; }
     or plan skip_all => 'Test::Memory::Cycle not present';
 
 {

--- a/t/session_object.t
+++ b/t/session_object.t
@@ -7,12 +7,11 @@ use Test::Fatal;
 
 use Dancer2::Core::Session;
 use Dancer2::Session::Simple;
-use Class::Load 'try_load_class';
 
 my $ENGINE = Dancer2::Session::Simple->new;
 
-my $CPRNG_AVAIL = try_load_class('Math::Random::ISAAC::XS')
-  && try_load_class('Crypt::URandom');
+my $CPRNG_AVAIL = eval { require Math::Random::ISAAC::XS; 1; }
+  && eval { require Crypt::URandom; 1; };
 
 note $CPRNG_AVAIL
   ? "Crypto strength tokens"

--- a/t/time.t
+++ b/t/time.t
@@ -3,12 +3,11 @@
 use strict;
 use warnings;
 use Test::More;
-use Class::Load 'try_load_class';
 
 my $mocked_epoch = 1355676244;    # "Sun, 16-Dec-2012 16:44:04 GMT"
 
 # The order is important!
-try_load_class('Test::MockTime')
+eval { require Test::MockTime; 1; }
     or plan skip_all => 'Test::MockTime not present';
 
 Test::MockTime::set_fixed_time($mocked_epoch);


### PR DESCRIPTION
This addresses #1145.

Module::Runtime is a faster module than Class::Load (even with
Class::Load::XS available) and is already available by our stack.

If and when App::Cmd removes its dependency on Class::Load, we
will not require this by our stack at all.