### PR TITLE
Bugfix/forward proxy

### DIFF
--- a/lib/Dancer2/Core/App.pm
+++ b/lib/Dancer2/Core/App.pm
@@ -1198,6 +1198,8 @@ sub make_forward_to {
     $new_request->{_route_params} = $request->{_route_params};
     $new_request->{body}          = $request->body;
     $new_request->{headers}       = $request->headers;
+    # Copy remaining settings
+    $new_request->{is_behind_proxy} = $request->{is_behind_proxy};
 
     # If a session object was created during processing of the original request
     # i.e. a session object exists but no cookie existed

--- a/t/forward.t
+++ b/t/forward.t
@@ -6,6 +6,8 @@ use HTTP::Request::Common;
 
 use Dancer2;
 
+set behind_proxy => 1;
+
 get '/' => sub {
     'home:' . join( ',', params );
 };
@@ -24,6 +26,12 @@ post '/simple_post_route/' => sub {
 get '/go_to_post/' => sub {
     return forward '/simple_post_route/', { foo => 'bar' },
       { method => 'post' };
+};
+get '/proxy/' => sub {
+    return uri_for('/');
+};
+get '/forward_with_proxy/' => sub {
+    forward '/proxy/';
 };
 
 # NOT SUPPORTED IN DANCER2
@@ -163,6 +171,12 @@ test_psgi $app, sub {
             '[POST /bounce/] Correct Server',
         );
     }
+
+    is(
+        $cb->( GET '/forward_with_proxy/', 'X-Forwarded-Proto' => 'https' )->content,
+        'https://localhost/',
+        '[GET /forward_with_proxy/] maintained is_behind_proxy',
+    );
 };
 
 done_testing;


### PR DESCRIPTION
Copy `is_behind_proxy` (which comes from the `behind_proxy` setting) into new request on forward.

Resolves #1165