### PR TITLE
Don't call private method for Request query params 

### DIFF
--- a/lib/Dancer2/Core/Request.pm
+++ b/lib/Dancer2/Core/Request.pm
@@ -345,7 +345,7 @@ sub query_parameters {
             );
         } else {
             # defer to Plack::Request
-            $self->_parse_query;
+            $self->SUPER::query_parameters;
         }
     };
 }


### PR DESCRIPTION
Private methods are, well private. The may change.

The Plack 1.0040 (TRIAL) release removes the _parse_query method which
we were calling. Far safer to call the overridden public method via SUPER.

(Similar fix to #1148 for body params)