### PR TITLE
Rebased: Add `send_as` keyword (from Dancer2::Plugin::SendAs)

### DIFF
--- a/lib/Dancer2/Core/App.pm
+++ b/lib/Dancer2/Core/App.pm
@@ -46,7 +46,7 @@ sub _with_plugin {
 
     if ( ref $plugin ) {
         # passing the plugin as an already-created object
-        
+
         # already loaded?
         if( my ( $already ) = grep { ref($plugin) eq ref $_; } @{ $self->plugins } ) {
                 die "trying to load two different objects for plugin ". ref $plugin
@@ -64,7 +64,7 @@ sub _with_plugin {
 
     # check if it's already there
     if( my ( $already ) = grep { $plugin eq ref $_ } @{ $self->plugins } ) {
-        return $already;    
+        return $already;
     }
 
     push @{ $self->plugins }, 
@@ -1000,7 +1000,7 @@ sub finish {
     $self->register_route_handlers;
     $self->compile_hooks;
 
-    @{$self->plugins} 
+    @{$self->plugins}
         && $self->plugins->[0]->can('_add_postponed_plugin_hooks')
         && $self->plugins->[0]->_add_postponed_plugin_hooks(
             $self->postponed_hooks
@@ -1598,7 +1598,7 @@ current one.
 
 =method with_plugins( @plugin_names )
 
-Creates instances of the given plugins and tie them to the app. 
+Creates instances of the given plugins and tie them to the app.
 The plugin classes are automatically loaded.
 Returns the newly created plugins.
 

--- a/lib/Dancer2/Core/DSL.pm
+++ b/lib/Dancer2/Core/DSL.pm
@@ -98,6 +98,7 @@ sub dsl_keywords {
         response_header      => { is_global => 0 },
         response_headers     => { is_global => 0 },
         runner               => { is_global => 1 },
+        send_as              => { is_global => 0 },
         send_error           => { is_global => 0 },
         send_file            => { is_global => 0 },
         session              => { is_global => 0 },
@@ -178,6 +179,8 @@ sub session {
         $session->delete($key);
     }
 }
+
+sub send_as { shift->app->send_as(@_) }
 
 sub send_error { shift->app->send_error(@_) }
 

--- a/lib/Dancer2/Manual.pod
+++ b/lib/Dancer2/Manual.pod
@@ -2822,15 +2822,18 @@ Returns request header(s).
     get '/get/headers' => sub {
         my $xfoo = request_header 'X-Foo';
         ...
+    };
+
 =head2 send_as
 
 Allows the current route handler to return specific content types to the
 client using either a specified serializer or as html.
 
-Any Dancer2 serializer may be used, serialization classes will be loaded
-as required. Serializer configuration may be added to your apps
-C<engines> configuration. If no serializer can be found or C<HTML> is
-specified, the content will be returned assuming it is HTML with
+Any Dancer2 serializer may be used. The specified serializer class will
+be loaded if required, or an error generated if the class can not be found.
+Serializer configuration may be added to your apps C<engines> configuration.
+
+If C<HTML> is specified, the content will be returned assuming it is HTML with
 appropriate C<Content-Type> headers and encoded using the apps configured
 C<charset> (or UTF-8).
 

--- a/lib/Dancer2/Manual.pod
+++ b/lib/Dancer2/Manual.pod
@@ -2822,6 +2822,50 @@ Returns request header(s).
     get '/get/headers' => sub {
         my $xfoo = request_header 'X-Foo';
         ...
+=head2 send_as
+
+Allows the current route handler to return specific content types to the
+client using either a specified serializer or as html.
+
+Any Dancer2 serializer may be used, serialization classes will be loaded
+as required. Serializer configuration may be added to your apps
+C<engines> configuration. If no serializer can be found or C<HTML> is
+specified, the content will be returned assuming it is HTML with
+appropriate C<Content-Type> headers and encoded using the apps configured
+C<charset> (or UTF-8).
+
+    set serializer => 'YAML';
+    set template   => 'TemplateToolkit';
+
+    # returns html (not YAML)
+    get '/' => sub { send_as HTML => template 'welcome.tt' };
+
+    # return json (not YAML)
+    get '/json' => sub {
+        send_as JSON => [ some => { data => 'structure' } ];
+    };
+
+C<send_as> uses L<send_file> to return the content immediately. You may
+pass any option C<send_file> supports as an extra option. For example:
+
+    # return json with a custom content_type header
+    get '/json' => sub {
+        send_as JSON => [ some => { data => 'structure' } ],
+                { content_type => 'application/json; charset=UTF-8' },
+    };
+
+B<WARNING:> Issuing a send_as immediately exits the current route, and
+performs the C<send_as>. Thus, any code after a C<send_as> is ignored,
+until the end of the route. Hence, it's not necessary to use C<return>
+with C<send_as>.
+
+    get '/some/route' => sub {
+        if (...) {
+            send_as JSON => $some_data;
+
+            # this code will be ignored
+            do_stuff();
+        }
     };
 
 =head2 send_error

--- a/t/dsl/send_as.t
+++ b/t/dsl/send_as.t
@@ -1,0 +1,79 @@
+use strict;
+use warnings;
+
+use Test::More import => ['!pass'];
+use Plack::Test;
+use HTTP::Request::Common;
+
+{
+    package Test::App::SendAs;
+    use Dancer2;
+
+    set serializer => 'YAML';
+    set template => 'TemplateToolkit';
+
+    get '/html' => sub {
+        send_as HTML => '<html></html>'
+    };
+
+    get '/json/**' => sub {
+        send_as JSON => splat;
+    };
+
+    get '/json-utf8/**' => sub {
+        send_as JSON => splat, { content_type => 'application/json; charset=utf-8' };
+    };
+
+    get '/yaml/**' => sub {
+        my @params = splat;
+        \@params;
+    };
+
+}
+
+my $test = Plack::Test->create( Test::App::SendAs->to_app );
+
+note "default serializer"; {
+    my $res = $test->request( GET '/yaml/is/useful' );
+    is $res->code, '200';
+    is $res->content_type, 'text/x-yaml';
+
+    my $expected = <<'YAML';
+---
+-
+  - is
+  - useful
+YAML
+
+    is $res->content, $expected;
+
+}
+
+note "send_as json"; {
+    my $res = $test->request( GET '/json/is/wonderful' );
+    is $res->code, '200';
+    is $res->content_type, 'application/json';
+
+    is $res->content, '["is","wonderful"]';
+}
+
+note "send_as json custom content-type"; {
+    my $res = $test->request( GET '/json-utf8/is/wonderful' );
+    is $res->code, '200';
+    is $res->content_type, 'application/json';
+    is $res->content_type_charset, 'UTF-8';
+
+    is $res->content, '["is","wonderful"]';
+}
+
+
+note "send_as html"; {
+    my $res = $test->request( GET '/html' );
+    is $res->code, '200';
+    is $res->content_type, 'text/html';
+    is $res->content_type_charset, 'UTF-8';
+
+    is $res->content, '<html></html>';
+}
+
+done_testing();


### PR DESCRIPTION
This is #1141 rebased onto current master with the following changes:
  * Uses Module::Runtime instead of Class::Load
  * The "types" must match the casing of the serializer names; i.e. `send_as JSON => $data`
to clean up the last concerns from @xsawyerx.

@xsawyerx @SysPete any chance of a quick review in time for the next release as #1141 had thumbs up :)