### PR TITLE
Reword logged error if serializaiton fails

### DIFF
--- a/lib/Dancer2/Core/Role/Serializer.pm
+++ b/lib/Dancer2/Core/Role/Serializer.pm
@@ -50,7 +50,7 @@ around serialize => sub {
     } or do {
         my $error = $@ || 'Zombie Error';
         blessed $self
-            and $self->log_cb->( core => "Failed to serialize the request: $error" );
+            and $self->log_cb->( core => "Failed to serialize content: $error" );
     };
 
     return $data;

--- a/t/classes/Dancer2-Core-Role-Serializer/with.t
+++ b/t/classes/Dancer2-Core-Role-Serializer/with.t
@@ -85,7 +85,7 @@ subtest 'Unsuccessful' => sub {
         is( $msg->{'level'}, 'core', 'Correct level' );
         like(
             $msg->{'message'},
-            qr{^Failed to serialize the request: \+foo\+},
+            qr{^Failed to serialize content: \+foo\+},
             'Correct error message',
         );
     }


### PR DESCRIPTION
Serializers can be used in more places that request/response data.
Having serializers log serialization errors against the "request" is
likely to be confusing.

Instead, log the failure stating we failed to serialize the "content",
which is applicable for a response body, or some other data that failed
to serialize elsewhere.

Resolves #1152.