### PR TITLE
Update plugin tests to stop deprecation warnings.

### DIFF
--- a/t/lib/Dancer2/Plugin/DancerPlugin.pm
+++ b/t/lib/Dancer2/Plugin/DancerPlugin.pm
@@ -16,11 +16,12 @@ register around_get => sub {
 
 register install_hooks => sub {
     my $dsl = shift;
-    $dsl->hook(
-        'before' => sub {
+    $dsl->app->add_hook( Dancer2::Core::Hook->new(
+        name => 'before',
+        code => sub {
             $dsl->session( before_plugin => ++$counter );
         }
-    );
+    ));
 };
 
 register_plugin;

--- a/t/lib/Dancer2/Plugin/FooPlugin.pm
+++ b/t/lib/Dancer2/Plugin/FooPlugin.pm
@@ -11,12 +11,12 @@ sub _html_sitemap {
 }
 
 register foo_wrap_request => sub {
-    my ($self) = plugin_args(@_);
-    return $self->request;
+    my ($self) = @_;
+    return $self->app->request;
 }, { is_global => 0 };
 
 register foo_route => sub {
-    my ($self) = plugin_args(@_);
+    my ($self) = @_;
     $self->get( '/foo', sub {'foo'} );
 } => { is_global => 1, prototype => '$@' };
 


### PR DESCRIPTION
As pointed out by @veryrusty we have some plugin tests that are using deprecated methods.

- Stop using `plugin_args` and `hook`
- Call `request` as `app->request`.