### PR TITLE
Stop using Test::Deep since we don't declare it as a build dep

### DIFF
--- a/t/plugin2/define-keywords.t
+++ b/t/plugin2/define-keywords.t
@@ -2,7 +2,6 @@ use strict;
 use warnings;
 
 use Test::More tests => 1;
-use Test::Deep;
 
 BEGIN {  
     package Dancer2::Plugin::Foo;
@@ -39,5 +38,5 @@ BEGIN {
 
 my $plugin = Dancer2::Plugin::Foo->new( app => undef );
 
-cmp_deeply [ keys %{ $plugin->keywords } ], 
-    bag( @::expected_keywords), "all expected keywords";
+is_deeply [ sort keys %{ $plugin->keywords } ], 
+    [ sort @::expected_keywords ], "all expected keywords";

--- a/t/plugin2/keywords-hooks-namespace.t
+++ b/t/plugin2/keywords-hooks-namespace.t
@@ -26,7 +26,6 @@ BEGIN {
 }
 
 use Test::More;
-use Test::Deep;
 
 my %tests = (
     'Plugin1' => { keywords => [ 'one' ], hooks => [ 'un' ] },
@@ -50,7 +49,6 @@ subtest app_side => sub {
     use Dancer2::Plugin::Plugin2;
 
     use Test::More;
-    use Test::Deep;
 
     Test::More::is one() => 'uno', 'from plugin1';
     Test::More::is two() => 'dos', 'from plugin2';

--- a/t/plugin2/with-plugins.t
+++ b/t/plugin2/with-plugins.t
@@ -1,8 +1,7 @@
 use strict;
 use warnings;
 
-use Test::More tests => 6;
-use Test::Deep;
+use Test::More tests => 8;
 use Scalar::Util qw/ refaddr /;
 
 {
@@ -31,28 +30,28 @@ my $plugin = $app->with_plugin('Foo');
 
 isa_ok $plugin => 'Dancer2::Plugin';
 
-cmp_deeply $app->plugins => [ 
-    isa('Dancer2::Plugin::Foo') 
-], "app has the plugin";
+cmp_ok @{ $app->plugins }, '==', 1, "app has one plugin";
+cmp_ok ref($app->plugins->[0]), 'eq', 'Dancer2::Plugin::Foo' , "app has plugin Foo";
 
 my $same_plugin =  $app->with_plugin('Foo');
 
 is refaddr $same_plugin => refaddr $plugin,
     "plugin is not redefined";
 
-cmp_deeply $app->plugins => [ 
-    isa('Dancer2::Plugin::Foo') 
-], "still a single plugin";
+cmp_ok @{ $app->plugins }, '==', 1, "app still has one plugin";
+cmp_ok ref($app->plugins->[0]), 'eq', 'Dancer2::Plugin::Foo' , "app has plugin Foo";
 
 subtest "adding plugin Bar" => sub {
     my $plugin = $app->with_plugin('Bar');
 
     isa_ok $plugin => 'Dancer2::Plugin';
 
-    cmp_deeply $app->plugins => [ 
-        isa('Dancer2::Plugin::Foo'),
-        isa('Dancer2::Plugin::Bar') 
-    ], "app has both plugins";
+    cmp_ok @{ $app->plugins }, '==', 2, "app has two plugins";
+
+    cmp_ok ref($app->plugins->[0]), 'eq', 'Dancer2::Plugin::Foo',
+      "app has plugin Foo";
+    cmp_ok ref($app->plugins->[1]), 'eq', 'Dancer2::Plugin::Bar',
+      "app has plugin Bar";
 };
 
 subtest "adding as an object" => sub {
@@ -61,9 +60,12 @@ subtest "adding as an object" => sub {
 
     is refaddr $p => refaddr $plugin, "it's the same";
 
-    cmp_deeply $app->plugins => [ 
-        isa('Dancer2::Plugin::Foo'),
-        isa('Dancer2::Plugin::Bar'),
-        isa('Dancer2::Plugin::Baz') 
-    ], "app has all 3 plugins";
+    cmp_ok @{ $app->plugins }, '==', 3, "app has three plugins";
+
+    cmp_ok ref($app->plugins->[0]), 'eq', 'Dancer2::Plugin::Foo',
+      "app has plugin Foo";
+    cmp_ok ref($app->plugins->[1]), 'eq', 'Dancer2::Plugin::Bar',
+      "app has plugin Bar";
+    cmp_ok ref($app->plugins->[2]), 'eq', 'Dancer2::Plugin::Baz',
+      "app has plugin Baz";
 };


### PR DESCRIPTION
Before plugin2 we didn't use Test::Deep and for the few tests for which it was used it is simple enough to rework these tests to use something else.

This is an alternative option to PR #1176 which adds a dep on Test::Deep.