### PR TITLE
Config take2

### DIFF
--- a/lib/Dancer2/Config.pod
+++ b/lib/Dancer2/Config.pod
@@ -29,20 +29,42 @@ those settings into a configuration file.
 
 =head2 Configuration file path and file names
 
-Dancer2 will first look for the file F<config.ext> (where .ext is the type
-of configuration file you are using) in the root directory of your
-application.  This is considered your global Dancer2 config file.  If you do
-not care to have separate settings for production and development
-environments (B<not> a recommended practice!), then this file is all you
-need.
+Dancer2 will first look for the file F<config.EXT> (where F<EXT> is the
+type of configuration file you are using; e.g. F<ini> or F<json> or
+F<yml>) in the root directory of your application. This is considered
+your global Dancer2 config file. If you do not care to have separate
+settings for production and development environments (B<not> a
+recommended practice!), then this file is all you need.
+
+Next, Dancer2 will look for a file called F<config_local.EXT>. This file
+is typically useful for deployment-specific configuration that should
+not be checked into source control. For instance, database credentials
+could be stored in this file.  Any settings in this file are merged into
+the existing configuration such that those with the same name in your 
+global configuration file will take precedence over those settings in 
+the global file. 
 
 Next, Dancer2 will look in the F<environments> directory for a configuration
-file specific to the platform you are deploying to (F<production.ext> and
-F<development.ext>, for example).  Any settings in these files that are
-named the same as settings in your global configuration file will take
-precedence over those settings in the global file. The rest of the settings
-are merged and Dancer2 uses the combination of settings from the two files
-as its operating configuration.
+file specific to the platform you are deploying to (F<production.EXT> or
+F<development.EXT>, for example).  Again, the configuration from the environment
+is merged with the existing configuration with the deployment config taking
+precedence.
+
+Finally, Dancer2 will look in the F<environments> directory for a
+local configuration for the specific platform you are deploying to
+(e.g. F<prodcution_local.EXT> or F<development_local.EXT>) 
+The configuration in this file is merged as before.
+
+Much like F<config_local.EXT>, this file would be useful for environment-
+specific configuration that would not be checked into source control.
+For instance, when developing an application that talks to multiple services, 
+each developer could have their own URLs to those services stored within
+their F<environments/development_local.yaml> file.
+
+Note, if there is no F<config.EXT>, Dancer2 will not look for a
+F<config_local.EXT>. The same is true for the local environment
+configuration.
+
 
 =head2 Supported configuration file formats
 
@@ -50,6 +72,13 @@ Dancer2 supports any configuration file format that is supported by
 L<Config::Any>.  At the time of this writing, that includes YAML (.yml and
 .yaml), JSON (.jsn and .json), INI (.ini), Apache-style configurations (.cnf
 and .conf), XML (.xml), and Perl-style hashes (.pl and .perl).
+
+Dancer2 iterates over these file extensions in the order provided by
+L<Config::Any> and loads any config files that it finds with later
+configuration information overriding earlier config information. To
+restrict which file extension Dancer2 looks for, you may set the
+C<DANCER_CONFIG_EXT> envinroment variable to a specific extension and
+Dancer2 will only look for config files with that extension.
 
 Make sure you pick the appropriate extension for your configuration file
 name, as Dancer2 guesses the type of format based on the file extension.

--- a/lib/Dancer2/Core/Role/ConfigReader.pm
+++ b/lib/Dancer2/Core/Role/ConfigReader.pm
@@ -143,7 +143,10 @@ sub _build_config {
 
     my $config = Hash::Merge::Simple->merge(
         $default,
-        map +( $self->load_config_file($_) ), @{ $self->config_files }
+        map {
+            warn "Merging config file $_\n" if $ENV{DANCER_CONFIG_VERBOSE};
+            $self->load_config_file($_) 
+        } @{ $self->config_files }
     );
 
     $config = $self->_normalize_config($config);

--- a/lib/Dancer2/Core/Role/ConfigReader.pm
+++ b/lib/Dancer2/Core/Role/ConfigReader.pm
@@ -126,7 +126,13 @@ sub _build_config_files {
         }
     }
 
-    return [ sort @files ];
+    # Look for *_local.ext files
+    @files = map {
+        (my $l = $_) =~ s/(\w+)(\.\w+)$/${1}_local$2/;
+        $_, (-r $l ? $l : () );
+    } sort @files;
+
+    return \@files;
 }
 
 sub _build_config {

--- a/lib/Dancer2/Core/Role/ConfigReader.pm
+++ b/lib/Dancer2/Core/Role/ConfigReader.pm
@@ -112,8 +112,20 @@ sub _build_config_files {
     return [] unless defined $location;
 
     my $running_env = $self->environment;
-    my @exts = Config::Any->extensions;
+    my @available_exts = Config::Any->extensions;
     my @files;
+
+    my @exts = @available_exts;
+    if (my $ext = $ENV{DANCER_CONFIG_EXT}) {
+        if (grep { $ext eq $_ } @available_exts) {
+            @exts = $ext;
+        } else {
+            warn "DANCER_CONFIG_EXT environment variable set to '$ext' which\n" .
+                 "is not recognized by Config::Any. Looking for config file\n" .
+                 "using default list of extensions:\n" .
+                 "\t@available_exts\n";
+        }
+    }
 
     foreach my $ext (@exts) {
         foreach my $file ( [ $location, "config.$ext" ],

--- a/lib/Dancer2/Core/Role/ConfigReader.pm
+++ b/lib/Dancer2/Core/Role/ConfigReader.pm
@@ -119,6 +119,8 @@ sub _build_config_files {
     if (my $ext = $ENV{DANCER_CONFIG_EXT}) {
         if (grep { $ext eq $_ } @available_exts) {
             @exts = $ext;
+            warn "Only looking for configs ending in '$ext'\n" 
+                if $ENV{DANCER_CONFIG_VERBOSE};
         } else {
             warn "DANCER_CONFIG_EXT environment variable set to '$ext' which\n" .
                  "is not recognized by Config::Any. Looking for config file\n" .

--- a/t/config2/config.yml
+++ b/t/config2/config.yml
@@ -1,0 +1,9 @@
+main: 1
+charset: 'UTF-8'
+show_errors: 1
+
+application:
+   feature_1: foo
+   feature_2: bar
+   feature_3: baz
+   feature_4: blat

--- a/t/config2/config_local.yml
+++ b/t/config2/config_local.yml
@@ -1,0 +1,4 @@
+application:
+    feature_2: alpha
+    feature_5: beta
+    feature_6: gamma

--- a/t/config2/environments/lconfig.yml
+++ b/t/config2/environments/lconfig.yml
@@ -1,0 +1,3 @@
+application:
+   feature_6: bar
+   feature_7: baz

--- a/t/config2/environments/lconfig_local.yml
+++ b/t/config2/environments/lconfig_local.yml
@@ -1,0 +1,3 @@
+application:
+   feature_3: replacement
+   feature_8: goober


### PR DESCRIPTION
@veryrusty @cromedome 

I've re-worked the configuration changes such that the configuration files are loaded the same as they are currently, but *_local.* files are looked for and loaded if present. i.e. for a development environment, the following config files will be loaded in this order if they exist: config.yml, config_local.yml, environments/development.yml environments/development_local.yml
It will still load config.yml and config.json if they both exist.

Also, you can restrict the extensions that Dancer2 will try to a single extension by setting the DANCER_CONFIG_EXT environment variable.

I added some tests, but more are probably needed.

And the things I'm less sure about ...

I also made it output some diagnostic information when loading the configuration files. You can turn it on by setting the DANCER_CONFIG_VERBOSE environment variable.

The diagnostic info is output using warn.   I tried $self->app->log but it didn't work for some reason and I'm too tired to investigate right now.  (maybe it didn't work because I'm too tired to do it correctly :)
