### PR TITLE
before_template vs before_template_render

### DIFF
--- a/lib/Dancer2/Manual.pod
+++ b/lib/Dancer2/Manual.pod
@@ -1277,7 +1277,7 @@ hashref as the third param to the template keyword:
     template 'index.tt', {}, { layout => undef };
 
 If your application is not mounted under root (C</>), you can use a
-C<before_template> hook instead of hardcoding the path into your application for your
+C<before_template_render> hook instead of hardcoding the path into your application for your
 CSS, images and JavaScript:
 
     hook before_template_render => sub {


### PR DESCRIPTION
before_template has been renamed before_template_render (lib/Dancer2/Core/Hook.pm lines 15-20)