### PR TITLE
don't use barewords under use strict

### DIFF
--- a/lib/Dancer2/Core/Request.pm
+++ b/lib/Dancer2/Core/Request.pm
@@ -32,8 +32,9 @@ my @http_env_keys = (qw/
 # apparently you can't eval core functions
 sub accept { $_[0]->env->{'HTTP_ACCEPT'} }
 
-eval << "_EVAL" for @http_env_keys; ## no critic
-sub $_ { \$_[0]->env->{ 'HTTP_' . ( uc $_ ) } }
+eval << "_EVAL" or die $@ for @http_env_keys; ## no critic
+sub $_ { \$_[0]->env->{ 'HTTP_' . ( uc "$_" ) } }
+1;
 _EVAL
 
 # check presence of XS module to speedup request


### PR DESCRIPTION
and report errors when dynamically creating subs.

Fixes https://github.com/PerlDancer/Dancer2/issues/1185
