### PR TITLE
Fix config option name in Dancer2::Core::Request documentation

### DIFF
--- a/lib/Dancer2/Core/Request.pm
+++ b/lib/Dancer2/Core/Request.pm
@@ -698,7 +698,7 @@ C<HTTP_FORWARDED_PROTO>.
 
 =item C<host>
 
-Checks whether we are behind a proxy using the C<is_behind_proxy>
+Checks whether we are behind a proxy using the C<behind_proxy>
 configuration option, and if so returns the first
 C<HTTP_X_FORWARDED_HOST>, since this is a comma separated list.
 


### PR DESCRIPTION
According to the `Dancer2::Config` documentation, the configuration option name is `behind_proxy`.