### PR TITLE
Add change_session_id method to App

### DIFF
--- a/lib/Dancer2/Core/App.pm
+++ b/lib/Dancer2/Core/App.pm
@@ -484,6 +484,37 @@ sub setup_session {
     }
 }
 
+sub change_session_id {
+    my $self = shift;
+
+    # Find the session engine
+    my $engine = $self->session_engine;
+
+    if ($engine->can('_change_id')) {
+        $engine->change_id;
+    }
+    else {
+
+        # grab data, destroy session and store data again
+        my $session = $self->session;
+        my %data = %{$session->data};
+
+        # destroy existing session
+        $self->destroy_session;
+
+        # get new session
+        $session = $self->session;
+
+        # write data from old session into new one
+        while (my ($key, $value) = each %data ) {
+            $session->write($key => $value);
+        }
+
+        # clear out destroyed session - no longer relevant
+        $self->clear_destroyed_session;
+    }
+}
+
 has prefix => (
     is        => 'rw',
     isa       => Maybe [Dancer2Prefix],

--- a/lib/Dancer2/Core/App.pm
+++ b/lib/Dancer2/Core/App.pm
@@ -487,6 +487,8 @@ sub setup_session {
 sub change_session_id {
     my $self = shift;
 
+    my $session;
+
     # Find the session engine
     my $engine = $self->session_engine;
 
@@ -496,7 +498,7 @@ sub change_session_id {
     else {
 
         # grab data, destroy session and store data again
-        my $session = $self->session;
+        $session = $self->session;
         my %data = %{$session->data};
 
         # destroy existing session
@@ -513,6 +515,8 @@ sub change_session_id {
         # clear out destroyed session - no longer relevant
         $self->clear_destroyed_session;
     }
+
+    return $session->id;
 }
 
 has prefix => (

--- a/lib/Dancer2/Core/App.pm
+++ b/lib/Dancer2/Core/App.pm
@@ -487,18 +487,19 @@ sub setup_session {
 sub change_session_id {
     my $self = shift;
 
-    my $session;
+    my $session = $self->session;
 
     # Find the session engine
     my $engine = $self->session_engine;
 
     if ($engine->can('_change_id')) {
-        $engine->change_id;
+
+        # session engine can change session ID
+        $engine->change_id( session => $session );
     }
     else {
 
         # grab data, destroy session and store data again
-        $session = $self->session;
         my %data = %{$session->data};
 
         # destroy existing session

--- a/lib/Dancer2/Core/App.pm
+++ b/lib/Dancer2/Core/App.pm
@@ -499,6 +499,25 @@ sub change_session_id {
     }
     else {
 
+        # Method order is important in here...
+        #
+        # On session build if there is no destroyed session then the session
+        # builder tries to recreate the session using the existing session
+        # cookie. We really don't want to do that in this case so it is
+        # important to create the new session before the
+        # clear_destroyed_session method is called.
+        #
+        # This sucks.
+        #
+        # Sawyer suggested:
+        #
+        # What if you take the session cookie logic out of that attribute into
+        # another attribute and clear that attribute?
+        # That would force the session rebuilt to rebuilt the attribute and
+        # get a different cookie value, no?
+        #
+        # TODO: think about this some more.
+
         # grab data, destroy session and store data again
         my %data = %{$session->data};
 

--- a/lib/Dancer2/Core/App.pm
+++ b/lib/Dancer2/Core/App.pm
@@ -511,9 +511,10 @@ sub change_session_id {
         # get new session
         $session = $self->session;
 
-        # write data from old session into new one
+        # write data from old session into new
+        # Some engines add session id to data so skip id.
         while (my ($key, $value) = each %data ) {
-            $session->write($key => $value);
+            $session->write($key => $value) unless $key eq 'id';
         }
     }
 

--- a/lib/Dancer2/Core/App.pm
+++ b/lib/Dancer2/Core/App.pm
@@ -505,9 +505,6 @@ sub change_session_id {
         # destroy existing session
         $self->destroy_session;
 
-        # clear out destroyed session - no longer relevant
-        $self->clear_destroyed_session;
-
         # get new session
         $session = $self->session;
 
@@ -516,6 +513,9 @@ sub change_session_id {
         while (my ($key, $value) = each %data ) {
             $session->write($key => $value) unless $key eq 'id';
         }
+
+        # clear out destroyed session - no longer relevant
+        $self->clear_destroyed_session;
     }
 
     return $session->id;

--- a/lib/Dancer2/Core/App.pm
+++ b/lib/Dancer2/Core/App.pm
@@ -505,6 +505,9 @@ sub change_session_id {
         # destroy existing session
         $self->destroy_session;
 
+        # clear out destroyed session - no longer relevant
+        $self->clear_destroyed_session;
+
         # get new session
         $session = $self->session;
 
@@ -512,9 +515,6 @@ sub change_session_id {
         while (my ($key, $value) = each %data ) {
             $session->write($key => $value);
         }
-
-        # clear out destroyed session - no longer relevant
-        $self->clear_destroyed_session;
     }
 
     return $session->id;

--- a/lib/Dancer2/Core/Role/SessionFactory.pm
+++ b/lib/Dancer2/Core/Role/SessionFactory.pm
@@ -366,6 +366,16 @@ found, triggers an exception.
 The method C<_retrieve> must be implemented.  It must take C<$id> as a single
 argument and must return a hash reference of session data.
 
+=head2 change_id
+
+Changes the session ID of the corresponding session.
+    
+    MySessionFactory->change_id(session => $session_object);
+
+The method C<_change_id> must be implemented. It must take C<$old_id> and
+C<$new_id> as arguments and change the ID from the old one to the new one
+in the underlying session storage.
+
 =head2 destroy
 
 Purges the session object that matches the ID given. Returns the ID of the

--- a/lib/Dancer2/Core/Role/SessionFactory/File.pm
+++ b/lib/Dancer2/Core/Role/SessionFactory/File.pm
@@ -8,6 +8,7 @@ use Carp 'croak';
 use Dancer2::Core::Types;
 use Dancer2::FileUtils qw(path set_file_mode escape_filename);
 use Fcntl ':flock';
+use File::Copy ();
 
 #--------------------------------------------------------------------------#
 # Required by classes consuming this role
@@ -71,6 +72,20 @@ sub _retrieve {
     close $fh or die "Can't close '$session_file': $!\n";
 
     return $data;
+}
+
+sub _change_id {
+    my ($self, $old_id, $new_id) = @_;
+
+    my $old_path =
+      path($self->session_dir, escape_filename($old_id) . $self->_suffix);
+
+    return if !-f $old_path;
+
+    my $new_path =
+      path($self->session_dir, escape_filename($new_id) . $self->_suffix);
+
+    File::Copy::move($old_path, $new_path);
 }
 
 sub _destroy {

--- a/lib/Dancer2/Manual.pod
+++ b/lib/Dancer2/Manual.pod
@@ -872,6 +872,12 @@ quickly and easily within your config file, for example:
 If the directory you specify does not exist, Dancer2 will attempt to create
 it for you.
 
+=head3 Changing session ID
+
+If you wish to change the session ID (for example on privilege level change):
+
+    my $new_session_id = app->change_session_id
+
 =head3 Destroying a session
 
 When you're done with your session, you can destroy it:

--- a/lib/Dancer2/Session/Simple.pm
+++ b/lib/Dancer2/Session/Simple.pm
@@ -25,6 +25,13 @@ sub _retrieve {
     return $s;
 }
 
+sub _change_id {
+    my ( $class, $old_id, $new_id ) = @_;
+
+    $SESSIONS->{$new_id} = $class->_retrieve($old_id);
+    delete $SESSIONS->{$old_id};
+}
+
 sub _destroy {
     my ( $class, $id ) = @_;
     delete $SESSIONS->{$id};

--- a/t/lib/Dancer2/Session/SimpleNoChangeId.pm
+++ b/t/lib/Dancer2/Session/SimpleNoChangeId.pm
@@ -1,0 +1,41 @@
+package Dancer2::Session::SimpleNoChangeId;
+# ABSTRACT: in-memory session backend for Dancer2
+#
+# This is a version of Dancer2::Session::Simple that does not support
+# _change_id thus using stash data/destroy/reload session
+
+use Moo;
+use Dancer2::Core::Types;
+use Carp;
+
+with 'Dancer2::Core::Role::SessionFactory';
+
+# The singleton that contains all the session objects created
+my $SESSIONS = {};
+
+sub _sessions {
+    my ($self) = @_;
+    return [ keys %{$SESSIONS} ];
+}
+
+sub _retrieve {
+    my ( $class, $id ) = @_;
+    my $s = $SESSIONS->{$id};
+
+    croak "Invalid session ID: $id"
+      if !defined $s;
+
+    return $s;
+}
+
+sub _destroy {
+    my ( $class, $id ) = @_;
+    delete $SESSIONS->{$id};
+}
+
+sub _flush {
+    my ( $class, $id, $data ) = @_;
+    $SESSIONS->{$id} = $data;
+}
+
+1;

--- a/t/session_hooks_no_change_id.t
+++ b/t/session_hooks_no_change_id.t
@@ -1,0 +1,195 @@
+use strict;
+use warnings;
+use Test::More;
+use Plack::Test;
+use HTTP::Cookies;
+use HTTP::Request::Common;
+use lib 't/lib';
+
+my @hooks_to_test = qw(
+  engine.session.before_retrieve
+  engine.session.after_retrieve
+
+  engine.session.before_create
+  engine.session.after_create
+
+  engine.session.before_change_id
+  engine.session.after_change_id
+
+  engine.session.before_destroy
+  engine.session.after_destroy
+
+  engine.session.before_flush
+  engine.session.after_flush
+);
+
+# we'll set a flag here when each hook is called. Then our test will then verify this
+my $test_flags = {};
+
+{
+    package App;
+    use Dancer2;
+
+    set(
+        show_errors => 1,
+        envoriment  => 'production'
+    );
+
+    setting( session => 'SimpleNoChangeId' );
+
+    for my $hook (@hooks_to_test) {
+        hook $hook => sub {
+            $test_flags->{$hook} ||= 0;
+            $test_flags->{$hook}++;
+        }
+    }
+
+    get '/set_session' => sub {
+        session foo => 'bar'; #setting causes a session flush
+        return "ok";
+    };
+
+    get '/get_session' => sub {
+        ::is session->read('foo'), 'bar', "Got the right session back";
+        return "ok";
+    };
+
+    get '/change_session_id' => sub {
+        app->change_session_id;
+        return "ok";
+    };
+
+    get '/destroy_session' => sub {
+        app->destroy_session;
+        return "ok";
+    };
+
+    #setup each hook again and test whether they return the correct type
+    #there is unfortunately quite some duplication here.
+    hook 'engine.session.before_create' => sub {
+        my ($response) = @_;
+        ::isa_ok( $response, 'Dancer2::Core::Session' );
+    };
+
+    hook 'engine.session.after_create' => sub {
+        my ($response) = @_;
+        ::isa_ok( $response, 'Dancer2::Core::Session' );
+    };
+
+    hook 'engine.session.after_retrieve' => sub {
+        my ($response) = @_;
+        ::isa_ok( $response, 'Dancer2::Core::Session' );
+    };
+}
+
+my $test = Plack::Test->create( App->to_app );
+my $jar  = HTTP::Cookies->new;
+my $url  = "http://localhost";
+
+is_deeply( $test_flags, {}, 'Make sure flag hash is clear' );
+
+subtest set_session => sub {
+    my $res = $test->request( GET "$url/set_session" );
+    is $res->content, "ok", "set_session ran ok";
+    $jar->extract_cookies($res);
+};
+
+# we verify whether the hooks were called correctly.
+subtest 'verify hooks for session create and session flush' => sub {
+    is $test_flags->{'engine.session.before_create'}, 1, "session.before_create called";
+    is $test_flags->{'engine.session.after_create'}, 1, "session.after_create called";
+    is $test_flags->{'engine.session.before_flush'}, 1, "session.before_flush called";
+    is $test_flags->{'engine.session.after_flush'}, 1, "session.after_flush called";
+
+    is $test_flags->{'engine.session.before_change_id'}, undef, "session.before_change_id not called";
+    is $test_flags->{'engine.session.after_change_id'}, undef, "session.after_change_id not called";
+    is $test_flags->{'engine.session.before_retrieve'}, undef, "session.before_retrieve not called";
+    is $test_flags->{'engine.session.after_retrieve'}, undef, "session.after_retrieve not called";
+    is $test_flags->{'engine.session.before_destroy'}, undef, "session.before_destroy not called";
+    is $test_flags->{'engine.session.after_destroy'}, undef, "session.after_destroy not called";
+};
+
+subtest 'verify Handler::File (static content) does not retrieve session' => sub {
+    my $req = GET "$url/file.txt";
+    $jar->add_cookie_header($req);
+    my $res = $test->request($req);
+    $jar->extract_cookies($res);
+
+    # These should not change from previous subtest
+    is $test_flags->{'engine.session.before_create'}, 1, "session.before_create not called";
+    is $test_flags->{'engine.session.after_create'}, 1, "session.after_create not called";
+    is $test_flags->{'engine.session.before_retrieve'}, undef, "session.before_retrieve not called";
+    is $test_flags->{'engine.session.after_retrieve'}, undef, "session.after_retrieve not called";
+};
+
+subtest get_session => sub {
+    my $req = GET "$url/get_session";
+    $jar->add_cookie_header($req);
+    my $res = $test->request($req);
+    is $res->content, "ok", "get_session ran ok";
+    $jar->extract_cookies($res);
+};
+
+subtest 'verify hooks for session retrieve' => sub {
+    is $test_flags->{'engine.session.before_retrieve'}, 1, "session.before_retrieve called";
+    is $test_flags->{'engine.session.after_retrieve'}, 1, "session.after_retrieve called";
+
+    is $test_flags->{'engine.session.before_create'}, 1, "session.before_create not called";
+    is $test_flags->{'engine.session.after_create'}, 1, "session.after_create not called";
+    is $test_flags->{'engine.session.before_flush'}, 1, "session.before_flush not called";
+    is $test_flags->{'engine.session.after_flush'}, 1, "session.after_flush not called";
+    is $test_flags->{'engine.session.before_change_id'}, undef, "session.before_change_id not called";
+    is $test_flags->{'engine.session.after_change_id'}, undef, "session.after_change_id not called";
+    is $test_flags->{'engine.session.before_destroy'}, undef, "session.before_destroy not called";
+    is $test_flags->{'engine.session.after_destroy'}, undef, "session.after_destroy not called";
+};
+
+subtest change_session_id => sub {
+    my $req = GET "$url/change_session_id";
+    $jar->add_cookie_header($req);
+    my $res = $test->request($req);
+    is $res->content, "ok", "get_session ran ok";
+    $jar->clear;
+    $jar->extract_cookies($res);
+};
+
+subtest 'verify hooks for change session id' => sub {
+    # change_session_id causes a retrieve
+    is $test_flags->{'engine.session.before_retrieve'}, 2, "session.before_retrieve called";
+    is $test_flags->{'engine.session.after_retrieve'}, 2, "session.after_retrieve called";
+
+    # and a new session is created since this engine doesn't have _change_id
+    is $test_flags->{'engine.session.before_create'}, 2, "session.before_create not called";
+    is $test_flags->{'engine.session.after_create'}, 2, "session.after_create not called";
+    # flushed as well
+    is $test_flags->{'engine.session.before_flush'}, 2, "session.before_flush not called";
+    is $test_flags->{'engine.session.after_flush'}, 2, "session.after_flush not called";
+    # these should never be called
+    is $test_flags->{'engine.session.before_change_id'}, undef, "session.before_change_id not called";
+    is $test_flags->{'engine.session.after_change_id'}, undef, "session.after_change_id not called";
+    # and the old session was destroyed
+    is $test_flags->{'engine.session.before_destroy'}, 1, "session.before_destroy not called";
+    is $test_flags->{'engine.session.after_destroy'}, 1, "session.after_destroy not called";
+};
+
+subtest destroy_session => sub {
+    my $req = GET "$url/destroy_session";
+    $jar->add_cookie_header($req);
+    my $res = $test->request($req);
+    is $res->content, "ok", "destroy_session ran ok";
+};
+
+subtest 'verify session destroy hooks' => sub {
+    is $test_flags->{'engine.session.before_destroy'}, 2, "session.before_destroy called";
+    is $test_flags->{'engine.session.after_destroy'}, 2, "session.after_destroy called";
+    #not sure if before and after retrieve should be called when the session is destroyed. But this happens.
+    is $test_flags->{'engine.session.before_retrieve'}, 3, "session.before_retrieve called";
+    is $test_flags->{'engine.session.after_retrieve'}, 3, "session.after_retrieve called";
+
+    is $test_flags->{'engine.session.before_create'}, 2, "session.before_create not called";
+    is $test_flags->{'engine.session.after_create'}, 2, "session.after_create not called";
+    is $test_flags->{'engine.session.before_flush'}, 2, "session.before_flush not called";
+    is $test_flags->{'engine.session.after_flush'}, 2, "session.after_flush not called";
+};
+
+done_testing;

--- a/t/session_lifecycle.t
+++ b/t/session_lifecycle.t
@@ -26,6 +26,13 @@ use HTTP::Cookies;
         "name='$name'";
     };
 
+    get '/change_session_id' => sub {
+        my $sid1 = session->id;
+        app->change_session_id;
+        my $sid2 = session->id;
+        return "changed from $sid1 to $sid2";
+    };
+
     get '/destroy_session' => sub {
         my $name = session('name') || '';
         app->destroy_session;
@@ -102,6 +109,39 @@ subtest 'Session cookie persists even if we do not touch sessions' => sub {
     ok( $jar->as_string, 'session cookie set again' );
 };
 
+my $sid2;
+subtest 'Change session ID' => sub {
+    my $req = GET "$url/change_session_id";
+    $jar->add_cookie_header($req);
+    my $res = $test->request($req);
+    ok $res->is_success, "/change_session_id";
+
+    $jar->clear;
+    ok( !$jar->as_string, 'Jar cleared' );
+
+    $jar->extract_cookies($res);
+    ok( $jar->as_string, 'session cookie set again' );
+
+    # extract SID
+    $jar->scan( sub { $sid2 = $_[2] } );
+    isnt $sid2, $sid1, "New session has different ID";
+};
+
+subtest 'Read value back after change_session_id' => sub {
+    # read value back
+    my $req = GET "$url/read_session";
+    $jar->add_cookie_header($req);
+    my $res = $test->request($req);
+    ok $res->is_success, "/read_session";
+
+    $jar->clear;
+    ok( !$jar->as_string, 'Jar cleared' );
+
+    $jar->extract_cookies($res);
+    ok( $jar->as_string, 'session cookie set again' );
+    like $res->content, qr/name='larry'/, "session value looks good";
+};
+
 subtest 'Destroy session and check that cookies expiration is set' => sub {
     my $req = GET "$url/destroy_session";
     $jar->add_cookie_header($req);
@@ -126,7 +166,7 @@ subtest 'Session cookie not sent after session destruction' => sub {
     ok( !$jar->as_string, 'Jar still empty (no new session cookie)' );
 };
 
-my $sid2;
+my $sid3;
 subtest 'Set value into session again' => sub {
     my $res = $test->request( GET "$url/set_session/curly" );
     ok $res->is_success, "/set_session/larry";
@@ -135,8 +175,8 @@ subtest 'Set value into session again' => sub {
     ok( $jar->as_string, 'session cookie set' );
 
     # extract SID
-    $jar->scan( sub { $sid2 = $_[2] } );
-    isnt $sid2, $sid1, "New session has different ID";
+    $jar->scan( sub { $sid3 = $_[2] } );
+    isnt $sid3, $sid2, "New session has different ID";
 };
 
 subtest 'Destroy and create a session in one request' => sub {
@@ -149,9 +189,9 @@ subtest 'Destroy and create a session in one request' => sub {
     $jar->extract_cookies($res);
     ok( $jar->as_string, 'session cookie set' );
 
-    my $sid3;
-    $jar->scan( sub { $sid3 = $_[2] } );
-    isnt $sid3, $sid2, "Changed session has different ID";
+    my $sid4;
+    $jar->scan( sub { $sid4 = $_[2] } );
+    isnt $sid4, $sid3, "Changed session has different ID";
 };
 
 subtest 'Read value back' => sub {

--- a/t/session_lifecycle.t
+++ b/t/session_lifecycle.t
@@ -44,164 +44,183 @@ use HTTP::Cookies;
 }
 
 my $url  = 'http://localhost';
-my $jar  = HTTP::Cookies->new();
 my $test = Plack::Test->create( App->to_app );
+my $app = Dancer2->runner->apps->[0];
 
-subtest 'No cookie set if session not referenced' => sub {
-    my $res = $test->request( GET "$url/no_session_data" );
-    ok $res->is_success, "/no_session_data"
-      or diag explain $res;
+for my $engine (qw(YAML Simple)) {
 
-    $jar->extract_cookies($res);
-    ok( !$jar->as_string, 'No cookie set' );
-};
+    # clear current session engine, and rebuild for the test
+    # This is *really* messy, playing in object hashrefs..
+    delete $app->{session_engine};
+    $app->config->{session} = $engine;
+    $app->session_engine;    # trigger a build
 
-subtest 'No empty session created if session read attempted' => sub {
-    my $res = $test->request( GET "$url/read_session" );
-    ok $res->is_success, "/read_session";
+    my $jar = HTTP::Cookies->new();
 
-    $jar->extract_cookies($res);
-    ok( !$jar->as_string, 'No cookie set' );
-};
+    subtest "[$engine] No cookie set if session not referenced" => sub {
+        my $res = $test->request(GET "$url/no_session_data");
+        ok $res->is_success, "/no_session_data"
+          or diag explain $res;
 
-my $sid1;
-subtest 'Set value into session' => sub {
-    my $res = $test->request( GET "$url/set_session/larry" );
-    ok $res->is_success, "/set_session/larry";
+        $jar->extract_cookies($res);
+        ok(!$jar->as_string, 'No cookie set');
+    };
 
-    $jar->extract_cookies($res);
-    ok( $jar->as_string, 'Cookie set' );
+    subtest "[$engine] No empty session created if session read attempted" =>
+      sub {
+        my $res = $test->request(GET "$url/read_session");
+        ok $res->is_success, "/read_session";
 
-    # extract SID
-    $jar->scan( sub { $sid1 = $_[2] } );
-    ok( $sid1, 'Got SID from cookie' );
-};
+        $jar->extract_cookies($res);
+        ok(!$jar->as_string, 'No cookie set');
+      };
 
-subtest 'Read value back' => sub {
-    # read value back
-    my $req = GET "$url/read_session";
-    $jar->add_cookie_header($req);
-    my $res = $test->request($req);
-    ok $res->is_success, "/read_session";
+    my $sid1;
+    subtest "[$engine] Set value into session" => sub {
+        my $res = $test->request(GET "$url/set_session/larry");
+        ok $res->is_success, "/set_session/larry";
 
-    $jar->clear;
-    ok( !$jar->as_string, 'Jar cleared' );
+        $jar->extract_cookies($res);
+        ok($jar->as_string, 'Cookie set');
 
-    $jar->extract_cookies($res);
-    ok( $jar->as_string, 'session cookie set again' );
-    like $res->content, qr/name='larry'/, "session value looks good";
-};
+        # extract SID
+        $jar->scan(sub { $sid1 = $_[2] });
+        ok($sid1, 'Got SID from cookie');
+    };
 
-subtest 'Session cookie persists even if we do not touch sessions' => sub {
-    my $req = GET "$url/no_session_data";
-    $jar->add_cookie_header($req);
+    subtest "[$engine] Read value back" => sub {
 
-    my $res = $test->request($req);
-    ok $res->is_success, "/no_session_data";
+        # read value back
+        my $req = GET "$url/read_session";
+        $jar->add_cookie_header($req);
+        my $res = $test->request($req);
+        ok $res->is_success, "/read_session";
 
-    $jar->clear;
-    ok( !$jar->as_string, 'Jar cleared' );
+        $jar->clear;
+        ok(!$jar->as_string, 'Jar cleared');
 
-    $jar->extract_cookies($res);
-    ok( $jar->as_string, 'session cookie set again' );
-};
+        $jar->extract_cookies($res);
+        ok($jar->as_string, 'session cookie set again');
+        like $res->content, qr/name='larry'/, "session value looks good";
+    };
 
-my $sid2;
-subtest 'Change session ID' => sub {
-    my $req = GET "$url/change_session_id";
-    $jar->add_cookie_header($req);
-    my $res = $test->request($req);
-    ok $res->is_success, "/change_session_id";
+    subtest
+      "[$engine] Session cookie persists even if we do not touch sessions" =>
+      sub {
+        my $req = GET "$url/no_session_data";
+        $jar->add_cookie_header($req);
 
-    $jar->clear;
-    ok( !$jar->as_string, 'Jar cleared' );
+        my $res = $test->request($req);
+        ok $res->is_success, "/no_session_data";
 
-    $jar->extract_cookies($res);
-    ok( $jar->as_string, 'session cookie set again' );
+        $jar->clear;
+        ok(!$jar->as_string, 'Jar cleared');
 
-    # extract SID
-    $jar->scan( sub { $sid2 = $_[2] } );
-    isnt $sid2, $sid1, "New session has different ID";
-    is $res->content, $sid2, "new session ID returned";
-};
+        $jar->extract_cookies($res);
+        ok($jar->as_string, 'session cookie set again');
+      };
 
-subtest 'Read value back after change_session_id' => sub {
-    # read value back
-    my $req = GET "$url/read_session";
-    $jar->add_cookie_header($req);
-    my $res = $test->request($req);
-    ok $res->is_success, "/read_session";
+    my $sid2;
+    subtest "[$engine] Change session ID" => sub {
+        my $req = GET "$url/change_session_id";
+        $jar->add_cookie_header($req);
+        my $res = $test->request($req);
+        ok $res->is_success, "/change_session_id";
 
-    $jar->clear;
-    ok( !$jar->as_string, 'Jar cleared' );
+        $jar->clear;
+        ok(!$jar->as_string, 'Jar cleared');
 
-    $jar->extract_cookies($res);
-    ok( $jar->as_string, 'session cookie set again' );
-    like $res->content, qr/name='larry'/, "session value looks good";
-};
+        $jar->extract_cookies($res);
+        ok($jar->as_string, 'session cookie set again');
 
-subtest 'Destroy session and check that cookies expiration is set' => sub {
-    my $req = GET "$url/destroy_session";
-    $jar->add_cookie_header($req);
+        # extract SID
+        $jar->scan(sub { $sid2 = $_[2] });
+        isnt $sid2, $sid1, "New session has different ID";
+        is $res->content, $sid2, "new session ID returned";
+    };
 
-    my $res = $test->request($req);
-    ok $res->is_success, "/destroy_session";
+    subtest "[$engine] Read value back after change_session_id" => sub {
 
-    ok( $jar->as_string, 'We have a cookie before reading response' );
-    $jar->extract_cookies($res);
-    ok( ! $jar->as_string, 'Cookie was removed from jar' );
-};
+        # read value back
+        my $req = GET "$url/read_session";
+        $jar->add_cookie_header($req);
+        my $res = $test->request($req);
+        ok $res->is_success, "/read_session";
 
-subtest 'Session cookie not sent after session destruction' => sub {
-    my $req = GET "$url/no_session_data";
-    $jar->add_cookie_header($req);
+        $jar->clear;
+        ok(!$jar->as_string, 'Jar cleared');
 
-    my $res = $test->request($req);
-    ok $res->is_success, "/no_session_data";
+        $jar->extract_cookies($res);
+        ok($jar->as_string, 'session cookie set again');
+        like $res->content, qr/name='larry'/, "session value looks good";
+    };
 
-    ok( !$jar->as_string, 'Jar is empty' );
-    $jar->extract_cookies($res);
-    ok( !$jar->as_string, 'Jar still empty (no new session cookie)' );
-};
+    subtest
+      "[$engine] Destroy session and check that cookies expiration is set" =>
+      sub {
+        my $req = GET "$url/destroy_session";
+        $jar->add_cookie_header($req);
 
-my $sid3;
-subtest 'Set value into session again' => sub {
-    my $res = $test->request( GET "$url/set_session/curly" );
-    ok $res->is_success, "/set_session/larry";
+        my $res = $test->request($req);
+        ok $res->is_success, "/destroy_session";
 
-    $jar->extract_cookies($res);
-    ok( $jar->as_string, 'session cookie set' );
+        ok($jar->as_string, 'We have a cookie before reading response');
+        $jar->extract_cookies($res);
+        ok(!$jar->as_string, 'Cookie was removed from jar');
+      };
 
-    # extract SID
-    $jar->scan( sub { $sid3 = $_[2] } );
-    isnt $sid3, $sid2, "New session has different ID";
-};
+    subtest "[$engine] Session cookie not sent after session destruction" =>
+      sub {
+        my $req = GET "$url/no_session_data";
+        $jar->add_cookie_header($req);
 
-subtest 'Destroy and create a session in one request' => sub {
-    my $req = GET "$url/churn_session";
-    $jar->add_cookie_header($req);
+        my $res = $test->request($req);
+        ok $res->is_success, "/no_session_data";
 
-    my $res = $test->request($req);
-    ok $res->is_success, "/churn_session";
+        ok(!$jar->as_string, 'Jar is empty');
+        $jar->extract_cookies($res);
+        ok(!$jar->as_string, 'Jar still empty (no new session cookie)');
+      };
 
-    $jar->extract_cookies($res);
-    ok( $jar->as_string, 'session cookie set' );
+    my $sid3;
+    subtest "[$engine] Set value into session again" => sub {
+        my $res = $test->request(GET "$url/set_session/curly");
+        ok $res->is_success, "/set_session/larry";
 
-    my $sid4;
-    $jar->scan( sub { $sid4 = $_[2] } );
-    isnt $sid4, $sid3, "Changed session has different ID";
-};
+        $jar->extract_cookies($res);
+        ok($jar->as_string, 'session cookie set');
 
-subtest 'Read value back' => sub {
-    my $req = GET "$url/read_session";
-    $jar->add_cookie_header($req);
+        # extract SID
+        $jar->scan(sub { $sid3 = $_[2] });
+        isnt $sid3, $sid2, "New session has different ID";
+    };
 
-    my $res = $test->request($req);
-    ok $res->is_success, "/read_session";
+    subtest "[$engine] Destroy and create a session in one request" => sub {
+        my $req = GET "$url/churn_session";
+        $jar->add_cookie_header($req);
 
-    $jar->extract_cookies($res);
-    ok( $jar->as_string, "session cookie set" );
-    like $res->content, qr/name='damian'/, "session value looks good";
-};
+        my $res = $test->request($req);
+        ok $res->is_success, "/churn_session";
+
+        $jar->extract_cookies($res);
+        ok($jar->as_string, 'session cookie set');
+
+        my $sid4;
+        $jar->scan(sub { $sid4 = $_[2] });
+        isnt $sid4, $sid3, "Changed session has different ID";
+    };
+
+    subtest "[$engine] Read value back" => sub {
+        my $req = GET "$url/read_session";
+        $jar->add_cookie_header($req);
+
+        my $res = $test->request($req);
+        ok $res->is_success, "/read_session";
+
+        $jar->extract_cookies($res);
+        ok($jar->as_string, "session cookie set");
+        like $res->content, qr/name='damian'/, "session value looks good";
+    };
+}
 
 done_testing;

--- a/t/session_lifecycle.t
+++ b/t/session_lifecycle.t
@@ -27,10 +27,7 @@ use HTTP::Cookies;
     };
 
     get '/change_session_id' => sub {
-        my $sid1 = session->id;
         app->change_session_id;
-        my $sid2 = session->id;
-        return "changed from $sid1 to $sid2";
     };
 
     get '/destroy_session' => sub {
@@ -125,6 +122,7 @@ subtest 'Change session ID' => sub {
     # extract SID
     $jar->scan( sub { $sid2 = $_[2] } );
     isnt $sid2, $sid1, "New session has different ID";
+    is $res->content, $sid2, "new session ID returned";
 };
 
 subtest 'Read value back after change_session_id' => sub {

--- a/t/session_lifecycle.t
+++ b/t/session_lifecycle.t
@@ -4,6 +4,7 @@ use Test::More;
 use Plack::Test;
 use HTTP::Request::Common;
 use HTTP::Cookies;
+use lib 't/lib';
 
 {
     package App;
@@ -47,7 +48,7 @@ my $url  = 'http://localhost';
 my $test = Plack::Test->create( App->to_app );
 my $app = Dancer2->runner->apps->[0];
 
-for my $engine (qw(YAML Simple)) {
+for my $engine (qw(YAML Simple SimpleNoChangeId)) {
 
     # clear current session engine, and rebuild for the test
     # This is *really* messy, playing in object hashrefs..


### PR DESCRIPTION
It is considered good security practice to change session id on any change of privilege level (for example on login):

https://www.owasp.org/index.php/Session_Management_Cheat_Sheet#Renew_the_Session_ID_After_Any_Privilege_Level_Change

This is also a requirement of a number of established security standards.

This branch adds a new method `change_session_id` which will do one of the following:

1. A new method `_change_id` can be added to session engines which is then expected to do the "right thing" for that session engine.

1. Otherwise the session data is stashed, the session destroyed, and then the new session has the old data written back into it.

It is expected that the new session engine method will become a requirement for all session engines at some point in the future.

This PR is currently missing tests and documentation for the new hooks that have been added. These will be added soon.