### PR TITLE
Simplify YAML version range dep using != 1.16

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -101,10 +101,10 @@ App::Cmd::Setup = 0
 Sub::Quote = 0
 ; Minimum version of YAML is needed due to:
 ; - https://github.com/PerlDancer/Dancer2/issues/899
-; Maximum version of YAML is needed due to:
+; Excluded 1.16 is needs due to:
 ; - http://www.cpantesters.org/cpan/report/25911c10-4199-11e6-8d7d-86c55bc2a771
 ; - http://www.cpantesters.org/cpan/report/284ac158-419a-11e6-9a35-e3e15bc2a771
-YAML = < 1.16, >= 0.86
+YAML = >= 0.86, != 1.16
 
 [Prereqs / Recommends]
 ; Serializers


### PR DESCRIPTION
Now newer version will be acceptable including 1.17 which does not break D2.