### PR TITLE
Correct bad brackets in Dancer2::Manual display of views/login.tt

### DIFF
--- a/lib/Dancer2/Manual.pod
+++ b/lib/Dancer2/Manual.pod
@@ -923,7 +923,7 @@ place it in a directory called C<views/>:
             <!-- Put the original path requested into a hidden
                        field so it's sent back in the POST and can be
                        used to redirect to the right page after login -->
-            <input type='hidden' name='path' value='[% path %]'/>
+            <input type='hidden' name='path' value='<% path %>'/>
 
             <input type='submit' value='Login' />
         </form>


### PR DESCRIPTION
See https://github.com/PerlDancer/Dancer2/issues/1203.  Square brackets were
being used; angle brackets were (for some reason) needed.