### PR TITLE
Fix logging shows wrong linenumber

### DIFF
--- a/lib/Dancer2/Core/Role/Logger.pm
+++ b/lib/Dancer2/Core/Role/Logger.pm
@@ -74,7 +74,7 @@ sub format_message {
     $message = Encode::encode( $self->auto_encoding_charset, $message )
       if $self->auto_encoding_charset;
 
-    my @stack = caller(5);
+    my @stack = caller(8);
     my $request = $self->request;
     my $config = $self->config;
 


### PR DESCRIPTION
hello!  dancer2 is very cool!!

Change line numbers in stack trace

package Simple;
use Dancer2;
get '/' => sub {
    info "hello!!"; # <- line number
    return 'index';
};

version 0.200002
Dancer2/Core/App.pm l. 840

version 0.166001
/Simple/bin/../lib/Simple.pm l. 7

thank you!

