### PR TITLE
Call DSL from plugin on the consumer class

### DIFF
--- a/lib/Dancer2/Plugin.pm
+++ b/lib/Dancer2/Plugin.pm
@@ -463,7 +463,17 @@ sub register_plugin {
 
     my $_DANCER2_IMPORT_TIME_SUBS = $plugin_module->_DANCER2_IMPORT_TIME_SUBS;
     unshift(@$_DANCER2_IMPORT_TIME_SUBS, sub {
-                foreach my $keyword ( keys %{$_[0]->app->name->dsl->dsl_keywords} ) {
+                my $app_dsl_cb;
+                ## no critic qw(ControlStructures::ProhibitCStyleForLoops)
+                for ( my $i = 0; my $caller = caller($i); $i++ ) {
+                    $app_dsl_cb = $caller->can('dsl')
+                        and last;
+                }
+
+                $app_dsl_cb
+                    or croak('Could not find Dancer2 app');
+
+                foreach my $keyword ( keys %{ $app_dsl_cb->()->dsl_keywords} ) {
                     # if not yet defined, inject the keyword in the plugin
                     # namespace, but make sure the code will always get the
                     # coderef from the right associated app, because one plugin

--- a/t/issues/gh-1216/gh-1216.t
+++ b/t/issues/gh-1216/gh-1216.t
@@ -1,0 +1,19 @@
+use strict;
+use warnings;
+use lib 't/issues/gh-1216/lib';
+
+use Test::More      'tests' => 2;
+use Test::Fatal     qw<exception>;
+use Module::Runtime qw<require_module>;
+
+my $app;
+is(
+    exception {
+        require_module('App');
+        $app = App->to_app;
+    },
+    undef,
+    'No exception when creating new app',
+);
+
+isa_ok( $app, 'CODE' );

--- a/t/issues/gh-1216/lib/App.pm
+++ b/t/issues/gh-1216/lib/App.pm
@@ -1,0 +1,4 @@
+package App;
+use App::Extra;
+use Dancer2;
+1;

--- a/t/issues/gh-1216/lib/App/Extra.pm
+++ b/t/issues/gh-1216/lib/App/Extra.pm
@@ -1,0 +1,7 @@
+package App::Extra;
+use Dancer2 appname => 'App';
+use Dancer2::Plugin::Null;
+
+get '/' => sub {'OK'};
+
+1;

--- a/t/issues/gh-1216/lib/Dancer2/Plugin/Null.pm
+++ b/t/issues/gh-1216/lib/Dancer2/Plugin/Null.pm
@@ -1,0 +1,4 @@
+package Dancer2::Plugin::Null;
+use Dancer2::Plugin;
+register_plugin;
+1;


### PR DESCRIPTION
The problem in GH #1216 is when a user loads a plugin which tries to access a DSL, while only loading "Dancer2" (and thus instating the DSL) comes after.

In that case, the DSL in the app class does not exist yet, and thus fails.

Instead of calling the app name as a class, use the first class in the caller tree that implements 'dsl', which is more likely to be the consumer of the plugin, even if under a different class.
