### PR TITLE
Revert type tiny

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -59,7 +59,7 @@ match = dist.ini
 Moo = 2.000000
 Moo::Role = 0
 Role::Tiny = 2.000000
-Type::Tiny = 0.008
+MooX::Types::MooseLike = 0
 Carp = 0
 Digest::SHA = 0
 Exporter = 5.57
@@ -99,7 +99,6 @@ Import::Into = 0
 Safe::Isa = 0
 Hash::Merge::Simple = 0
 App::Cmd::Setup = 0
-Sub::Quote = 0
 ; Minimum version of YAML is needed due to:
 ; - https://github.com/PerlDancer/Dancer2/issues/899
 ; Excluded 1.16 is needs due to:
@@ -118,7 +117,6 @@ Test::Builder = 0
 ; Extra speed with Request
 URL::Encode::XS = 0
 CGI::Deurl::XS = 0
-Type::Tiny::XS = 0
 ; Strong session tokens
 Math::Random::ISAAC::XS = 0
 Crypt::URandom = 0

--- a/lib/Dancer2/Core/Types.pm
+++ b/lib/Dancer2/Core/Types.pm
@@ -1,14 +1,15 @@
 package Dancer2::Core::Types;
-# ABSTRACT: Type::Tiny types for Dancer2 core.
+# ABSTRACT: Moo types for Dancer2 core.
 
 use strict;
 use warnings;
+use Scalar::Util 'blessed', 'looks_like_number';
+use MooX::Types::MooseLike 0.16 'exception_message';
+use MooX::Types::MooseLike::Base qw/:all/;
 
-use Type::Library -base;
-use Type::Utils -all;
-use Sub::Quote 'quote_sub';
-
-BEGIN { extends "Types::Standard" };
+use Exporter 'import';
+our @EXPORT;
+our @EXPORT_OK;
 
 our %supported_http_methods = map +( $_ => 1 ), qw<
     GET HEAD POST PUT DELETE OPTIONS PATCH
@@ -26,43 +27,71 @@ my $namespace = qr/
     $
 /x;
 
+my $definitions = [
+    {   name => 'ReadableFilePath',
+        test => sub { -e $_[0] && -r $_[0] },
+        message =>
+          sub { return exception_message( $_[0], 'ReadableFilePath' ) },
+        inflate => 0,
+    },
+    {   name => 'WritableFilePath',
+        test => sub { -e $_[0] && -w $_[0] },
+        message =>
+          sub { return exception_message( $_[0], 'WritableFilePath' ) },
+        inflate => 0,
+    },
 
-declare 'ReadableFilePath',
-  constraint => quote_sub q{ -e $_ && -r $_ };
+    # Dancer2-specific types
+    {   name       => 'Dancer2Prefix',
+        subtype_of => 'Str',
+        from       => 'MooX::Types::MooseLike::Base',
+        test       => sub {
 
+            # a prefix must start with the char '/'
+            # index is much faster than =~ /^\//
+            index( $_[0], '/' ) == 0;
+        },
+        message =>
+          sub { return exception_message( $_[0], 'a Dancer2Prefix' ) },
+        inflate => 0,
+    },
+    {   name       => 'Dancer2AppName',
+        subtype_of => 'Str',
+        from       => 'MooX::Types::MooseLike::Base',
+        test       => sub {
 
-declare 'WritableFilePath',
-  constraint => quote_sub q{ -e $_ && -w $_ };
-
-
-declare 'Dancer2Prefix',
-  as 'Str',
-  where {
-    # a prefix must start with the char '/'
-    # index is much faster than =~ /^\//
-    index($_, '/') == 0
-  };
-
-
-declare 'Dancer2AppName',
-  as 'Str',
-  where {
-    # TODO need a real check of valid app names
-    $_ =~ $namespace;
-  },
-  message {
-    sprintf("%s is not a Dancer2AppName",
-        ($_ && length($_)) ? $_ : 'Empty string')
-  };
-
-
-declare 'Dancer2Method',
-  as Enum[map +(lc), keys %supported_http_methods];
-
-
-declare 'Dancer2HTTPMethod',
-  as Enum[keys %supported_http_methods];
-
+            # TODO need a real check of valid app names
+            $_[0] =~ $namespace;
+        },
+        message => sub {
+            return exception_message(
+                ($_[0] && length( $_[0] )) ? $_[0] : 'Empty string',
+                'a Dancer2AppName'
+            );
+        },
+        inflate => 0,
+    },
+    {   name       => 'Dancer2Method',
+        subtype_of => 'Str',
+        from       => 'MooX::Types::MooseLike::Base',
+        test       => sub {
+            grep {/^$_[0]$/} map +( lc ), keys %supported_http_methods
+        },
+        message =>
+          sub { return exception_message( $_[0], 'a Dancer2Method' ) },
+        inflate => 0,
+    },
+    {   name       => 'Dancer2HTTPMethod',
+        subtype_of => 'Str',
+        from       => 'MooX::Types::MooseLike::Base',
+        test       => sub {
+            grep {/^$_[0]$/} keys %supported_http_methods
+        },
+        message =>
+          sub { return exception_message( $_[0], 'a Dancer2HTTPMethod' ) },
+        inflate => 0,
+    },
+];
 
 # generate abbreviated class types for core dancer objects
 for my $type (
@@ -86,12 +115,24 @@ for my $type (
     /
   )
 {
-    declare $type,
-    as InstanceOf[ 'Dancer2::Core::' . $type ];
+    push @$definitions, {
+        name => $type,
+        test => sub {
+            return
+                 $_[0]
+              && blessed( $_[0] )
+              && ref( $_[0] ) eq 'Dancer2::Core::' . $type;
+        },
+        message =>
+          sub {"The value `$_[0]' does not pass the constraint check."},
+        inflate => 0,
+    };
 }
 
-# export everything!
-our @EXPORT = __PACKAGE__->type_names;
+MooX::Types::MooseLike::register_types( $definitions, __PACKAGE__ );
+
+# Export everything by default.
+@EXPORT = ( @MooX::Types::MooseLike::Base::EXPORT_OK, @EXPORT_OK );
 
 1;
 
@@ -99,7 +140,7 @@ __END__
 
 =head1 DESCRIPTION
 
-L<Type::Tiny> definitions for Moo attributes. These are defined as subroutines.
+Type definitions for Moo attributes. These are defined as subroutines.
 
 =head1 MOO TYPES
 
@@ -138,6 +179,6 @@ and I<OPTIONS>.
 
 =head1 SEE ALSO
 
-L<Types::Standard> for more available types
+L<MooX::Types::MooseLike> for more available types
 
 =cut

--- a/lib/Dancer2/Core/Types.pm
+++ b/lib/Dancer2/Core/Types.pm
@@ -123,8 +123,6 @@ for my $type (
               && blessed( $_[0] )
               && ref( $_[0] ) eq 'Dancer2::Core::' . $type;
         },
-        message =>
-          sub {"The value `$_[0]' does not pass the constraint check."},
         inflate => 0,
     };
 }

--- a/lib/Dancer2/Manual.pod
+++ b/lib/Dancer2/Manual.pod
@@ -1837,7 +1837,6 @@ Add a requirement using the L<cpanfile> format:
      recommends 'URL::Encode::XS' => 0;
      recommends 'CGI::Deurl::XS' => 0;
      recommends 'HTTP::Parser::XS' => 0;
-     recommends 'Type::Tiny::XS' => 0;
 
 Ask carton to set it up:
 

--- a/lib/Dancer2/Manual/Migration.pod
+++ b/lib/Dancer2/Manual/Migration.pod
@@ -109,8 +109,6 @@ for details.
 
 =item * L<Scope::Upper>
 
-=item * L<Type::Tiny::XS>
-
 =back
 
 They would need to be installed separately. This is because L<Dancer2> does

--- a/t/issues/gh-1098.t
+++ b/t/issues/gh-1098.t
@@ -13,7 +13,7 @@ subtest 'Core::Error serializer isa tests' => sub {
     is exception { Dancer2::Core::Error->new }, undef, "Error->new lived";
 
     like exception { Dancer2::Core::Error->new(show_errors => []) },
-    qr/Reference \Q[]\E did not pass type constraint "Bool"/i,
+    qr/is not a Boolean/,
       "Error->new(show_errors => []) died";
 
     is exception {
@@ -29,13 +29,7 @@ subtest 'Core::Error serializer isa tests' => sub {
     "Error->new(serializer => Dancer2::Serializer::JSON->new) lived";
 
     like exception { Dancer2::Core::Error->new(serializer => JSON->new) },
-    qr/
-    (
-    requires\sthat\sthe\sreference\sdoes\sDancer2::Core::Role::Serializer
-    |
-    did\snot\spass\stype\sconstraint
-    )
-    /x,
+    qr/is not a consumer of roles/,
     "Error->new(serializer => JSON->new) died";
 };
 
@@ -89,6 +83,6 @@ subtest 'Core::Role::Logger log_level isa tests' => sub {
     }
 
     like exception { TestLogger->new(log_level => 'BadLevel') },
-      qr/Value "BadLevel" did not pass type constraint "Enum/,
+      qr/BadLevel is not any of the possible values:/,
       "Logger->new(log_level => 'BadLevel') died";
 };

--- a/t/types.t
+++ b/t/types.t
@@ -1,6 +1,6 @@
 use strict;
 use warnings;
-use Test::More tests => 51;
+use Test::More tests => 46;
 use Test::Fatal;
 use Dancer2::Core::Types;
 
@@ -11,7 +11,7 @@ is( exception { Str->('something') }, undef, 'Str', );
 
 like(
     exception { Str->( { foo => 'something' } ) },
-    qr{Reference.+foo.+something.+did not pass type constraint.+Str}, 'Str',
+    qr{HASH\(\w+\) is not a string}, 'Str',
 );
 
 is( exception { Num->(34) }, undef, 'Num', );
@@ -20,7 +20,7 @@ ok( exception { Num->(undef) }, 'Num does not accept undef value', );
 
 like(
     exception { Num->('not a number') },
-    qr{not a number.+did not pass type constraint.+Num},
+    qr{(?i:not a number is not a Number)},
     'Num fail',
 );
 
@@ -30,17 +30,13 @@ is( exception { Bool->(0) }, undef, 'Bool false value', );
 
 is( exception { Bool->(undef) }, undef, 'Bool does accepts undef value', );
 
-like(
-    exception { Bool->('2') },
-    qr{2.+did not pass type constraint.+Bool},
-    'Bool fail',
-);
+like( exception { Bool->('2') }, qr{2 is not a Boolean}, 'Bool fail', );
 
 is( exception { RegexpRef->(qr{.*}) }, undef, 'Regexp', );
 
 like(
     exception { RegexpRef->('/.*/') },
-    qr{\Q/.*/\E.+did not pass type constraint.+RegexpRef},
+    qr{\Q/.*/\E is not a RegexpRef},
     'Regexp fail',
 );
 
@@ -50,7 +46,7 @@ is( exception { HashRef->( { goo => 'le' } ) }, undef, 'HashRef', );
 
 like(
     exception { HashRef->('/.*/') },
-    qr{\Q/.*/\E.+did not pass type constraint.+HashRef},
+    qr{\Q/.*/\E is not a HashRef},
     'HashRef fail',
 );
 
@@ -60,7 +56,7 @@ is( exception { ArrayRef->( [ 1, 2, 3, 4 ] ) }, undef, 'ArrayRef', );
 
 like(
     exception { ArrayRef->('/.*/') },
-    qr{\Q/.*/\E.+did not pass type constraint.+ArrayRef},
+    qr{\Q/.*/\E is not an ArrayRef},
     'ArrayRef fail',
 );
 
@@ -75,7 +71,7 @@ is( exception {
 
 like(
     exception { CodeRef->('/.*/') },
-    qr{\Q/.*/\E.+did not pass type constraint.+CodeRef},
+    qr{\Q/.*/\E is not a CodeRef},
     'CodeRef fail',
 );
 
@@ -85,7 +81,7 @@ ok( exception { CodeRef->(undef) }, 'CodeRef does not accept undef value', );
 
     package InstanceChecker::zad7;
     use Moo;
-    use Dancer2::Core::Types qw/InstanceOf/;
+    use Dancer2::Core::Types;
     has foo => ( is => 'ro', isa => InstanceOf ['Foo'] );
 }
 
@@ -95,7 +91,7 @@ is( exception { InstanceChecker::zad7->new( foo => bless {}, 'Foo' ) },
 
 like(
     exception { InstanceChecker::zad7->new( foo => bless {}, 'Bar' ) },
-    qr{Reference bless.+Bar.+not isa Foo},
+    qr{Bar=HASH\(\w+\) is not an instance of the class: Foo},
     'InstanceOf fail',
 );
 
@@ -107,14 +103,14 @@ is( exception { Dancer2Prefix->('/foo') }, undef, 'Dancer2Prefix', );
 
 like(
     exception { Dancer2Prefix->('bar/something') },
-    qr{bar/something.+did not pass type constraint.+Dancer2Prefix},
+    qr{bar/something is not a Dancer2Prefix},
     'Dancer2Prefix fail',
 );
 
 # see Dancer2Prefix definition, undef is a valid value
 like(
     exception { Dancer2Prefix->(undef) },
-    qr/Undef.+did not pass type constraint.+Dancer2Prefix/,
+    qr/undef is not a Dancer2Prefix/,
     'Dancer2Prefix does not accept undef value',
 );
 
@@ -181,7 +177,7 @@ is( exception { Dancer2Method->('post') }, undef, 'Dancer2Method', );
 
 like(
     exception { Dancer2Method->('POST') },
-    qr{POST.+did not pass type constraint.+Dancer2Method},
+    qr{POST is not a Dancer2Method},
     'Dancer2Method fail',
 );
 
@@ -193,34 +189,10 @@ is( exception { Dancer2HTTPMethod->('POST') }, undef, 'Dancer2HTTPMethod', );
 
 like(
     exception { Dancer2HTTPMethod->('post') },
-    qr{post.+did not pass type constraint.+Dancer2HTTPMethod},
+    qr{post is not a Dancer2HTTPMethod},
     'Dancer2HTTPMethod fail',
 );
 
 ok( exception { Dancer2HTTPMethod->(undef) },
     'Dancer2Method does not accept undef value',
 );
-
-use Dancer2::Core::Error;
-use Dancer2::Core::Hook;
-
-ok( exception { Hook->(undef) }, 'Hook does not accept undef value' );
-
-ok(exception { Hook->(Dancer2::Core::Error->new) },
-    'Hook does not Core::Error as value');
-
-is( exception {
-        Hook->(Dancer2::Core::Hook->new(name => 'test', code => sub { }))
-    },
-    undef,
-    'Hook',
-);
-
-is(exception { ReadableFilePath->('t') }, undef, 'ReadableFilePath');
-
-like(
-    exception { ReadableFilePath->('nosuchdirectory') },
-    qr/nosuchdirectory.+did not pass type constraint.+ReadableFilePath/,
-    'ReadableFilePath'
-);
-

--- a/t/types.t
+++ b/t/types.t
@@ -1,6 +1,6 @@
 use strict;
 use warnings;
-use Test::More tests => 46;
+use Test::More tests => 51;
 use Test::Fatal;
 use Dancer2::Core::Types;
 
@@ -195,4 +195,27 @@ like(
 
 ok( exception { Dancer2HTTPMethod->(undef) },
     'Dancer2Method does not accept undef value',
+);
+
+use Dancer2::Core::Error;
+use Dancer2::Core::Hook;
+
+ok( exception { Hook->(undef) }, 'Hook does not accept undef value' );
+
+ok(exception { Hook->(Dancer2::Core::Error->new) },
+    'Hook does not Core::Error as value');
+
+is( exception {
+        Hook->(Dancer2::Core::Hook->new(name => 'test', code => sub { }))
+    },
+    undef,
+    'Hook',
+);
+
+is(exception { ReadableFilePath->('t') }, undef, 'ReadableFilePath');
+
+like(
+    exception { ReadableFilePath->('nosuchdirectory') },
+    qr/nosuchdirectory is not ReadableFilePath/,
+    'ReadableFilePath'
 );


### PR DESCRIPTION
Revert feature/type_tiny so we use `MooX::Types::MooseLike` (see #1180)
    
Rather than using git revert which can do some terrible things to history this patch started as:
```    
gitt diff 88f9ef3d063d2cceb318403fecb424bd95544eca \
      5d3cdca3e53fb776767f8d9f507456fa333653ea
```
which was then cut back to something slightly saner (along with fixes where it did not apply).
    
I did not put back the inlined type checks that existed prior to the move to `Type::Tiny` since there is likely little (if any) performance gain from using hand-built inlined checks rather than `MooX::Types::MooseLike` type checks.

Extra tests added by the feature/type_tiny branch have been kept.
