### PR TITLE
Add YAML::XS to Recommends.

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -117,6 +117,9 @@ Test::Builder = 0
 ; Extra speed with Request
 URL::Encode::XS = 0
 CGI::Deurl::XS = 0
+; User might have YAML::Syck which fails big time on UTF-8 config files so
+; prefer YAML::XS in attempt to stop Config::Any using YAML::Syck
+YAML::XS = 0
 ; Strong session tokens
 Math::Random::ISAAC::XS = 0
 Crypt::URandom = 0


### PR DESCRIPTION
If you are unfortunate enough to have YAML::Syck installed but not
YAML::XS then Config::Any will use YAML::Syck to load your configs. This
is all well and good as long as you have no UTF-8 config files which
YAML::Suck (stet) will merrily trash leaving you scratching your head
for hours as to why some UTF-8 glyph from the config has been double
decoded before reaching your webpage. Just don't do YAML::Syck. Please.