### PR TITLE
Allow plugins to access the DSL keywords

### DIFF
--- a/lib/Dancer2/Plugin.pm
+++ b/lib/Dancer2/Plugin.pm
@@ -443,6 +443,15 @@ END
 
     die $@ if $@;
 
+    my $app_dsl_cb = _find_consumer();
+    my $dsl        = $app_dsl_cb->();
+
+    {
+        no strict 'refs';
+        no warnings 'redefine';
+        *{"${caller}::dsl"} = sub {$dsl};
+    }
+
     return map { [ $_ => { class => $caller } ] }
                qw/ plugin_keywords plugin_hooks /;
 }
@@ -480,12 +489,6 @@ sub register_plugin {
     unshift(@$_DANCER2_IMPORT_TIME_SUBS, sub {
                 my $app_dsl_cb = _find_consumer();
                 my $dsl        = $app_dsl_cb->();
-
-                {
-                    no strict 'refs';
-                    no warnings 'redefine';
-                    *{"${plugin_module}::dsl"} = sub {$dsl};
-                }
 
                 foreach my $keyword ( keys %{ $dsl->dsl_keywords} ) {
                     # if not yet defined, inject the keyword in the plugin

--- a/lib/Dancer2/Plugin.pm
+++ b/lib/Dancer2/Plugin.pm
@@ -481,6 +481,10 @@ sub register_plugin {
                 my $app_dsl_cb = _find_consumer();
                 my $dsl        = $app_dsl_cb->();
 
+                {
+                    no strict 'refs';
+                    *{"${plugin_module}::dsl"} = sub {$dsl};
+                }
 
                 foreach my $keyword ( keys %{ $dsl->dsl_keywords} ) {
                     # if not yet defined, inject the keyword in the plugin

--- a/lib/Dancer2/Plugin.pm
+++ b/lib/Dancer2/Plugin.pm
@@ -483,6 +483,7 @@ sub register_plugin {
 
                 {
                     no strict 'refs';
+                    no warnings 'redefine';
                     *{"${plugin_module}::dsl"} = sub {$dsl};
                 }
 

--- a/t/issues/gh-1226/gh-1226.t
+++ b/t/issues/gh-1226/gh-1226.t
@@ -1,0 +1,26 @@
+use strict;
+use warnings;
+use lib 't/issues/gh-1226/lib';
+
+use Test::More 'tests' => 4 + 9;
+use Test::Fatal qw<exception>;
+use Plack::Test ();
+use Module::Runtime qw<require_module>;
+use HTTP::Request::Common qw<GET>;
+
+my $app;
+is(
+    exception {
+        require_module('App');
+        $app = App->to_app;
+    },
+    undef,
+    'No exception when creating new app',
+);
+
+isa_ok( $app, 'CODE' );
+
+my $test     = Plack::Test->create($app);
+my $response = $test->request( GET '/' );
+is( $response->code,    200,  'Correct response code' );
+is( $response->content, 'OK', 'Correct response content' );

--- a/t/issues/gh-1226/lib/App.pm
+++ b/t/issues/gh-1226/lib/App.pm
@@ -1,0 +1,4 @@
+package App;
+use Dancer2 appname => 'OtherApp';
+use App::Extra;
+1;

--- a/t/issues/gh-1226/lib/App/Extra.pm
+++ b/t/issues/gh-1226/lib/App/Extra.pm
@@ -1,0 +1,11 @@
+package App::Extra;
+use Dancer2 'appname' => 'OtherApp';
+use Dancer2::Plugin::Test::AccessDSL;
+
+get '/' => sub {
+    status(500);
+    change_response_status();
+    return 'OK';
+};
+
+1;

--- a/t/issues/gh-1226/lib/Dancer2/Plugin/Test/AccessDSL.pm
+++ b/t/issues/gh-1226/lib/Dancer2/Plugin/Test/AccessDSL.pm
@@ -1,0 +1,56 @@
+package Dancer2::Plugin::Test::AccessDSL;
+use strict;
+use warnings;
+use Dancer2::Plugin;
+
+plugin_keywords('change_response_status');
+
+sub change_response_status {
+    my $self   = shift;
+    my $caller = caller(1);
+    ::is( $self->app->name, 'OtherApp', 'Appname is OtherApp' );
+    ::is( $caller, 'App::Extra', 'The caller class is App::Extra' );
+
+    ::ok(
+        ::exception(sub{ $self->app->dsl }),
+        'Cannot call DSL via app (bc appname is app)',
+    );
+
+    ::ok(
+        ::exception( sub { $self->app->name->dsl } ),
+        'Cannot call DSL via appname (bc it is not the consumer class)',
+    );
+
+    ::ok(
+        ::exception( sub { OtherApp->status(400) } ),
+        'Cannot call DSL via appname string (bc it is not the consumer class)',
+    );
+
+    ::is(
+        ::exception( sub { App::Extra::status(400) } ),
+        undef,
+        'Was able to successfully call the DSL (via consumer class)',
+    );
+
+    ::is(
+        $self->app->response->status(),
+        400,
+        'Status was set correctly',
+    );
+
+    ::is(
+        ::exception( sub { $self->dsl->status(200) } ),
+        undef,
+        'Was able to successfully call the DSL (via plugin->dsl)',
+    );
+
+    ::is(
+        $self->app->response->status(),
+        200,
+        'Status was set correctly',
+    );
+}
+
+register_plugin();
+
+1;

--- a/t/issues/gh-1226/lib/Dancer2/Plugin/Test/AccessDSL.pm
+++ b/t/issues/gh-1226/lib/Dancer2/Plugin/Test/AccessDSL.pm
@@ -51,6 +51,4 @@ sub change_response_status {
     );
 }
 
-register_plugin();
-
 1;


### PR DESCRIPTION
This fixes #1266.

You will now be able to do this:

```perl
package Dancer2::Plugin::MyPlugin;
use Dancer2::Plugin;

sub my_thing {
    my $self = shift;

    # define a new GET route with the DSL methods:
    $self->dsl->get( '/' => sub {...} );
}
```

Please read the commit messages before approving. We will also need to document this, since it's a big (and important) change. It doesn't break, but it makes things much easier for plugin authors.
