### PR TITLE
Allow register_plugin() to pass @_ properly:

### DIFF
--- a/lib/Dancer2/Plugin.pm
+++ b/lib/Dancer2/Plugin.pm
@@ -352,7 +352,7 @@ sub _exporter_plugin {
 
             # this is important as it'll do the keywords mapping between the
             # plugin and the app
-            sub register_plugin { Dancer2::Plugin::register_plugin(@_) }
+            sub register_plugin { Dancer2::Plugin::register_plugin(\@_) }
 
             sub register {
                 my ( \$keyword, \$sub ) = \@_;


### PR DESCRIPTION
This is inside an eval block, so I think it needs to be escaped
so it would be used as a literal.

Can someone approve this for me?