### PR TITLE
Allow import of plugins' DSL into other plugins

### DIFF
--- a/lib/Dancer2/Plugin.pm
+++ b/lib/Dancer2/Plugin.pm
@@ -192,7 +192,7 @@ sub _exporter_app {
     # Otherwise you can only import from a plugin to an app,
     # but with this, you can import to anything
     # that has a DSL with an app, which translates to "also plugins"
-    my $app = eval "${caller}::app()" || $caller->dsl->app
+    my $app = eval("${caller}::app()") || eval { $caller->dsl->app }
         or return; ## no critic
 
     return unless $app->can('with_plugin');

--- a/lib/Dancer2/Plugin.pm
+++ b/lib/Dancer2/Plugin.pm
@@ -187,7 +187,13 @@ sub _exporter_app {
     my( $class, $caller, $global ) = @_;
 
     $exported_app->{$caller} = 1;
-    my $app = eval "${caller}::app()" or return; ## no critic
+
+    # The check for ->dsl->app is to handle plugins as well.
+    # Otherwise you can only import from a plugin to an app,
+    # but with this, you can import to anything
+    # that has a DSL with an app, which translates to "also plugins"
+    my $app = eval "${caller}::app()" || $caller->dsl->app
+        or return; ## no critic
 
     return unless $app->can('with_plugin');
 

--- a/t/issues/gh-1230/gh-1230.t
+++ b/t/issues/gh-1230/gh-1230.t
@@ -1,0 +1,26 @@
+use strict;
+use warnings;
+use lib 't/issues/gh-1230/lib';
+
+use Test::More 'tests' => 4 + 5 + 9;
+use Test::Fatal qw<exception>;
+use Plack::Test ();
+use Module::Runtime qw<require_module>;
+use HTTP::Request::Common qw<GET>;
+
+my $app;
+is(
+    exception {
+        require_module('App');
+        $app = App->to_app;
+    },
+    undef,
+    'No exception when creating new app',
+);
+
+isa_ok( $app, 'CODE' );
+
+my $test     = Plack::Test->create($app);
+my $response = $test->request( GET '/' );
+is( $response->code,    200,  'Correct response code' );
+is( $response->content, 'OK', 'Correct response content' );

--- a/t/issues/gh-1230/lib/App.pm
+++ b/t/issues/gh-1230/lib/App.pm
@@ -1,0 +1,4 @@
+package App;
+use Dancer2 appname => 'OtherApp';
+use App::Extra;
+1;

--- a/t/issues/gh-1230/lib/App/Extra.pm
+++ b/t/issues/gh-1230/lib/App/Extra.pm
@@ -1,0 +1,11 @@
+package App::Extra;
+use Dancer2 'appname' => 'OtherApp';
+use Dancer2::Plugin::Test::AccessPluginDSL;
+
+get '/' => sub {
+    status(500);
+    test_change_response_status();
+    return 'OK';
+};
+
+1;

--- a/t/issues/gh-1230/lib/Dancer2/Plugin/Test/AccessDSL.pm
+++ b/t/issues/gh-1230/lib/Dancer2/Plugin/Test/AccessDSL.pm
@@ -1,0 +1,60 @@
+package Dancer2::Plugin::Test::AccessDSL;
+use strict;
+use warnings;
+use Dancer2::Plugin;
+
+plugin_keywords('change_response_status');
+
+sub change_response_status {
+    my $self   = shift;
+    my $caller = caller(1);
+
+    ::is( $self->app->name, 'OtherApp', 'Appname is OtherApp' );
+
+    ::is(
+        $caller,
+        'Dancer2::Plugin::Test::AccessPluginDSL',
+        'The caller class is the first plugin (AccessPluginDSL)',
+    );
+
+    ::ok(
+        ::exception(sub{ $self->app->dsl }),
+        'Cannot call DSL via app (bc appname is app)',
+    );
+
+    ::ok(
+        ::exception( sub { $self->app->name->dsl } ),
+        'Cannot call DSL via appname (bc it is not the consumer class)',
+    );
+
+    ::ok(
+        ::exception( sub { OtherApp->status(400) } ),
+        'Cannot call DSL via appname string (bc it is not the consumer class)',
+    );
+
+    ::is(
+        ::exception( sub { App::Extra::status(400) } ),
+        undef,
+        'Was able to successfully call the DSL (via consumer class)',
+    );
+
+    ::is(
+        $self->app->response->status(),
+        400,
+        'Status was set correctly',
+    );
+
+    ::is(
+        ::exception( sub { $self->dsl->status(200) } ),
+        undef,
+        'Was able to successfully call the DSL (via plugin->dsl)',
+    );
+
+    ::is(
+        $self->app->response->status(),
+        200,
+        'Status was set correctly',
+    );
+}
+
+1;

--- a/t/issues/gh-1230/lib/Dancer2/Plugin/Test/AccessPluginDSL.pm
+++ b/t/issues/gh-1230/lib/Dancer2/Plugin/Test/AccessPluginDSL.pm
@@ -1,0 +1,33 @@
+package Dancer2::Plugin::Test::AccessPluginDSL;
+use strict;
+use warnings;
+use Dancer2::Plugin;
+use Dancer2::Plugin::Test::AccessDSL;
+
+plugin_keywords('test_change_response_status');
+
+sub test_change_response_status {
+    my $self   = shift;
+    my $caller = caller(1);
+    ::is( $self->app->name, 'OtherApp', 'Appname is OtherApp' );
+    ::is( $caller, 'App::Extra', 'The caller class is App::Extra' );
+
+    ::ok(
+        ::exception( sub { App::Extra::change_response_status() } ),
+        'App does not receive DSL from our inner Plugin',
+    );
+
+    ::is(
+        ::exception( sub { change_response_status() } ),
+        undef,
+        'Successfully called the plugin DSL (via plugin->dsl)',
+    );
+
+    ::is(
+        $self->app->response->status(),
+        200,
+        'Status was set correctly',
+    );
+}
+
+1;


### PR DESCRIPTION
The reason plugins calling DSL on other plugins doesn't work is because we explicitly only allow importing plugins DSL from applications.

The way we verify this is by trying to call "app" attribute on the consuming class. Plugins don't have this. The change I made here is to check if "->dsl->app" is also available, which is available in plugins.

This fixed GH #1230, but assumes that GH #1227 was already merged.