### PR TITLE
Bugfix/body data parse

### DIFF
--- a/t/issues/gh-1232.t
+++ b/t/issues/gh-1232.t
@@ -1,0 +1,58 @@
+use strict;
+use warnings;
+
+use Test::More tests => 1;
+use Plack::Test;
+use Plack::Builder;
+use Plack::Request;
+use HTTP::Request::Common;
+use Encode qw(encode_utf8);
+
+{
+    package App;
+    use Dancer2;
+
+    # default, we're actually overriding this later
+    set serializer => 'JSON';
+
+    # for now
+    set logger     => 'Capture';
+
+    post '/json' => sub {
+        my $p = body_parameters;
+        return [ map +( $_ => $p->get($_) ), sort $p->keys ];
+    };
+}
+
+my $psgi = builder {
+    # inline middleware FTW!
+    # Create a Plack::Request object and parse body to tickle #1232
+    enable sub {
+        my $app = shift;
+        sub {
+            my $req = Plack::Request->new($_[0])->body_parameters;
+            return $app->($_[0]);            
+        }
+    };
+    App->to_app;
+};
+
+my $test = Plack::Test->create( $psgi );
+
+subtest 'POST request with parameters' => sub {
+    my $characters = encode_utf8("∑∏");
+    
+    my $res = $test->request(
+        POST "/json",
+            'Content-Type' => 'application/json',
+            'Content'      => qq!{ "foo": 1, "bar": 2, "baz": "$characters" }!
+    );
+
+    is(
+        $res->content,
+        qq!["bar",2,"baz","$characters","foo",1]!,
+        "Body parameters deserialized",
+    );
+};
+
+done_testing();


### PR DESCRIPTION
A logic error (described in #1232) made it possible for a request to
have serialized data that wouldn't be deserialized into body_parameters
if any middleware had previously created a Plack::Request object and
parsed the request body.

Instead, when a Dancer2::Core::Request object is instanciated, explicitly
call $self->data to force deserialization and (directly) set
env->{plack.request.body} to a HMV of that data (if its a hash). Setting
env->{plack.request.body} in this way is a bit messy; but we are
subclass Plack::Request so digging in internals is somewhat excused (for
now).

Also; deserialized data has already been decoded to characters (that how
we define our deserialization actions). A change in the 0.202000 release
was double decoding them.

Includes tests for both the deserialization (into body_parameters) and
checking for double decoding of utf8.