### PR TITLE
add code_mapping, status_mapping and all_mappings

### DIFF
--- a/t/http_status.t
+++ b/t/http_status.t
@@ -1,43 +1,41 @@
 use strict;
 use warnings;
-use Test::More tests => 11;
+use Test::More tests => 5;
 
 use Dancer2::Core::HTTP;
 
-note "HTTP status"; {
-    my @tests = (
-        { status => undef,          expected => undef },
-        { status => 200,            expected => 200   },
-        { status => 'Not Found',    expected => 404   },
-        { status => 'bad_request',  expected => 400   },
-        { status => 'i_m_a_teapot', expected => 418   },
-        { status => 'error',        expected => 500   },
-        { status => 911,            expected => 911   },
-    );
-
-    for my $test (@tests) {
-        my $status_text = defined $test->{status}
-            ? $test->{status} : 'undef';
-        is( Dancer2::Core::HTTP->status( $test->{status} ),
-            $test->{expected},
-            "HTTP status looks good for $status_text" );
-    }
-}
+subtest "HTTP status" => sub {
+    is( Dancer2::Core::HTTP->status( $_->{status} ) => $_->{expected},
+        'status: '. ( $_->{status} || 'undef' ) )
+        for { status => undef,          expected => undef },
+            { status => 200,            expected => 200   },
+            { status => 'Not Found',    expected => 404   },
+            { status => 'bad_request',  expected => 400   },
+            { status => 'i_m_a_teapot', expected => 418   },
+            { status => 'error',        expected => 500   },
+            { status => 911,            expected => 911   };
+};
 
 
-note "HTTP status_message"; {
-    my @tests = (
-        { status => undef,   expected => undef                   },
-        { status => 200,     expected => 'OK'                    },
-        { status => 'error', expected => 'Internal Server Error' },
-        { status => 911,     expected => undef                   },
-    );
+subtest "HTTP status_message" => sub {
+    is( Dancer2::Core::HTTP->status_message( $_->{status} ) => $_->{expected},
+        'status: '. ( $_->{status} || 'undef' ) )
+        for { status => undef,   expected => undef                   },
+            { status => 200,     expected => 'OK'                    },
+            { status => 'error', expected => 'Internal Server Error' },
+            { status => 911,     expected => undef                   };
+};
 
-    for my $test (@tests) {
-        my $status_text = defined $test->{status}
-            ? $test->{status} : 'undef';
-        is( Dancer2::Core::HTTP->status_message( $test->{status} ),
-            $test->{expected},
-            "HTTP status message looks good for $status_text" );
-    }
-}
+is { Dancer2::Core::HTTP->status_mapping }->{"I'm a teapot"} 
+    => 418, 'status_mapping';
+
+is { Dancer2::Core::HTTP->code_mapping }->{418} 
+    => "I'm a teapot", 'code_mapping';
+
+subtest 'all_mappings' => sub {
+    my %mappings = Dancer2::Core::HTTP->all_mappings;
+
+    is $mappings{"I'm a teapot"} => 418;
+    is $mappings{"i_m_a_teapot"} => 418;
+    is $mappings{418} => "I'm a teapot";
+};


### PR DESCRIPTION
Add a few functions to allow code to access (copies) of our HTTP_CODES table. Mostly useful for plugins like Dancer2::Plugin::REST that won't have to copy the table for its own internal use.