### PR TITLE
retrieved sessions can have blessed hashrefs too

### DIFF
--- a/lib/Dancer2/Core/Role/SessionFactory.pm
+++ b/lib/Dancer2/Core/Role/SessionFactory.pm
@@ -11,6 +11,7 @@ use Digest::SHA 'sha1';
 use List::Util 'shuffle';
 use MIME::Base64 'encode_base64url';
 use Module::Runtime 'require_module';
+use Scalar::Util 'reftype';
 
 sub hook_aliases { +{} }
 sub supported_hooks {
@@ -163,7 +164,7 @@ sub retrieve {
     my %args = ( id => $id, );
 
     $args{data} = $data
-      if $data and ref $data eq 'HASH';
+      if ref $data and reftype $data eq 'HASH';
 
     $args{expires} = $self->cookie_duration
       if $self->has_cookie_duration;


### PR DESCRIPTION
There's no technical reason why a session couldn't have a
blessed hashref. So this commit modifies the check to accept
them too.

TODO: a session that has something other than a hashref
should not be simply ignored, but it should die or warn.

It shouldn't take a look at Dancer2 internals to figure
out why the data your Dancer2::Session engine is providing
is not made available to the Dancer2 app that is using it.