### PR TITLE
Minimum version for List::Util

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,5 +1,10 @@
 {{$NEXT}}
 
+
+    [ BUG FIXES ]
+    * GH #1237: Specify minimum version of List::Util required for pair*
+      functionals. (Russell @veryrusty Jenkins)
+
 0.203000  2016-08-24 22:09:56-05:00 America/Chicago
 
     [ BUG FIXES ]

--- a/dist.ini
+++ b/dist.ini
@@ -79,6 +79,8 @@ HTTP::Date = 0
 HTTP::Body = 0
 HTTP::Headers::Fast = 0
 HTTP::Tiny = 0
+; 1.29 has the pair* functions
+List::Util = 1.29
 ; 3.13 has the URL safe variants
 MIME::Base64 = 3.13
 ; added the "wrap" method in Plack::Builder in 1.0016


### PR DESCRIPTION
The `pair*` functionals used in Dancer2::Core::HTTP were introduced in List::Util v1.29.

Specify this as the minimum version of List::Util we require.