### PR TITLE
Dont use HMV->from_mixed when deserializing JSON body data

### DIFF
--- a/Changes
+++ b/Changes
@@ -4,6 +4,9 @@
     [ BUG FIXES ]
     * GH #1237: Specify minimum version of List::Util required for pair*
       functionals. (Russell @veryrusty Jenkins)
+    * GH #1240: JSON body deserialization should use HMV->new since
+      HMV->from_mixed does horrible things to first-level hash reference
+      values. (Peter Mottram - SysPete)
 
 0.203000  2016-08-24 22:09:56-05:00 America/Chicago
 

--- a/lib/Dancer2.pm
+++ b/lib/Dancer2.pm
@@ -237,6 +237,7 @@ Returns the current runner. It is of type L<Dancer2::Core::Runner>.
     Bas Bloemsaat
     baynes
     Ben Hutton
+    Björn Weinehall
     Blabos de Blebe
     Breno G. de Oliveira
     cdmalon

--- a/lib/Dancer2/Core/Request.pm
+++ b/lib/Dancer2/Core/Request.pm
@@ -214,7 +214,7 @@ sub deserialize {
     # Set body parameters (HMV)
     # Not happy with fiddling with Plack::Request internals -- veryrusty Aug 2016.
     $self->env->{'plack.request.body'} =
-        Hash::MultiValue->from_mixed( ref $data eq 'HASH' ? %$data : () );
+        Hash::MultiValue->new( ref $data eq 'HASH' ? %$data : () );
 
     return $data;
 }

--- a/t/issues/gh-1240.t
+++ b/t/issues/gh-1240.t
@@ -1,0 +1,45 @@
+use strict;
+use warnings;
+use Test::More tests => 3;
+use Plack::Test;
+use HTTP::Request::Common;
+
+{
+    package App;
+    use Dancer2;
+    set serializer => 'JSON';
+
+    post '/' => sub {
+        send_as html => to_json(body_parameters->as_hashref, {canonical => 1});
+    };
+}
+
+my $test = Plack::Test->create( App->to_app );
+
+# something very simple not affected by #1240
+
+is(
+    $test->request( POST '/', Content => '{"foo":42}' )->content,
+    '{"foo":42}',
+    'Correct JSON content in POST',
+);
+
+# example from OP in #1240
+
+my $json = q{{"baz":{"foobar":[{"blah":2}]},"foo":[{"bar":1}]}};
+is(
+    $test->request( POST '/', Content => $json )->content,
+    $json,
+    'Correct JSON content in POST',
+);
+
+# more complex contrived example
+
+$json = q{{"a":[1],"b":[1,2],"c":[{"a":1}],"d":[{"a":1},{"b":2}],"e":1,"f":{"a":1},"g":{"a":1,"b":1},"h":{"a":[1],"b":{"c":1}}}};
+is(
+    $test->request( POST '/', Content => $json )->content,
+    $json,
+    'Correct JSON content in POST',
+);
+
+done_testing;


### PR DESCRIPTION
This addresses #1240.

It appears that HMV->from_mixed trashes many first-level values that are array references but any deeper structures are left alone. Seems I misunderstood its workings when I first used it.