### PR TITLE
Replace Class::Load with Module::Runtime

### DIFF
--- a/lib/Dancer2/Core/Request.pm
+++ b/lib/Dancer2/Core/Request.pm
@@ -12,7 +12,7 @@ use URI;
 use URI::Escape;
 use Safe::Isa;
 use Hash::MultiValue;
-use Class::Load 'try_load_class';
+use Module::Runtime 'require_module';
 
 use Dancer2::Core::Types;
 use Dancer2::Core::Request::Upload;
@@ -38,9 +38,9 @@ sub $_ { \$_[0]->env->{ 'HTTP_' . ( uc "$_" ) } }
 _EVAL
 
 # check presence of XS module to speedup request
-our $XS_URL_DECODE         = try_load_class('URL::Encode::XS');
-our $XS_PARSE_QUERY_STRING = try_load_class('CGI::Deurl::XS');
-our $XS_HTTP_COOKIES       = try_load_class('HTTP::XSCookies');
+our $XS_URL_DECODE         = eval { require_module('URL::Encode::XS'); 1; };
+our $XS_PARSE_QUERY_STRING = eval { require_module('CGI::Deurl::XS');  1; };
+our $XS_HTTP_COOKIES       = eval { require_module('HTTP::XSCookies'); 1; };
 
 our $_id = 0;
 


### PR DESCRIPTION
Module::Runtime is a faster module than Class::Load (even with
Class::Load::XS available) and is already available by our stack.

This was applied in #1164; but was erroneously undone in a later Pr.