### PR TITLE
 Fix another edge case in plugin compat:

### DIFF
--- a/lib/Dancer2/Plugin.pm
+++ b/lib/Dancer2/Plugin.pm
@@ -523,7 +523,10 @@ sub register_plugin {
                     $plugin_module->can($keyword)
                       or *{"${plugin_module}::$keyword"} = sub {
                         $_[0]
-                          ? do { my $cc = shift()->app->name->can($keyword); $cc->(@_) }
+                          ? do {
+                            my $cb = shift()->app->name->can($keyword);
+                            $cb->(@_);
+                          }
                           : $app_dsl_cb->(@_);
                       };
                 }

--- a/lib/Dancer2/Plugin.pm
+++ b/lib/Dancer2/Plugin.pm
@@ -522,8 +522,9 @@ sub register_plugin {
                     no strict 'refs';
                     $plugin_module->can($keyword)
                       or *{"${plugin_module}::$keyword"} = sub {
-                          my $coderef = shift()->app->name->can($keyword);
-                          $coderef->(@_);
+                        $_[0]
+                          ? do { my $cc = shift()->app->name->can($keyword); $cc->(@_) }
+                          : $app_dsl_cb->(@_);
                       };
                 }
             });

--- a/t/plugin2/app_dsl_cb/app_dsl_cb.t
+++ b/t/plugin2/app_dsl_cb/app_dsl_cb.t
@@ -1,0 +1,20 @@
+use strict;
+use warnings;
+use lib 't/plugin2/app_dsl_cb/lib';
+use Test::More 'tests' => 4;
+use Plack::Test;
+use HTTP::Request::Common 'GET';
+use App with => { show_errors => 1 };
+use Test::Fatal 'exception';
+
+my $app = App->to_app;
+my $test = Plack::Test->create($app);
+
+my $res;
+is(
+    exception { $res = $test->request( GET '/' ) },
+    undef,
+    'Did not crash',
+);
+
+is( $res->content, 'GET DONE', 'Ran successfully' );

--- a/t/plugin2/app_dsl_cb/lib/App.pm
+++ b/t/plugin2/app_dsl_cb/lib/App.pm
@@ -1,0 +1,13 @@
+package App;
+use strict;
+use warnings;
+use Dancer2 appname => 'Other';
+use App::TestPlugin;
+
+get '/' => sub {
+    my $res = foo_from_plugin('Foo');
+    ::is( $res, 'OK', 'Plugin returned OK' );
+    return 'GET DONE';
+};
+
+1;

--- a/t/plugin2/app_dsl_cb/lib/App/TestPlugin.pm
+++ b/t/plugin2/app_dsl_cb/lib/App/TestPlugin.pm
@@ -1,0 +1,17 @@
+package App::TestPlugin;
+use strict;
+use warnings;
+use Dancer2::Plugin;
+
+plugin_keywords('foo_from_plugin');
+
+sub foo_from_plugin {
+    my ( $self, $arg ) = @_;
+    ::is( $arg, 'Foo', 'Correct argument to plugin' );
+    params();
+    return 'OK';
+}
+
+register_plugin();
+
+1;


### PR DESCRIPTION
[If you can figure this out... `$diety` help you.]

Here's the thing. I don't know how to describe this problem. I
never seem to be in the zone enough to fully understand it or
explain it. However, I have these bits of gleaned information
which I quote below.

```
So, I think it's like this: If you have a plugin that uses
DSL directly (which are only available on D2P1, in D2P2 you
have to use `$self`⁠⁠), anyou didn't call `register_plugin`,
those will not be available yet, and when you try to call them,
it will fail that they do not exist.

(Which makes sense. We create them for you, with a warning,
if you call `⁠register_plug⁠`, which you would do for D2P1
plugin anyway.)

However, and here's the kicker, if you do this while defining
your `appname` to a class that does not exist, you get a
different error. The error you get is that the specified
`appname` class cannot call the keyword you wanted.

This is because there was one more place in which I didn't
resolve GH #1226.
```

Here, then, is the final fix. It should be to just use the found
"app_cb_dsl" class, but that broke a test. Ugh. Anyway, crazy,
but works. How? Not sure.
