### PR TITLE
Consistency for TemplateToolkit config

### DIFF
--- a/lib/Dancer2/Core/Role/Template.pm
+++ b/lib/Dancer2/Core/Role/Template.pm
@@ -130,6 +130,7 @@ sub apply_renderer {
     $self->execute_hook( 'engine.template.before_render', $tokens );
 
     my $content = $self->render( $view, $tokens );
+
     $self->execute_hook( 'engine.template.after_render', \$content );
 
     # make sure to avoid ( undef ) in list context return

--- a/share/skel/config.yml
+++ b/share/skel/config.yml
@@ -24,8 +24,9 @@ template: "simple"
 # engines:
 #   template:
 #     template_toolkit:
-#       start_tag: '<%'
-#       end_tag:   '%>'
+#       START_TAG: '<%'
+#       END_TAG:   '%>'
+#       ANYCASE:   1
 
 # session engine
 #


### PR DESCRIPTION
Update skel config.yml to use the original Template::Toolkit
configuration keys and disable the ANYCASE config.

Use of the lower-case config tags will log a warning in debug mode.

This fixes: gh-1249
