### PR TITLE
One should use get_all() to get multiple values.

### DIFF
--- a/lib/Dancer2/Manual.pod
+++ b/lib/Dancer2/Manual.pod
@@ -2599,7 +2599,7 @@ Returns a L<Hash::MultiValue> object from the body parameters.
 
     post '/' => sub {
         my $last_name = body_parameters->get('name');
-        my @all_names = body_parameters->get('name');
+        my @all_names = body_parameters->get_all('name');
     };
 
 =head2 pass


### PR DESCRIPTION
Nod to tushar on #dancer who was having trouble and lead me to spot this.

Hash::MultiValue's docs for get() say: "Note that this always returns the single
element as a scalar, regardless of its context".