### PR TITLE
Fixup issue #1191 - use of named captures prior to dispatch breaks di…

### DIFF
--- a/lib/Dancer2/Core/Route.pm
+++ b/lib/Dancer2/Core/Route.pm
@@ -83,16 +83,17 @@ sub match {
 
     my @values = $request->dispatch_path =~ $self->regexp;
 
+    return unless @values;
+
     # if some named captures are found, return captures
     # no warnings is for perl < 5.10
+    # - Note no @values implies no named captures
     if (my %captures =
         do { no warnings; %+ }
       )
     {
         return $self->_match_data( { captures => \%captures } );
     }
-
-    return unless @values;
 
     # regex comments are how we know if we captured a token,
     # splat or a megasplat

--- a/t/disp_named_capture.t
+++ b/t/disp_named_capture.t
@@ -1,0 +1,22 @@
+package app;
+use Dancer2;
+get '/1' => sub {
+    return '1';
+};
+get '/2' => sub {
+    return '2';
+};
+package main;
+use Plack::Test;
+use HTTP::Request;
+use Test::More tests => 2;
+my $test = Plack::Test->create( app->to_app );
+my $request  = HTTP::Request->new( GET => 'http://localhost/1' );
+my $response = $test->request( $request );
+is( $response->content, 1 );
+"12345" =~ m#(?<capture>23)#;
+my $c = $+{capture};
+$request  = HTTP::Request->new( GET => 'http://localhost/2' );
+$response = $test->request( $request );
+is( $response->content, 2 );
+


### PR DESCRIPTION
…spatch

The code to handle named captures was being executed
even when the pattern did not match. If a named capture
matches then @values must have at least one value so
we can just move the empty @values guard clause up one
block.

I do think its a bit odd that the presence of named captures
causes such a change in code path. That seems dangerous
and problematic, but I leave that to a future bug report