### PR TITLE
fix #1255 - add_hook overriding is not operational

### DIFF
--- a/lib/Dancer2/Plugin.pm
+++ b/lib/Dancer2/Plugin.pm
@@ -572,7 +572,7 @@ sub _exporter_expand_sub {
     $orig_cb and *{'Dancer2::Core::App::add_hook'} = sub {
         my ( $app, $hook ) = @_;
 
-        my $hook_code = $hook->code;
+        my $hook_code = Scalar::Util::blessed($hook) ? $hook->code : $hook->{code};
         my $plugin    = $CUR_PLUGIN;
 
         $hook->{'code'} = sub {


### PR DESCRIPTION
Better fix than suggested in the bug report, we check if $hook is blessed, if it is we call the method, otherwise we access the $hook slot.