### PR TITLE
Move to Path::Tin

### DIFF
--- a/lib/Dancer2.pm
+++ b/lib/Dancer2.pm
@@ -9,7 +9,6 @@ use Import::Into;
 use Dancer2::Core;
 use Dancer2::Core::App;
 use Dancer2::Core::Runner;
-use Dancer2::FileUtils;
 
 our $AUTHORITY = 'SUKRIA';
 

--- a/lib/Dancer2/Core/DSL.pm
+++ b/lib/Dancer2/Core/DSL.pm
@@ -6,7 +6,7 @@ use Moo;
 use Carp;
 use Module::Runtime 'require_module';
 use Dancer2::Core::Hook;
-use Dancer2::FileUtils;
+use Dancer2::FileUtils ();
 use Dancer2::Core::Response::Delayed;
 
 with 'Dancer2::Core::Role::DSL';

--- a/lib/Dancer2/Core/Role/HasLocation.pm
+++ b/lib/Dancer2/Core/Role/HasLocation.pm
@@ -3,7 +3,7 @@ package Dancer2::Core::Role::HasLocation;
 
 use Moo::Role;
 use Dancer2::Core::Types;
-use Dancer2::FileUtils;
+use Dancer2::FileUtils ();
 use File::Spec;
 use Sub::Quote 'quote_sub';
 

--- a/lib/Dancer2/Template/Simple.pm
+++ b/lib/Dancer2/Template/Simple.pm
@@ -2,7 +2,8 @@ package Dancer2::Template::Simple;
 # ABSTRACT: Pure Perl 5 template engine for Dancer2
 
 use Moo;
-use Dancer2::FileUtils 'read_file_content';
+use Dancer2::FileUtils qw<read_file_content>;
+use Path::Tiny qw<path>;
 
 with 'Dancer2::Core::Role::Template';
 
@@ -26,10 +27,13 @@ sub BUILD {
 
 sub render {
     my ( $self, $template, $tokens ) = @_;
-    my $content;
 
-    $content = read_file_content($template);
-    $content = $self->parse_branches( $content, $tokens );
+    my $content =
+      ref $template eq 'SCALAR'
+      ? read_file_content($template)
+      : path($template)->slurp_utf8;
+
+    $content = $self->parse_branches($content, $tokens);
 
     return $content;
 }


### PR DESCRIPTION
[Path::Tiny](https://metacpan.org/pod/Path::Tiny) provides a clean, correct, and consistent interface to various path-related modules. We have our own module, which could be improved.

I want to at least replace the core of it with `Path::Tiny` and maybe remove it at some point in favor.

This is a work in progress. I have more work to commit once the tests pass.