### PR TITLE
Feature/send file charset

### DIFF
--- a/lib/Dancer2/Manual.pod
+++ b/lib/Dancer2/Manual.pod
@@ -2880,6 +2880,11 @@ like this:
 
     send_file(params->{file}, content_type => 'png');
 
+The encoding of the file or filehandle may be specified by passing both
+the C<content_type> and C<charset> options. For example:
+
+    send_file($fh, content_type => 'text/csv', charset => 'utf-8' );
+
 For files outside your B<public> folder, you can use the C<system_path>
 switch. Just bear in mind that its use needs caution as it can be dangerous.
 
@@ -2898,7 +2903,7 @@ Content-Disposition header, to hint the browser about the filename it should
 use.
 
    send_file( \$data, content_type => 'image/png'
-                             filename     => 'onion.png' );
+                      filename     => 'onion.png' );
 
 
 =head2 set

--- a/t/dsl/send_as.t
+++ b/t/dsl/send_as.t
@@ -22,7 +22,7 @@ use HTTP::Request::Common;
     };
 
     get '/json-utf8/**' => sub {
-        send_as JSON => splat, { content_type => 'application/json; charset=utf-8' };
+        send_as JSON => splat, { content_type => 'application/json', charset => 'utf-8' };
     };
 
     get '/yaml/**' => sub {

--- a/t/dsl/send_file.t
+++ b/t/dsl/send_file.t
@@ -36,7 +36,7 @@ use File::Spec;
 
     get '/filehandle' => sub {
         open my $fh, "<:raw", __FILE__;
-        send_file( $fh, content_type => 'text/plain' );
+        send_file( $fh, content_type => 'text/plain', charset => 'utf-8' );
     };
 
     get '/check_content_type' => sub {
@@ -100,6 +100,8 @@ test_psgi $app, sub {
         my $r = $cb->( GET '/filehandle' );
 
         is( $r->code, 200, 'send_file set status to 200 (filehandle)');
+        is( $r->content_type, 'text/plain', 'expected content_type');
+        is( $r->content_type_charset, 'UTF-8', 'expected charset');
         like( $r->content, qr{package StaticContent}, 'filehandle content' );
     };
 


### PR DESCRIPTION
Specify optional `charset` to `send_file` and `send_as`:

```
send_file( $filehandle, content_type => 'text/plain', charset => 'utf-8' );
```

Resolves #1260.