### PR TITLE
Feature/static 304

### DIFF
--- a/t/static_content.t
+++ b/t/static_content.t
@@ -1,0 +1,30 @@
+use strict;
+use warnings;
+use utf8;
+
+use Test::More;
+use Plack::Test;
+use HTTP::Request::Common;
+
+{
+    package PublicContent;
+    use Dancer2;
+
+    set public_dir => 't/corpus/static';
+
+    get '/' => sub { return 'Welcome Home' };
+
+}
+
+my $test = Plack::Test->create( PublicContent->to_app );
+
+subtest 'public content' => sub {
+    my $res = $test->request( GET '/1x1.png' );
+    is $res->code, 200, "200 response";
+    my $last_modified = $res->header('Last-Modified');
+    
+    $res = $test->request( GET '/1x1.png', 'If-Modified-Since' => $last_modified );
+    is $res->code, 304, "304 response";
+};
+
+done_testing();


### PR DESCRIPTION
The previous use of Middleware::Static was roughly

  If a file exists in the public directory that matched the request
  PATH_INFO, then use App::File to generate the response for the
  request.  Otherwise we pass-through to the Dancer2 app.

Then #1253 requested (quite reasonably) that the static handler support
Conditional GET's. However its not possible to do that with
Middleware::Static. A patch was submitted upstream and rejected; as
there *is* a simplier way of implementing the above logic using existing
middleware.

Instead, the above logic is implemented using Middleware::Conditional to
deal with the "if/then/else" part. If the file exists, use an App::File
instance wrapped in ConditionalGET to server the content, resolving #1253.
Otherwise the request is handled by out app.