### PR TITLE
fix wrong regex check against  $_

### DIFF
--- a/lib/Dancer2/Core/App.pm
+++ b/lib/Dancer2/Core/App.pm
@@ -71,7 +71,7 @@ sub _with_plugin {
     # short plugin names get Dancer2::Plugin:: prefix
     # plugin names starting with a '+' are full package names
     if ( $plugin !~ s/^\+// ) {
-        $plugin =~ s/^/Dancer2::Plugin::/ unless /^Dancer2::Plugin::/;
+        $plugin =~ s/^(?!Dancer2::Plugin::)/Dancer2::Plugin::/;
     }
 
     # check if it's already there


### PR DESCRIPTION
pretty sure the original line shouldn't have checked against $_ and should have been:
`... unless $plugin =~ /^Dancer2::Plugin::/;`

while at it, we could have just add the check into a negative look-ahead on the substitution regex.