### PR TITLE
eval named capture regex so tests pass on perl 5.8

### DIFF
--- a/t/disp_named_capture.t
+++ b/t/disp_named_capture.t
@@ -1,21 +1,34 @@
-package app;
-use Dancer2;
-get '/1' => sub {
-    return '1';
-};
-get '/2' => sub {
-    return '2';
-};
-package main;
+use warnings;
+use strict;
+
 use Plack::Test;
 use HTTP::Request;
 use Test::More tests => 2;
+
+{
+    package app;
+    use Dancer2;
+    get '/1' => sub {
+        return '1';
+    };
+    get '/2' => sub {
+        return '2';
+    };
+}
+
 my $test = Plack::Test->create( app->to_app );
 my $request  = HTTP::Request->new( GET => 'http://localhost/1' );
 my $response = $test->request( $request );
 is( $response->content, 1 );
+
+# "Dummy" regex to populate global $+
+# eval'd as named captures are not available until 5.10
+my $c;
+eval <<'NAMED';
 "12345" =~ m#(?<capture>23)#;
-my $c = $+{capture};
+$c = $+{capture};
+NAMED
+
 $request  = HTTP::Request->new( GET => 'http://localhost/2' );
 $response = $test->request( $request );
 is( $response->content, 2 );


### PR DESCRIPTION
Named captures are only supported for perl >= 5.10; with perl 5.8.9
throwing an error about the syntax of the named capture group
(only version tested). eval the regex as a string of code to "hide"
the named capture on perl < 5.10.