### PR TITLE
Call route_exception hook before logging error

### DIFF
--- a/lib/Dancer2/Core/App.pm
+++ b/lib/Dancer2/Core/App.pm
@@ -1587,8 +1587,8 @@ sub _prep_response {
 sub response_internal_error {
     my ( $self, $error ) = @_;
 
-    $self->log( error => "Route exception: $error" );
     $self->execute_hook( 'core.app.route_exception', $self, $error );
+    $self->log( error => "Route exception: $error" );
 
     local $Dancer2::Core::Route::REQUEST  = $self->request;
     local $Dancer2::Core::Route::RESPONSE = $self->response;


### PR DESCRIPTION
One might want to do "other things" when an exception has been raised, such as raising other exceptions. In this case, you probably don't want to also call the error logger. Therefore, this patch calls the logger after the hook rather than before. It saves dirty hacks like this:

https://metacpan.org/source/MARKOV/Log-Report-1.18/lib/Dancer2/Logger/LogReport.pm#L64
