### PR TITLE
Stop removing script_name from request's dispatch_path.

### DIFF
--- a/lib/Dancer2/Core/Request.pm
+++ b/lib/Dancer2/Core/Request.pm
@@ -278,15 +278,6 @@ sub dispatch_path {
 
     my $path = $self->path;
 
-    # Want $self->base->path, without needing the URI object,
-    # and trim any trailing '/'.
-    my $base = '';
-    $base .= $self->script_name if defined $self->script_name;
-    $base =~ s|/+$||;
-
-    # Remove base from front of path.
-    $path =~ s|^(\Q$base\E)?||;
-    $path =~ s|^/+|/|;
     # PSGI spec notes that '' should be considered '/'
     $path = '/' if $path eq '';
     return $path;

--- a/t/dsl/path.t
+++ b/t/dsl/path.t
@@ -1,6 +1,6 @@
 use strict;
 use warnings;
-use Test::More tests => 4;
+use Test::More tests => 5;
 use Plack::Test;
 use Plack::Request;
 use Plack::Builder;
@@ -107,4 +107,17 @@ subtest '/mounted/endpoint' => sub {
     ok( $res->is_success, 'Result successful' );
     is( $res->content, '/mounted', 'script_name is /mounted' );
 };
+
+subtest '/e/endpoint' => sub {
+    my $app = builder {
+        mount '/' => sub { [200,[],['OK']] };
+        mount '/e' => App->to_app;
+    };
+
+    my $test = Plack::Test->create($app);
+
+    my $res = $test->request( GET '/e/endpoint' );
+    ok( $res->is_success, 'Result successful' );
+    is( $res->content, '/e', 'script_name is /e' );
+}
 


### PR DESCRIPTION
This appears to be unnecessary and in the case where the mount point matches the start of the requested path, the request ends up with the mount point part removed from the path.

This gist should demonstrate the issue:

https://gist.github.com/jbarrett/458baf48a11802ad51f60888e7c9305d

Thanks!
