### PR TITLE
Fix in _read_to_end

### DIFF
--- a/lib/Dancer2/Core/Request.pm
+++ b/lib/Dancer2/Core/Request.pm
@@ -520,7 +520,7 @@ sub _read_to_end {
 
     my $body = '';
     if ( $content_length && $content_length > 0 ) {
-        while ( my $buffer = $self->_read() ) {
+        while ( length ( my $buffer = $self->_read() ) ) {
             $body .= $buffer;
         }
         $self->{_http_body}->add($body);


### PR DESCRIPTION
The bug in the original code: the buffer appears empty, if it reads the string '0', which means false in Perl.
Therefore we should test buffer length instead.