### PR TITLE
Document change_session_id in Core::App

### DIFF
--- a/lib/Dancer2/Core/App.pm
+++ b/lib/Dancer2/Core/App.pm
@@ -1658,6 +1658,12 @@ retrieve the session from the cookie in the request.  If no new session is
 created, this is set (with expiration) as a cookie to force the browser to
 expire the cookie.
 
+=method change_session_id
+
+Changes the session ID used by the current session. This should be used on
+any change of privilege level, for example on login. Returns the new session
+ID.
+
 =method destroy_session
 
 Destroys the current session and ensures any subsequent session is created


### PR DESCRIPTION
Mea Culpa. Should have done this when I initially added the method. There is documentation in Manual but nothing in Core::App.