### PR TITLE
Improve support for "has" in Dancer2::Plugin

### DIFF
--- a/lib/Dancer2/Plugin.pm
+++ b/lib/Dancer2/Plugin.pm
@@ -342,8 +342,17 @@ sub _exporter_plugin {
             our \@EXPORT = ( ':app' );
 
             around has => sub {
-                my( \$orig, \$name, \@args ) = \@_;
-                \$orig->( ${caller}->_p2_has( \$_, \@args) )
+                my( \$orig, \$name, \%args ) = \@_;
+
+                if (ref \$name eq 'ARRAY'
+                        && exists \$args{'plugin_keyword'}
+                        && ref \$args{'plugin_keyword'} eq 'ARRAY') {
+
+                    Carp::croak('Setting "plugin_keyword" to an array is disallowed'
+                        . ' when defining multiple attributes simultaneously');
+                }
+
+                \$orig->( ${caller}->_p2_has( \$_, \%args) )
                     for ref \$name ? @\$name : \$name;
             };
 

--- a/lib/Dancer2/Plugin.pm
+++ b/lib/Dancer2/Plugin.pm
@@ -342,8 +342,9 @@ sub _exporter_plugin {
             our \@EXPORT = ( ':app' );
 
             around has => sub {
-                my( \$orig, \@args ) = \@_;
-                \$orig->( ${caller}->_p2_has( \@args) );
+                my( \$orig, \$name, \@args ) = \@_;
+                \$orig->( ${caller}->_p2_has( \$_, \@args) )
+                    for ref \$name ? @\$name : \$name;
             };
 
             sub PluginKeyword :ATTR(CODE,BEGIN) {

--- a/t/plugin2/from-config.t
+++ b/t/plugin2/from-config.t
@@ -1,7 +1,7 @@
 use strict;
 use warnings;
 
-use Test::More tests => 5;
+use Test::More tests => 7;
 
 {
 package Dancer2::Plugin::FromConfig;
@@ -37,6 +37,12 @@ has six => (
     plugin_keyword => 1,
 );
 
+has [qw(seven eight)] => (
+    is => 'ro',
+    from_config => 1,
+    plugin_keyword => 1,
+);
+
 plugin_keywords qw/ one three four five /;
 
 }
@@ -54,7 +60,9 @@ plugin_keywords qw/ one three four five /;
             one => 'un',
             two => {
                 three => 'trois',
-            }
+            },
+            seven => 'sept',
+            eight => 'huit',
         }
     };
 
@@ -64,6 +72,8 @@ plugin_keywords qw/ one three four five /;
     Test::More::is four() => 'quatre', 'nothing in config, default value';
     Test::More::is five() => 'cinq', 'from_config a coderef';
     Test::More::is six() => 'AH!', 'from_config a coderef, no override';
+    Test::More::is seven() => 'sept', 'from_config, defined two fields at once #1';
+    Test::More::is eight() => 'huit', 'from_config, defined two fields at once #2';
 }
 
 

--- a/t/plugin2/from-config.t
+++ b/t/plugin2/from-config.t
@@ -1,7 +1,7 @@
 use strict;
 use warnings;
 
-use Test::More tests => 7;
+use Test::More tests => 8;
 
 {
 package Dancer2::Plugin::FromConfig;
@@ -43,6 +43,15 @@ has [qw(seven eight)] => (
     plugin_keyword => 1,
 );
 
+eval {
+    has [qw(nine ten)] => (
+        is => 'ro',
+        from_config => 1,
+        plugin_keyword => ['nine', 'ten'],
+    );
+};
+our $plugin_keyword_exception = $@;
+
 plugin_keywords qw/ one three four five /;
 
 }
@@ -74,6 +83,9 @@ plugin_keywords qw/ one three four five /;
     Test::More::is six() => 'AH!', 'from_config a coderef, no override';
     Test::More::is seven() => 'sept', 'from_config, defined two fields at once #1';
     Test::More::is eight() => 'huit', 'from_config, defined two fields at once #2';
+    Test::More::ok $Dancer2::Plugin::FromConfig::plugin_keyword_exception,
+        "defining two fields simultaneously with multiple plugin_keyword values"
+        . " is disallowed";
 }
 
 


### PR DESCRIPTION
Hello! I was writing a Dancer2 plugin for $WORK, and couldn't figure out why my attributes weren't pulling their values from the plugin configs. Eventually I figured out it was because I was defining multiple attributes at once in my plugin, a la:

````perl
#!/usr/bin/env perl

package PluginTest;
use Dancer2::Plugin;
has [qw(field1)]    => ( is => 'ro', from_config => 1 ); # THIS BREAKS!
has 'field2'        => ( is => 'ro', from_config => 1 ); # This works

plugin_keywords 'test_fields' => sub {
    my $self = shift;
    foreach my $field (qw(field1 field2)) {
        print STDERR "$field:" . ($self->$field // '(undef)') . "\n";
    }
};

package main;
use Dancer2;
PluginTest->import();

set plugins => {
    "PluginTest" => {
        field1 => 'woo',
        field2 => 'hoo',
    },
};

get '/' => sub {
    test_fields();
    return "TEST";
};
dance;
````

When I run that script and hit localhost:3000/ , I get:

````
➜  Foo perl server.pl 
>> Dancer2 v0.204001 server 14578 listening on http://0.0.0.0:3000
[main:14578] core @2016-11-22 17:49:30> looking for get / in /home/nfg/.plenv/versions/5.20.3/lib/perl5/site_perl/5.20.3/Dancer2/Core/App.pm l. 34
[main:14578] core @2016-11-22 17:49:30> Entering hook core.app.before_request in (eval 115) l. 1
field1:(undef)
field2:hoo
[main:14578] core @2016-11-22 17:49:30> Entering hook core.app.after_request in (eval 115) l. 1
````

This PR should fix the issue.