### PR TITLE
typo fix

### DIFF
--- a/lib/Dancer2/Core/Response.pm
+++ b/lib/Dancer2/Core/Response.pm
@@ -305,7 +305,7 @@ if nothing was specified
 Encodes the stored content according to the stored L<content_type>.  If the content_type
 is a text format C<^text>, then no encoding will take place.
 
-Interally, it uses the L<is_encoded> flag to make sure that content is not encoded twice.
+Internally, it uses the L<is_encoded> flag to make sure that content is not encoded twice.
 
 If it encodes the content, then it will return the encoded content.  In all other
 cases it returns C<false>.


### PR DESCRIPTION

In Debian we are currently applying the following patch to Dancer2.
We thought you might be interested in it too.

    Description: typo fix
    Origin: vendor
    Author: gregor herrmann <gregoa@debian.org>
    Last-Update: 2016-12-23
    

The patch is tracked in our Git repository at
https://anonscm.debian.org/cgit/pkg-perl/packages/libdancer2-perl.git/plain/debian/patches/spelling.patch

Thanks for considering,
  gregor herrmann,
  Debian Perl Group
