### PR TITLE
fix serializers not honouring config in send_as

### DIFF
--- a/lib/Dancer2/Core/App.pm
+++ b/lib/Dancer2/Core/App.pm
@@ -955,7 +955,7 @@ sub send_as {
 
     # load any serializer engine config
     my $engine_options =
-        $self->_get_config_for_engine( serializer => $type, {} ) || {};
+        $self->_get_config_for_engine( serializer => $type, $self->config ) || {};
     my $serializer = $serializer_class->new( config => $engine_options );
     my $content = $serializer->serialize( $data );
     $options->{content_type} ||= $serializer->content_type;


### PR DESCRIPTION
When send_as() instantiates a new serializer object, _get_config_for_engine() doesn't pass in the app's config. As such, it never returns the config options for a serializer engine.

Fixes #1302 