### PR TITLE
Revert "Consistency for TemplateToolkit config"

### DIFF
--- a/lib/Dancer2/Core/Role/Template.pm
+++ b/lib/Dancer2/Core/Role/Template.pm
@@ -130,7 +130,6 @@ sub apply_renderer {
     $self->execute_hook( 'engine.template.before_render', $tokens );
 
     my $content = $self->render( $view, $tokens );
-
     $self->execute_hook( 'engine.template.after_render', \$content );
 
     # make sure to avoid ( undef ) in list context return

--- a/lib/Dancer2/Template/TemplateToolkit.pm
+++ b/lib/Dancer2/Template/TemplateToolkit.pm
@@ -23,25 +23,19 @@ sub _build_engine {
         %{ $self->config },
     );
 
-    # Mappings, fade out at some stage, was there an intent to make them the same as
-    # the tags for Dancer2::Template::Simple?
-    my %legacy = (
-      INCLUDE_PATH => ['include_path'],
-      END_TAG => ['stop_tag', 'end_tag'],
-      START_TAG => ['start_tag'],
-    );
-    while (my ($key, $aliases) = each %legacy) {
-      foreach my $alias (@$aliases) {
-        if (exists $self->config->{$alias}) {
-          $self->log_cb()->('debug' => 
-            "deprecated: please update your config '$alias' should be '$key'");
-          $tt_config{$key} = $self->config->{$alias};
-        }
-      }
-    }
+    my $start_tag = $self->config->{'start_tag'};
+    my $stop_tag = $self->config->{'stop_tag'} || $self->config->{end_tag};
+    $tt_config{'START_TAG'} = $start_tag
+      if defined $start_tag && $start_tag ne '[%';
+    $tt_config{'END_TAG'} = $stop_tag
+      if defined $stop_tag && $stop_tag ne '%]';
 
     Scalar::Util::weaken( my $ttt = $self );
-    $tt_config{'INCLUDE_PATH'} ||= [ sub { [ $ttt->views ] }, ];
+    my $include_path = $self->config->{include_path};
+    $tt_config{'INCLUDE_PATH'} ||= [
+        ( defined $include_path ? $include_path : () ),
+        sub { [ $ttt->views ] },
+    ];
 
     my $tt = Template->new(%tt_config);
     $Template::Stash::PRIVATE = undef if $self->config->{show_private_variables};

--- a/share/skel/config.yml
+++ b/share/skel/config.yml
@@ -24,9 +24,8 @@ template: "simple"
 # engines:
 #   template:
 #     template_toolkit:
-#       START_TAG: '<%'
-#       END_TAG:   '%>'
-#       ANYCASE:   1
+#       start_tag: '<%'
+#       end_tag:   '%>'
 
 # session engine
 #


### PR DESCRIPTION
This reverts commit 8d0f3b105897283f3c28eade020f0e01798923f5.

See https://github.com/PerlDancer/Dancer2/issues/1307

Summary: that commit breaks [% %] tags in TT.