### PR TITLE
Adjust dist.ini to set build_requires for ExtUtils::MakeMaker #1315

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -34,6 +34,11 @@ add_files_in = README.mkdn
 [MakeMaker]
 eumm_version = 7.1101
 
+[Prereqs]
+; required to set minimal build requires version in META.yml file
+-phase = build
+ExtUtils::MakeMaker= 7.1101
+
 ; -- static meta-information
 [MetaResources]
 homepage        = http://perldancer.org/


### PR DESCRIPTION
The ExtUtils::MakeMaker version was not set correctly
in the build_requires section of the META.yml file.

simple test
```
before> grep -B2 MakeMaker Dancer2-0.204004/META.yml
build_requires:
  Capture::Tiny: '0.12'
  ExtUtils::MakeMaker: '0'
--
  Test::More: '0.92'
configure_requires:
  ExtUtils::MakeMaker: '7.1101'

after> grep -B2 MakeMaker Dancer2-0.204004/META.yml
build_requires:
  Capture::Tiny: '0.12'
  ExtUtils::MakeMaker: '7.1101'
--
  Test::More: '0.92'
configure_requires:
  ExtUtils::MakeMaker: '7.1101'  
```