### PR TITLE
Add support for the SameSite cookie attribute

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -54,7 +54,7 @@ recommends 'CGI::Deurl::XS';
 recommends 'Class::XSAccessor';
 recommends 'Cpanel::JSON::XS';
 recommends 'Crypt::URandom';
-recommends 'HTTP::XSCookies', '0.000005';
+recommends 'HTTP::XSCookies', '0.000007';
 recommends 'HTTP::XSHeaders';
 recommends 'Math::Random::ISAAC::XS';
 recommends 'Pod::Simple::Search';

--- a/lib/Dancer2/Core/Cookie.pm
+++ b/lib/Dancer2/Core/Cookie.pm
@@ -39,6 +39,7 @@ sub xs_to_header {
             expires  => $self->expires,
             httponly => $self->http_only,
             secure   => $self->secure,
+            samesite => $self->same_site,
         }
     );
 }
@@ -50,10 +51,11 @@ sub pp_to_header {
     my $no_httponly = defined( $self->http_only ) && $self->http_only == 0;
 
     my @headers = $self->name . '=' . $value;
-    push @headers, "Path=" . $self->path       if $self->path;
-    push @headers, "Expires=" . $self->expires if $self->expires;
-    push @headers, "Domain=" . $self->domain   if $self->domain;
-    push @headers, "Secure"                    if $self->secure;
+    push @headers, "Path=" . $self->path          if $self->path;
+    push @headers, "Expires=" . $self->expires    if $self->expires;
+    push @headers, "Domain=" . $self->domain      if $self->domain;
+    push @headers, "SameSite=" . $self->same_site if $self->same_site;
+    push @headers, "Secure"                       if $self->secure;
     push @headers, 'HttpOnly' unless $no_httponly;
 
     return join '; ', @headers;
@@ -124,6 +126,12 @@ has http_only => (
     isa      => Bool,
     required => 0,
     default  => sub {0},
+);
+
+has same_site => (
+    is       => 'rw',
+    isa      => Enum[qw[Strict Lax]],
+    required => 0,
 );
 
 1;
@@ -202,5 +210,10 @@ the server (via HTTP) and not by any JavaScript code.
 
 If your cookie is meant to be used by some JavaScript code, set this
 attribute to 0.
+
+=attr same_site
+
+Whether the cookie ought not to be sent along with cross-site requests,
+an enum of either "Strict" or "Lax", default is unset.
 
 =cut

--- a/t/cookie.t
+++ b/t/cookie.t
@@ -1,5 +1,6 @@
 use strict;
 use warnings;
+use Test::Fatal;
 use Test::More;
 
 BEGIN {
@@ -69,6 +70,8 @@ sub run_test {
     is $cookie->http_only(0) => 0;
     ok !$cookie->http_only;
 
+    like exception { $cookie->same_site('foo') },
+        qr/foo is not any of the possible values: Strict, Lax!/;
 
     note "expiration strings";
 
@@ -137,6 +140,20 @@ sub run_test {
                 value => 'foo',
             },
             expected => "bar=foo; Path=/",
+        },
+        {   cookie => {
+                name      => 'same-site',
+                value     => 'strict',
+                same_site => 'Strict',
+            },
+            expected => 'same-site=strict; Path=/; SameSite=Strict',
+        },
+        {   cookie => {
+                name      => 'same-site',
+                value     => 'lax',
+                same_site => 'Lax',
+            },
+            expected => 'same-site=lax; Path=/; SameSite=Lax',
         },
     );
 


### PR DESCRIPTION
Support for the SameSite attribute was added to HTTP::XSCookies in https://github.com/gonzus/http-xscookies/pull/2 which was released with version 0.000007

This commit adds support to the Dancer2 layer on top.