### PR TITLE
Bugfix/deprecate dispatch path

### DIFF
--- a/lib/Dancer2/Core/Request.pm
+++ b/lib/Dancer2/Core/Request.pm
@@ -274,22 +274,8 @@ sub uri_base {
 }
 
 sub dispatch_path {
-    my $self = shift;
-
-    my $path = $self->path;
-
-    # Want $self->base->path, without needing the URI object,
-    # and trim any trailing '/'.
-    my $base = '';
-    $base .= $self->script_name if defined $self->script_name;
-    $base =~ s|/+$||;
-
-    # Remove base from front of path.
-    $path =~ s|^(\Q$base\E)?||;
-    $path =~ s|^/+|/|;
-    # PSGI spec notes that '' should be considered '/'
-    $path = '/' if $path eq '';
-    return $path;
+    warn q{request->dispatch_path is deprecated};
+    return shift->path;
 }
 
 sub uri_for {
@@ -807,8 +793,7 @@ content, returns the deserialized structure as a hashref.
 
 =method dispatch_path
 
-The part of the C<path> after C<base>. This is the path used
-for dispatching the request to routes.
+Alias for L<path>. Deprecated.
 
 =method env
 

--- a/lib/Dancer2/Core/Route.pm
+++ b/lib/Dancer2/Core/Route.pm
@@ -81,7 +81,7 @@ sub match {
         return unless $self->validate_options($request);
     }
 
-    my @values = $request->dispatch_path =~ $self->regexp;
+    my @values = $request->path =~ $self->regexp;
 
     return unless @values;
 

--- a/lib/Dancer2/Manual.pod
+++ b/lib/Dancer2/Manual.pod
@@ -490,9 +490,9 @@ For another example, this can be used along with session support to easily
 give non-logged-in users a login page:
 
     hook before => sub {
-        if (!session('user') && request->dispatch_path !~ m{^/login}) {
+        if (!session('user') && request->path !~ m{^/login}) {
             # Pass the original path requested along to the handler:
-            forward '/login', { requested_path => request->dispatch_path };
+            forward '/login', { requested_path => request->path };
         }
     };
 
@@ -914,8 +914,8 @@ This can easily be handled using a before hook to check their session:
     set session => "Simple";
 
     hook before => sub {
-        if (!session('user') && request->dispatch_path !~ m{^/login}) {
-            forward '/login', { requested_path => request->dispatch_path };
+        if (!session('user') && request->path !~ m{^/login}) {
+            forward '/login', { requested_path => request->path };
         }
     };
 

--- a/t/dsl/halt.t
+++ b/t/dsl/halt.t
@@ -61,7 +61,7 @@ subtest 'halt in before hook' => sub {
 
         hook before => sub {
             response->content('I was halted');
-            halt if request->dispatch_path eq '/shortcircuit';
+            halt if request->path eq '/shortcircuit';
         };
 
     }

--- a/t/dsl/halt_with_param.t
+++ b/t/dsl/halt_with_param.t
@@ -59,7 +59,7 @@ subtest 'halt with parameter in before hook' => sub {
         use Dancer2;
 
         hook before => sub {
-            halt('I was halted') if request->dispatch_path eq '/shortcircuit';
+            halt('I was halted') if request->path eq '/shortcircuit';
         };
 
     }

--- a/t/dsl/path.t
+++ b/t/dsl/path.t
@@ -1,6 +1,6 @@
 use strict;
 use warnings;
-use Test::More tests => 4;
+use Test::More tests => 5;
 use Plack::Test;
 use Plack::Request;
 use Plack::Builder;
@@ -106,5 +106,20 @@ subtest '/mounted/endpoint' => sub {
     my $res = $test->request( GET '/mounted/endpoint' );
     ok( $res->is_success, 'Result successful' );
     is( $res->content, '/mounted', 'script_name is /mounted' );
+};
+
+# Tests behaviour when SCRIPT_NAME is also the beginning of PATH_INFO
+# See the discussion in #1288.
+subtest '/endpoint/endpoint' => sub {
+    my $app = builder {
+        mount '/' => sub { [200,[],['OK']] };
+        mount '/endpoint' => App->to_app;
+    };
+
+    my $test = Plack::Test->create($app);
+
+    my $res = $test->request( GET '/endpoint/endpoint' );
+    ok( $res->is_success, 'Result successful' );
+    is( $res->content, '/endpoint', 'script_name is /endpoint' );
 };
 

--- a/t/forward_before_hook.t
+++ b/t/forward_before_hook.t
@@ -18,14 +18,14 @@ get '/redirect' => sub {
 };
 
 hook before => sub {
-    return if request->dispatch_path eq '/default';
+    return if request->path eq '/default';
 
     # Add some content to the response
     response->content("SillyStringIsSilly");
 
     # redirect - response should include the above content
     return redirect '/default'
-        if request->dispatch_path eq '/redirect';
+        if request->path eq '/redirect';
 
     # The response object will get replaced by the result of the forward.
     forward '/default';

--- a/t/issues/gh-944.t
+++ b/t/issues/gh-944.t
@@ -11,7 +11,7 @@ use HTTP::Request::Common;
     set serializer => 'JSON';
 
     hook before => sub {
-        return if request->dispatch_path eq '/content';
+        return if request->path eq '/content';
         response->content({ foo => 'bar' });
         response->halt;
     };

--- a/t/request.t
+++ b/t/request.t
@@ -122,8 +122,8 @@ sub run_test {
         is $req->scheme, 'http';
     }
 
-    note "testing path, dispatch_path and uri_base"; {
-        # Base env used for path, dispatch_path and uri_base tests
+    note "testing path and uri_base"; {
+        # Base env used for path and uri_base tests
         my $base = {
             'psgi.url_scheme' => 'http',
             REQUEST_METHOD    => 'GET',
@@ -145,9 +145,6 @@ sub run_test {
         is( $req->uri_base, 'http://localhost:5000/foo',
             'uri_base correct when empty PATH_INFO'
         );
-        is( $req->dispatch_path, '/',
-            'dispatch_path correct when empty PATH_INFO'
-        );
 
         # SCRIPT_NAME not set
         $env = {
@@ -160,9 +157,6 @@ sub run_test {
         is( $req->path, '/foo', 'path corrent when empty SCRIPT_NAME' );
         is( $req->uri_base, 'http://localhost:5000',
             'uri_base handles empty SCRIPT_NAME'
-        );
-        is( $req->dispatch_path, '/foo',
-            'dispatch_path handles empty SCRIPT_NAME'
         );
 
         # Both SCRIPT_NAME and PATH_INFO set
@@ -180,9 +174,6 @@ sub run_test {
         is( $req->uri_base, 'http://localhost:5000/foo',
             'uri_base correct when both PATH_INFO and SCRIPT_NAME set',
         );
-        is( $req->dispatch_path, '/bar/baz/',
-            'dispatch_path correct when both PATH_INFO and SCRIPT_NAME set'
-        );
 
         # Neither SCRIPT_NAME or PATH_INFO set
         $env = {
@@ -197,9 +188,6 @@ sub run_test {
         );
         is( $req->uri_base, 'http://localhost:5000',
             'uri_base correct when calculated from REQUEST_URI',
-        );
-        is( $req->dispatch_path, '/',
-            'dispatch_path correct when calculated from REQUEST_URI'
         );
     }
 


### PR DESCRIPTION
`request->dispatch_path` was introduced due to a buggy `request->path` implementation. (See #373).  Commit c6af1c0 fixed the `request->path` implementation; but caused `dispatch_path` to incorrectly fail route match when SCRIPT_NAME was also a prefix of the PATH_INFO.

After c6af1c0 was applied; it was safe to dispatch against the corrected `request->path` implementation. This PR deprecates `request->dispatch_path` (warns then calls `request->path`).

This is an alternate approach to #1288. Thanks to @jbarrett for reporting the issue there.