### PR TITLE
Test & support multi-value cookies under XS

### DIFF
--- a/lib/Dancer2/Core/Cookie.pm
+++ b/lib/Dancer2/Core/Cookie.pm
@@ -31,9 +31,12 @@ BEGIN {
 sub xs_to_header {
     my $self = shift;
 
+    # HTTP::XSCookies can't handle multi-value cookies.
+    return $self->pp_to_header(@_) if @{[ $self->value ]} > 1;
+
     return HTTP::XSCookies::bake_cookie(
         $self->name,
-        {   value    => join('&', $self->value),
+        {   value    => $self->value,
             path     => $self->path,
             domain   => $self->domain,
             expires  => $self->expires,

--- a/t/cookie.t
+++ b/t/cookie.t
@@ -10,6 +10,7 @@ BEGIN {
 }
 
 use Dancer2::Core::Cookie;
+use Dancer2::Core::Request;
 
 diag "If you want extra speed, install HTTP::XSCookies"
   if !Dancer2::Core::Cookie::_USE_XS;
@@ -163,6 +164,16 @@ sub run_test {
         my @a = split /; /, $c->to_header;
         is join("; ", shift @a, sort @a), $cook->{expected};
     }
+
+    note 'multi-value';
+
+    my $c = Dancer2::Core::Cookie->new( name => 'foo', value => [qw/bar baz/] );
+
+    is $c->to_header, 'foo=bar&baz; Path=/';
+
+    my $r = Dancer2::Core::Request->new( env => { HTTP_COOKIE => 'foo=bar&baz' } );
+
+    is_deeply [ $r->cookies->{foo}->value ], [qw/bar baz/];
 }
 
 note "Run test with XS_HTTP_COOKIES" if Dancer2::Core::Cookie::_USE_XS;


### PR DESCRIPTION
The issue is that we join on ampersand **before** escaping the value in the XS path which leads to incorrectly escaped ampersands in the final HTTP header.

A better fix would of course be to work out a calling convention to support multi-value cookies with HTTP::XSCookie, but in the mean time this at least restores working behaviour for people who opt into the XS backend.