### PR TITLE
Add preliminary prepare_app with guard

### DIFF
--- a/lib/Dancer2/Core/App.pm
+++ b/lib/Dancer2/Core/App.pm
@@ -593,6 +593,18 @@ has routes => (
     },
 );
 
+has 'calling_class' => (
+    'is'      => 'ro',
+    'isa'     => Str,
+    'default' => sub {
+        my $class = ( caller(2) )[0] ||
+                    ( caller(1) )[0] ||
+                    ( caller(0) )[0];
+
+        return $class;
+    },
+);
+
 # add_hook will add the hook to the first "hook candidate" it finds that support
 # it. If none, then it will try to add the hook to the current application.
 around add_hook => sub {
@@ -1111,6 +1123,11 @@ sub finish {
         && $self->plugins->[0]->_add_postponed_plugin_hooks(
             $self->postponed_hooks
         );
+
+    $self->calling_class->can('prepare_app')
+      and warn "WARNING: You have a subroutine in your "
+      . "app called 'prepare_app'. In the future "
+      . "this will automatically be called by Dancer2.";
 }
 
 sub init_route_handlers {

--- a/t/prepare_app.t
+++ b/t/prepare_app.t
@@ -1,0 +1,57 @@
+use strict;
+use warnings;
+use Plack::Test;
+use HTTP::Request::Common;
+use Test::More 'tests' => 2;
+use Capture::Tiny qw< capture_stderr capture_merged >;
+
+{
+    package App;
+    use Dancer2;
+    sub prepare_app {1}
+    get '/' => sub {'OK'};
+}
+
+{
+    package Bar;
+    use Dancer2 'appname' => 'App';
+    sub prepare_app {2}
+    get '/' => sub {'OK'};
+}
+
+my $msg = qr{
+    ^ WARNING: \s You \s have \s a \s subroutine \s in \s your
+    \s app \s called \s 'prepare_app' \.
+    \s In \s the \s future \s this \s will \s automatically
+    \s be \s called \s by \s Dancer2 \.
+}xms;
+
+subtest 'App' => sub {
+    my $app;
+    like(
+        capture_stderr { $app = App->to_app; },
+        $msg,
+        'Got warning on prepare_app sub',
+    );
+
+    my $test = Plack::Test->create($app);
+    my $res;
+    my $out;
+    capture_merged { $res = $test->request( GET '/' )->content },
+    is(
+        $res,
+        'OK',
+        'Correct content',
+    );
+
+    is( $out, undef, 'No extra warnings or output' );
+};
+
+subtest 'Bar' => sub {
+    my $app;
+    like(
+        capture_stderr { $app = Bar->to_app; },
+        $msg,
+        'Got warning on prepare_app sub',
+    );
+};


### PR DESCRIPTION
I want to have a `prepare_app` which will be triggered on a `to_app`, just like what we manually do with `setup`, which is uncomfortable and not assured.

In order to introduce a `prepare_app` method in the caller, we need
to first make sure a user does not have one. This implements the
logic necessary to call it when it is available by including the
original class that was called, and then checking on it whether
the class has it, and if so, warns about it loudly.

Perhaps we should set a version or date?

We set the caller by attempting to reach level 2, which is the
correct level, but if you're calling App->new() manually (like
from a test), then you might have it at level 1, but if that's
not good, we can at least take level 0.