### PR TITLE
Fix Cookbook prefix example

### DIFF
--- a/lib/Dancer2/Cookbook.pod
+++ b/lib/Dancer2/Cookbook.pod
@@ -857,7 +857,7 @@ receiving serialized requests) and providing rendered pages.
      get '/' => sub { +{ resources => \%resources, ... } };
 
      # user-specific routes, for example
-     prefix => '/users' => sub {
+     prefix '/users' => sub {
          get '/view'     => sub {...};
          get '/view/:id' => sub {...};
          put '/add'      => sub {...}; # automatically deserialized params


### PR DESCRIPTION
Previously the example looked like this

  prefix => '/users' => sub {

but that generates warnings, and I believe it was just a typo.
So I'm removing the => after prefix.