### PR TITLE
Minor docs fix

### DIFF
--- a/lib/Dancer2/Core/Request.pm
+++ b/lib/Dancer2/Core/Request.pm
@@ -735,7 +735,7 @@ Checks whether we are behind a proxy using the C<behind_proxy>
 configuration option, and if so returns the first
 C<HTTP_X_FORWARDED_HOST>, since this is a comma separated list.
 
-If you have not configured that you behind a proxy, it returns HTTP
+If you have not configured that you are behind a proxy, it returns HTTP
 header C<HTTP_HOST>.
 
 =item C<keep_alive>


### PR DESCRIPTION
Added missing word "are" in `request->host` documentation