### PR TITLE
fix a typo

### DIFF
--- a/lib/Dancer2/Core/Response/Delayed.pm
+++ b/lib/Dancer2/Core/Response/Delayed.pm
@@ -92,7 +92,7 @@ This object represents a delayed (asynchronous) response for L<Dancer2>.
 It can be used via the C<delayed> keyword.
 
 It keeps references to a request and a response in order to avoid
-keeping a reference ot the application.
+keeping a reference to the application.
 
 =head1 ATTRIBUTES
 


### PR DESCRIPTION

In Debian we are currently applying the following patch to Dancer2.
We thought you might be interested in it too.

    Description: fix a typo
    Origin: vendor
    Author: gregor herrmann <gregoa@debian.org>
    Last-Update: 2017-06-18
    

The patch is tracked in our Git repository at
https://anonscm.debian.org/cgit/pkg-perl/packages/libdancer2-perl.git/plain/debian/patches/spelling.patch

Thanks for considering,
  gregor herrmann,
  Debian Perl Group
