### PR TITLE
Converted the rest of the ref checks to Ref::Util

### DIFF
--- a/lib/Dancer2/Logger/Capture.pm
+++ b/lib/Dancer2/Logger/Capture.pm
@@ -69,6 +69,7 @@ It's primary purpose is for testing. Here is an example of a test:
     use Test::More;
     use Plack::Test;
     use HTTP::Request::Common;
+    use Ref::Util qw<is_coderef>;
 
     {
         package App;
@@ -85,7 +86,7 @@ It's primary purpose is for testing. Here is an example of a test:
     }
 
     my $app = Dancer2->psgi_app;
-    is( ref $app, 'CODE', 'Got app' );
+    ok( is_coderef($app), 'Got app' );
 
     test_psgi $app, sub {
         my $cb = shift;

--- a/lib/Dancer2/Manual/Migration.pod
+++ b/lib/Dancer2/Manual/Migration.pod
@@ -235,6 +235,7 @@ For example:
     use Test::More import => ['!pass'];
     use Plack::Test;
     use HTTP::Request::Common;
+    use Ref::Util qw<is_coderef>;
 
     {
         package App;
@@ -250,7 +251,7 @@ For example:
     }
 
     my $app = Dancer2->psgi_app;
-    is( ref $app, 'CODE', 'Got app' );
+    ok( is_coderef($app), 'Got app' );
 
     test_psgi $app, sub {
         my $cb = shift;

--- a/lib/Dancer2/Plugin.pm
+++ b/lib/Dancer2/Plugin.pm
@@ -10,6 +10,7 @@ use List::Util qw/ reduce /;
 use Module::Runtime 'require_module';
 use Attribute::Handlers;
 use Scalar::Util;
+use Ref::Util qw<is_arrayref is_coderef>;
 
 our $CUR_PLUGIN;
 
@@ -110,7 +111,7 @@ sub _p2_has_from_config {
 
     $args{lazy} = 1;
 
-    if ( ref $config_name eq 'CODE' ) {
+    if ( is_coderef($config_name) ) {
         $args{default} ||= $config_name;
         $config_name = 1;
     }
@@ -152,7 +153,7 @@ sub PluginKeyword :ATTR(CODE,BEGIN) {
 
     my $func_name = *{$sym_ref}{NAME};
 
-    $args = join '', @$args if ref $args eq 'ARRAY';
+    $args = join '', @$args if is_arrayref($args);
 
     for my $name ( split ' ', $args || $func_name ) {
         $class->keywords->{$name} = $code;
@@ -598,7 +599,7 @@ sub _exported_plugin_keywords{
     return plugin_keywords => sub(@) {
         while( my $name = shift @_ ) {
             ## no critic
-            my $sub = ref $_[0] eq 'CODE'
+            my $sub = is_coderef($_[0])
                 ? shift @_
                 : eval '\&'.$class."::" . ( ref $name ? $name->[0] : $name );
             $class->keywords->{$_} = $sub for ref $name ? @$name : $name;

--- a/lib/Dancer2/Template/Implementation/ForkedTiny.pm
+++ b/lib/Dancer2/Template/Implementation/ForkedTiny.pm
@@ -5,6 +5,7 @@ package Dancer2::Template::Implementation::ForkedTiny;
 use 5.00503;
 use strict;
 no warnings;
+use Ref::Util qw<is_arrayref is_coderef is_plain_hashref>;
 
 # Evaluatable expression
 my $EXPR = qr/ [a-z_][\w.]* /xs;
@@ -174,9 +175,7 @@ sub _foreach {
 
     # Resolve the expression
     my $list = $self->_expression( $stash, $expr );
-    if ( ref $list ne 'ARRAY' ) {
-        return '';
-    }
+    is_arrayref($list) or return '';
 
     # Iterate
     return join '',
@@ -193,24 +192,21 @@ sub _expression {
         return if substr( $_, 0, 1 ) eq '_';
 
         # Split by data type
-        my $type = ref $cursor;
-        if ( $type eq 'ARRAY' ) {
+        ref $cursor or return '';
+        if ( is_arrayref($cursor) ) {
             return '' unless /^(?:0|[0-9]\d*)\z/;
             $cursor = $cursor->[$_];
         }
-        elsif ( $type eq 'HASH' ) {
+        elsif ( is_plain_hashref($cursor) ) {
             $cursor = $cursor->{$_};
         }
-        elsif ($type) {
-            $cursor = $cursor->$_();
-        }
         else {
-            return '';
+            $cursor = $cursor->$_();
         }
     }
 
     # If the last expression is a CodeRef, execute it
-    ref($cursor) eq 'CODE'
+    is_coderef($cursor)
       and $cursor = $cursor->();
     return $cursor;
 }

--- a/lib/Dancer2/Template/Simple.pm
+++ b/lib/Dancer2/Template/Simple.pm
@@ -3,6 +3,7 @@ package Dancer2::Template::Simple;
 
 use Moo;
 use Dancer2::FileUtils 'read_file_content';
+use Ref::Util qw<is_arrayref is_coderef is_plain_hashref>;
 
 with 'Dancer2::Core::Role::Template';
 
@@ -113,7 +114,7 @@ sub _find_value_from_token_name {
         if ( not defined $value ) {
             $value = $tokens->{$e};
         }
-        elsif ( ref($value) eq 'HASH' ) {
+        elsif ( is_plain_hashref($value) ) {
             $value = $value->{$e};
         }
         elsif ( ref($value) ) {
@@ -127,12 +128,12 @@ sub _find_value_from_token_name {
 
 sub _interpolate_value {
     my ($value) = @_;
-    if ( ref($value) eq 'CODE' ) {
+    if ( is_coderef($value) ) {
         local $@;
         eval { $value = $value->() };
         $value = "" if $@;
     }
-    elsif ( ref($value) eq 'ARRAY' ) {
+    elsif ( is_arrayref($value) ) {
         $value = "@{$value}";
     }
 

--- a/share/skel/t/002_index_route.t
+++ b/share/skel/t/002_index_route.t
@@ -5,9 +5,10 @@ use [d2% appname %2d];
 use Test::More tests => 2;
 use Plack::Test;
 use HTTP::Request::Common;
+use Ref::Util qw<is_coderef>;
 
 my $app = [d2% appname %2d]->to_app;
-is( ref $app, 'CODE', 'Got app' );
+ok( is_coderef($app), 'Got app' );
 
 my $test = Plack::Test->create($app);
 my $res  = $test->request( GET '/' );

--- a/t/charset_server.t
+++ b/t/charset_server.t
@@ -6,6 +6,7 @@ use utf8;
 
 use Plack::Test;
 use HTTP::Request::Common;
+use Ref::Util qw<is_coderef>;
 
 {
     package App;
@@ -31,7 +32,7 @@ use HTTP::Request::Common;
 }
 
 my $app = Dancer2->psgi_app;
-is( ref $app, 'CODE', 'Got app' );
+ok( is_coderef($app), 'Got app' );
 
 test_psgi $app, sub {
     my $cb = shift;

--- a/t/classes/Dancer2-Core-Route/match.t
+++ b/t/classes/Dancer2-Core-Route/match.t
@@ -5,6 +5,7 @@ use Test::Fatal;
 use Dancer2::Core::Request;
 use Dancer2::Core::Route;
 use Capture::Tiny 0.12 'capture_stderr';
+use Ref::Util qw<is_regexpref>;
 
 my @tests = (
     [   [ 'get', '/', sub {11} ], '/', [ {}, 11 ] ],
@@ -117,7 +118,7 @@ plan tests => 110;
 for my $t (@tests) {
     my ( $route, $path, $expected ) = @$t;
 
-    if ( ref($expected) eq 'Regexp' ) {
+    if ( is_regexpref($expected) ) {
         like(
             exception {
                 my $r = Dancer2::Core::Route->new(

--- a/t/dancer-test.t
+++ b/t/dancer-test.t
@@ -4,6 +4,7 @@ use strict;
 use warnings;
 use File::Spec;
 use File::Basename qw/dirname/;
+use Ref::Util qw<is_arrayref>;
 
 BEGIN {
     # Disable route handlers so we can actually test route_exists
@@ -103,7 +104,7 @@ is $file_response->content, 'testfile', 'file uploaded with supplied filename';
 ## Check multiselect/multi parameters get through ok
 get '/multi' => sub {
     my $t = param('test');
-    return 'bad' if ref($t) ne 'ARRAY';
+    return 'bad' if !is_arrayref($t);
     my $p = join( '', @$t );
     return $p;
 };

--- a/t/dispatcher.t
+++ b/t/dispatcher.t
@@ -2,6 +2,7 @@ use strict;
 use warnings;
 use Test::More import => ['!pass'];
 use Carp 'croak';
+use Ref::Util qw<is_regexpref>;
 
 use Dancer2;
 use Dancer2::Core::App;
@@ -183,7 +184,7 @@ foreach my $test (@tests) {
     my %exp_headers = @{ $expected->[1] };
     is_deeply( \%got_headers, \%exp_headers, "[$path] Correct headers" );
 
-    if ( ref( $expected->[2] ) eq "Regexp" ) {
+    if ( is_regexpref( $expected->[2] ) ) {
         like $resp->[2][0] => $expected->[2], "[$path] Contents ok. (test $counter)";
     }
     else {

--- a/t/dsl/error_template.t
+++ b/t/dsl/error_template.t
@@ -4,6 +4,7 @@ use warnings;
 use Test::More;
 use Plack::Test;
 use HTTP::Request::Common;
+use Ref::Util qw<is_coderef>;
 
 {
     package CustomError;
@@ -36,8 +37,8 @@ use HTTP::Request::Common;
 my $custom_error_app   = CustomError->to_app;
 my $standard_error_app = StandardError->to_app;
 
-is( ref $custom_error_app,   'CODE', 'Got app' );
-is( ref $standard_error_app, 'CODE', 'Got app' );
+ok( is_coderef($custom_error_app), 'Got app' );
+ok( is_coderef($standard_error_app), 'Got app' );
 
 my $custom_error_test   = Plack::Test->create($custom_error_app);
 my $standard_error_test = Plack::Test->create($standard_error_app);

--- a/t/dsl/halt.t
+++ b/t/dsl/halt.t
@@ -3,6 +3,7 @@ use warnings;
 use Test::More;
 use Plack::Test;
 use HTTP::Request::Common;
+use Ref::Util qw<is_coderef>;
 
 subtest 'halt within routes' => sub {
     {
@@ -23,7 +24,7 @@ subtest 'halt within routes' => sub {
     }
 
     my $app = App->to_app;
-    is( ref $app, 'CODE', 'Got app' );
+    ok( is_coderef($app), 'Got app' );
 
     test_psgi $app, sub {
         my $cb = shift;
@@ -67,7 +68,7 @@ subtest 'halt in before hook' => sub {
     }
 
     my $app = App->to_app;
-    is( ref $app, 'CODE', 'Got app' );
+    ok( is_coderef($app), 'Got app' );
 
     test_psgi $app, sub {
         my $cb  = shift;

--- a/t/dsl/halt_with_param.t
+++ b/t/dsl/halt_with_param.t
@@ -3,6 +3,7 @@ use warnings;
 use Test::More;
 use Plack::Test;
 use HTTP::Request::Common;
+use Ref::Util qw<is_coderef>;
 
 subtest 'halt with parameter within routes' => sub {
     {
@@ -22,7 +23,7 @@ subtest 'halt with parameter within routes' => sub {
     }
 
     my $app = App->to_app;
-    is( ref $app, 'CODE', 'Got app' );
+    ok( is_coderef($app), 'Got app' );
 
     test_psgi $app, sub {
         my $cb = shift;
@@ -65,7 +66,7 @@ subtest 'halt with parameter in before hook' => sub {
     }
 
     my $app = App->to_app;
-    is( ref $app, 'CODE', 'Got app' );
+    ok( is_coderef($app), 'Got app' );
 
     test_psgi $app, sub {
         my $cb  = shift;

--- a/t/dsl/pass.t
+++ b/t/dsl/pass.t
@@ -3,6 +3,7 @@ use warnings;
 use Test::More;
 use Plack::Test;
 use HTTP::Request::Common;
+use Ref::Util qw<is_coderef>;
 
 subtest 'pass within routes' => sub {
     {
@@ -22,7 +23,7 @@ subtest 'pass within routes' => sub {
     }
 
     my $app = App->to_app;
-    is( ref $app, 'CODE', 'Got app' );
+    ok( is_coderef($app), 'Got app' );
 
     test_psgi $app, sub {
         my $cb = shift;

--- a/t/dsl/send_file.t
+++ b/t/dsl/send_file.t
@@ -8,6 +8,7 @@ use Plack::Test;
 use HTTP::Request::Common;
 use File::Temp;
 use File::Spec;
+use Ref::Util qw<is_coderef>;
 
 {
     package StaticContent;
@@ -59,7 +60,7 @@ use File::Spec;
 }
 
 my $app = StaticContent->to_app;
-is( ref $app, 'CODE', 'Got app' );
+ok( is_coderef($app), 'Got app' );
 
 test_psgi $app, sub {
     my $cb = shift;

--- a/t/error.t
+++ b/t/error.t
@@ -3,6 +3,7 @@ use warnings;
 use Test::More import => ['!pass'];
 use Plack::Test;
 use HTTP::Request::Common;
+use Ref::Util qw<is_coderef>;
 
 use Dancer2::Core::App;
 use Dancer2::Core::Response;
@@ -59,7 +60,7 @@ subtest "send_error in route" => sub {
     }
 
     my $app = App->to_app;
-    is( ref $app, 'CODE', 'Got app' );
+    ok( is_coderef($app), 'Got app' );
 
     test_psgi $app, sub {
         my $cb = shift;
@@ -93,7 +94,7 @@ subtest "send_error with custom stuff" => sub {
     }
 
     my $app = App->to_app;
-    is( ref $app, 'CODE', 'Got app' );
+    ok( is_coderef($app), 'Got app' );
 
     test_psgi $app, sub {
         my $cb = shift;

--- a/t/forward.t
+++ b/t/forward.t
@@ -3,6 +3,7 @@ use warnings;
 use Test::More import => ['!pass'];
 use Plack::Test;
 use HTTP::Request::Common;
+use Ref::Util qw<is_coderef>;
 
 use Dancer2;
 
@@ -42,7 +43,7 @@ get '/forward_with_proxy/' => sub {
 # get '/a' => sub { return "test is " . var('test'); };
 
 my $app = __PACKAGE__->to_app;
-is( ref $app, 'CODE', 'Got app' );
+ok( is_coderef($app), 'Got app' );
 
 test_psgi $app, sub {
     my $cb = shift;

--- a/t/forward_before_hook.t
+++ b/t/forward_before_hook.t
@@ -4,6 +4,7 @@ use Test::More import => ['!pass'], tests => 4;
 use Dancer2;
 use Plack::Test;
 use HTTP::Request::Common;
+use Ref::Util qw<is_coderef>;
 
 get '/' => sub {
     return 'Forbidden';
@@ -32,7 +33,7 @@ hook before => sub {
 };
 
 my $app = __PACKAGE__->to_app;
-is( ref $app, 'CODE', 'Got app' );
+ok( is_coderef($app), 'Got app' );
 
 test_psgi $app, sub {
     my $cb = shift;

--- a/t/forward_test_tcp.t
+++ b/t/forward_test_tcp.t
@@ -3,6 +3,7 @@ use warnings;
 use Test::More;
 use Plack::Test;
 use HTTP::Request::Common;
+use Ref::Util qw<is_coderef>;
 
 {
     package App;
@@ -36,7 +37,7 @@ use HTTP::Request::Common;
 }
 
 my $app = Dancer2->psgi_app;
-is( ref $app, 'CODE', 'Got app' );
+ok( is_coderef($app), 'Got app' );
 
 test_psgi $app, sub {
     my $cb = shift;

--- a/t/hooks.t
+++ b/t/hooks.t
@@ -15,6 +15,8 @@ my $tests_flags = {};
 {
     package App::WithSerializer;
     use Dancer2;
+    use Ref::Util qw<is_arrayref is_hashref>;
+
     set serializer => 'JSON';
 
     my @hooks = qw(
@@ -36,9 +38,9 @@ my $tests_flags = {};
 
     hook 'before_serializer' => sub {
         my ($data) = @_;  # don't shift, want to alias..
-        if ( ref $data eq 'ARRAY' ) {
+        if ( is_arrayref($data) ) {
             push( @{$data}, ( added_in_hook => 1 ) );
-        } elsif ( ref $data eq 'HASH' ) {
+        } elsif ( is_hashref($data) ) {
             $data->{'added_in_hook'} = 1;
         } else {
             $_[0] = +{ 'added_in_hook' => 1 };

--- a/t/http_methods.t
+++ b/t/http_methods.t
@@ -4,6 +4,7 @@ use warnings;
 use Test::More tests => 12;
 use Plack::Test;
 use HTTP::Request;
+use Ref::Util qw<is_coderef>;
 
 use Dancer2;
 
@@ -17,7 +18,7 @@ my %method = (
 );
 
 my $app = __PACKAGE__->to_app;
-is( ref $app, 'CODE', 'Got app' );
+ok( is_coderef($app), 'Got app' );
 
 test_psgi $app, sub {
     my $cb = shift;

--- a/t/issues/gh-650/gh-650.t
+++ b/t/issues/gh-650/gh-650.t
@@ -6,6 +6,7 @@ use warnings;
 use Test::More;
 use Plack::Test;
 use HTTP::Request::Common;
+use Ref::Util qw<is_coderef>;
 
 {
     package MyApp;
@@ -24,7 +25,7 @@ use HTTP::Request::Common;
 }
 
 my $app = Dancer2->psgi_app;
-is( ref $app, 'CODE', 'Got app' );
+ok( is_coderef($app), 'Got app' );
 
 test_psgi $app, sub {
     my $cb = shift;

--- a/t/log_die_before_hook.t
+++ b/t/log_die_before_hook.t
@@ -4,6 +4,7 @@ use warnings;
 use Plack::Test;
 use HTTP::Request::Common;
 use Capture::Tiny 'capture_stderr';
+use Ref::Util qw<is_coderef>;
 
 {
     package App;
@@ -22,7 +23,7 @@ use Capture::Tiny 'capture_stderr';
 }
 
 my $app = App->to_app;
-is( ref $app, 'CODE', 'Got app' );
+ok( is_coderef($app), 'Got app' );
 
 test_psgi $app, sub {
     my $cb      = shift;

--- a/t/plugin_import.t
+++ b/t/plugin_import.t
@@ -5,6 +5,7 @@ use warnings;
 use Test::More;
 use Plack::Test;
 use HTTP::Request::Common;
+use Ref::Util qw<is_coderef>;
 
 {
     use Dancer2;
@@ -17,7 +18,7 @@ use HTTP::Request::Common;
 }
 
 my $app = __PACKAGE__->to_app;
-is( ref $app, 'CODE', 'Got app' );
+ok( is_coderef($app), 'Got app' );
 
 test_psgi $app, sub {
     my $cb = shift;

--- a/t/plugin_multiple_apps.t
+++ b/t/plugin_multiple_apps.t
@@ -5,6 +5,7 @@ use warnings;
 use Test::More;
 use Plack::Test;
 use HTTP::Request::Common;
+use Ref::Util qw<is_coderef>;
 
 {
     package App;
@@ -21,7 +22,7 @@ use HTTP::Request::Common;
 }
 
 my $app = Dancer2->psgi_app;
-is( ref $app, 'CODE', 'Got app' );
+ok( is_coderef($app), 'Got app' );
 
 test_psgi $app, sub {
     my $cb = shift;

--- a/t/plugin_syntax.t
+++ b/t/plugin_syntax.t
@@ -4,6 +4,7 @@ use Test::More import => ['!pass'];
 use Plack::Test;
 use HTTP::Request::Common;
 use JSON::MaybeXS;
+use Ref::Util qw<is_coderef>;
 
 subtest 'global and route keywords' => sub {
     {
@@ -26,7 +27,7 @@ subtest 'global and route keywords' => sub {
     }
 
     my $app = App1->to_app;
-    is( ref $app, 'CODE', 'Got app' );
+    ok( is_coderef($app), 'Got app' );
 
     test_psgi $app, sub {
         my $cb = shift;
@@ -68,7 +69,7 @@ subtest 'plugin old syntax' => sub {
     }
 
     my $app = App2->to_app;
-    is( ref $app, 'CODE', 'Got app' );
+    ok( is_coderef($app), 'Got app' );
 
     test_psgi $app, sub {
         my $cb = shift;
@@ -83,7 +84,7 @@ subtest 'plugin old syntax' => sub {
 
 subtest caller_dsl => sub {
     my $app = App1->to_app;
-    is( ref $app, 'CODE', 'Got app' );
+    ok( is_coderef($app), 'Got app' );
 
     test_psgi $app, sub {
         my $cb = shift;
@@ -137,7 +138,7 @@ subtest 'hooks in plugins' => sub {
     }
 
     my $app = App3->to_app;
-    is( ref $app, 'CODE', 'Got app' );
+    ok( is_coderef($app), 'Got app' );
 
     test_psgi $app, sub {
         my $cb = shift;

--- a/t/redirect.t
+++ b/t/redirect.t
@@ -4,6 +4,7 @@ use warnings;
 use Test::More;
 use Plack::Test;
 use HTTP::Request::Common;
+use Ref::Util qw<is_coderef>;
 
 subtest 'basic redirects' => sub {
     {
@@ -17,7 +18,7 @@ subtest 'basic redirects' => sub {
     }
 
     my $app = App1->to_app;
-    is( ref $app, 'CODE', 'Got app' );
+    ok( is_coderef($app), 'Got app' );
 
     test_psgi $app, sub {
         my $cb = shift;
@@ -86,7 +87,7 @@ subtest 'absolute and relative redirects' => sub {
     }
 
     my $app = App2->to_app;
-    is( ref $app, 'CODE', 'Got app' );
+    ok( is_coderef($app), 'Got app' );
 
     test_psgi $app, sub {
         my $cb = shift;
@@ -133,7 +134,7 @@ subtest 'redirect behind a proxy' => sub {
     }
 
     my $app = App3->to_app;
-    is( ref $app, 'CODE', 'Got app' );
+    ok( is_coderef($app), 'Got app' );
 
     test_psgi $app, sub {
         my $cb = shift;
@@ -198,7 +199,7 @@ subtest 'redirect behind multiple proxies' => sub {
     }
 
     my $app = App4->to_app;
-    is( ref $app, 'CODE', 'Got app' );
+    ok( is_coderef($app), 'Got app' );
 
     test_psgi $app, sub {
         my $cb = shift;

--- a/t/serializer.t
+++ b/t/serializer.t
@@ -5,6 +5,7 @@ use Test::More tests => 5;
 use Dancer2::Serializer::Dumper;
 use Plack::Test;
 use HTTP::Request::Common;
+use Ref::Util qw<is_coderef>;
 
 {
     package MyApp;
@@ -14,7 +15,7 @@ use HTTP::Request::Common;
 }
 
 my $app = MyApp->to_app;
-is( ref $app, 'CODE', 'Got app' );
+ok( is_coderef($app), 'Got app' );
 
 test_psgi $app, sub {
     my $cb = shift;

--- a/t/serializer_mutable.t
+++ b/t/serializer_mutable.t
@@ -8,22 +8,25 @@ use HTTP::Request::Common;
 use Encode;
 use JSON::MaybeXS;
 use YAML;
+use Ref::Util qw<is_coderef>;
 
 {
     package MyApp;
     use Dancer2;
+    use Ref::Util qw<is_hashref>;
+
     set serializer => 'Mutable';
 
     get '/serialize'     => sub { +{ bar => 'baz' } };
     post '/deserialize'  => sub {
         return request->data &&
-               ref request->data eq 'HASH' &&
+               is_hashref( request->data ) &&
                request->data->{bar} ? { bar => request->data->{bar} } : { ret => '?' };
     };
 }
 
 my $app = MyApp->to_app;
-is( ref $app, 'CODE', 'Got app' );
+ok( is_coderef($app), 'Got app' );
 
 test_psgi $app, sub {
     my $cb = shift;

--- a/t/session_in_template.t
+++ b/t/session_in_template.t
@@ -5,6 +5,7 @@ use Test::More;
 use Plack::Test;
 use HTTP::Request::Common;
 use HTTP::Cookies;
+use Ref::Util qw<is_coderef>;
 
 {
     package TestApp;
@@ -40,7 +41,7 @@ use HTTP::Cookies;
 }
 
 my $app = TestApp->to_app;
-is( ref $app, 'CODE', 'Got app' );
+ok( is_coderef($app), 'Got app' );
 
 my $test = Plack::Test->create($app);
 my $jar = HTTP::Cookies->new();

--- a/t/template_default_tokens.t
+++ b/t/template_default_tokens.t
@@ -5,6 +5,7 @@ use File::Basename 'dirname';
 use Test::More;
 use Plack::Test;
 use HTTP::Request::Common;
+use Ref::Util qw<is_coderef>;
 
 eval { require Template; Template->import(); 1 }
   or plan skip_all => 'Template::Toolkit probably missing.';
@@ -39,7 +40,7 @@ session.foo in session
 vars.foo: in var";
 
 my $app = Foo->to_app;
-is( ref $app, 'CODE', 'Got app' );
+ok( is_coderef($app), 'Got app' );
 
 test_psgi $app, sub {
     my $cb = shift;

--- a/t/template_name.t
+++ b/t/template_name.t
@@ -5,6 +5,7 @@ use File::Basename 'dirname';
 use Test::More;
 use Plack::Test;
 use HTTP::Request::Common;
+use Ref::Util qw<is_coderef>;
 
 {
 
@@ -18,7 +19,7 @@ use HTTP::Request::Common;
 }
 
 my $app = Foo->to_app;
-is( ref $app, 'CODE', 'Got app' );
+ok( is_coderef($app), 'Got app' );
 
 test_psgi $app, sub {
     my $cb = shift;

--- a/t/template_tiny/03_samples.t
+++ b/t/template_tiny/03_samples.t
@@ -11,6 +11,7 @@ use Test::More;
 use File::Spec::Functions ':ALL';
 use Dancer2::Template::Implementation::ForkedTiny ();
 use FindBin qw($Bin);
+use Ref::Util qw<is_hashref>;
 
 my $SAMPLES = catdir( $Bin, 'samples' );
 unless ( -d $SAMPLES ) {
@@ -51,7 +52,7 @@ foreach my $template (@TEMPLATES) {
     my $txt = slurp($txt_file);
     eval $var;
     die $@ if $@;
-    is( ref($VAR1), 'HASH', "$template: Loaded stash from file" );
+    ok( is_hashref($VAR1), "$template: Loaded stash from file" );
 
     # Create the processor normally
     my %params = ( INCLUDE_PATH => $SAMPLES, );

--- a/t/template_tiny/04_compat.t
+++ b/t/template_tiny/04_compat.t
@@ -13,7 +13,7 @@ eval "require Template";
 if ($@) {
     plan( skip_all => 'Template Toolkit is not installed' );
 }
-
+use Ref::Util qw<is_hashref>;
 use FindBin qw($Bin);
 my $SAMPLES = catdir( $Bin, 'samples' );
 unless ( -d $SAMPLES ) {
@@ -46,7 +46,7 @@ foreach my $name (@TEMPLATES) {
     my $txt = slurp($txt_file);
     eval $var;
     die $@ if $@;
-    is( ref($VAR1), 'HASH', "$name: Loaded stash from file" );
+    ok( is_hashref($VAR1), "$name: Loaded stash from file" );
 
     # Create the template processor
     my %params = ( INCLUDE_PATH => $SAMPLES, );

--- a/t/uri_for.t
+++ b/t/uri_for.t
@@ -3,6 +3,7 @@ use warnings;
 use Test::More import => ['!pass'];
 use Plack::Test;
 use HTTP::Request::Common;
+use Ref::Util qw<is_coderef>;
 
 {
     package App;
@@ -13,7 +14,7 @@ use HTTP::Request::Common;
 }
 
 my $app = App->to_app;
-is( ref $app, 'CODE', 'Got app' );
+ok( is_coderef($app), 'Got app' );
 
 test_psgi $app, sub {
     my $cb = shift;

--- a/t/vars.t
+++ b/t/vars.t
@@ -3,6 +3,7 @@ use warnings;
 use Test::More import => ['!pass'];
 use Plack::Test;
 use HTTP::Request::Common;
+use Ref::Util qw<is_coderef>;
 
 plan tests => 3;
 
@@ -24,7 +25,7 @@ plan tests => 3;
 }
 
 my $app = __PACKAGE__->to_app;
-is( ref $app, 'CODE', 'Got app' );
+ok( is_coderef($app), 'Got app' );
 
 test_psgi $app, sub {
     my $cb = shift;


### PR DESCRIPTION
So there's the rest of them.

Question: do we want to convert the likes of:
`isa_ok( $app, 'CODE'...` 

I didn't touch those yet (we have many).