### PR TITLE
Cookies set by cookie keyword should be httpOnly by default

### DIFF
--- a/lib/Dancer2/Core/Cookie.pm
+++ b/lib/Dancer2/Core/Cookie.pm
@@ -129,7 +129,7 @@ has http_only => (
     is       => 'rw',
     isa      => Bool,
     required => 0,
-    default  => sub {0},
+    default  => sub {1},
 );
 
 has same_site => (

--- a/t/cookie.t
+++ b/t/cookie.t
@@ -68,11 +68,7 @@ sub run_test {
     is $cookie->secure(0) => 0, "disabling \$cookie->secure returns new value";
     ok !$cookie->secure, "\$cookie->secure flag is disabled";
 
-    ok !$cookie->http_only, "no http_only by default";;
-    is $cookie->http_only(1) => 1,
-        "enabling \$cookie->http_only returns new value";;
-    is $cookie->http_only    => 1,
-        "\$cookie->http_only is now enabled";
+    ok $cookie->http_only, "http_only by default";
     is $cookie->http_only(0) => 0,
         "disabling \$cookie->http_only returns new value";
     ok !$cookie->http_only,
@@ -131,8 +127,10 @@ sub run_test {
                 expires => '+2h',
                 secure  => 1
             },
-            expected =>
-            sprintf( "bar=foo; Expires=%s; Path=/; Secure", $times{'+2h'} ),
+            expected => sprintf(
+                "bar=foo; Expires=%s; HttpOnly; Path=/; Secure",
+                $times{'+2h'},
+            ),
         },
         {   cookie => {
                 name      => 'bar',
@@ -147,21 +145,21 @@ sub run_test {
                 name  => 'bar',
                 value => 'foo',
             },
-            expected => "bar=foo; Path=/",
+            expected => "bar=foo; HttpOnly; Path=/",
         },
         {   cookie => {
                 name      => 'same-site',
                 value     => 'strict',
                 same_site => 'Strict',
             },
-            expected => 'same-site=strict; Path=/; SameSite=Strict',
+            expected => 'same-site=strict; HttpOnly; Path=/; SameSite=Strict',
         },
         {   cookie => {
                 name      => 'same-site',
                 value     => 'lax',
                 same_site => 'Lax',
             },
-            expected => 'same-site=lax; Path=/; SameSite=Lax',
+            expected => 'same-site=lax; HttpOnly; Path=/; SameSite=Lax',
         },
     );
 
@@ -176,7 +174,7 @@ sub run_test {
 
     my $c = Dancer2::Core::Cookie->new( name => 'foo', value => [qw/bar baz/] );
 
-    is $c->to_header, 'foo=bar&baz; Path=/';
+    is $c->to_header, 'foo=bar&baz; Path=/; HttpOnly';
 
     my $r = Dancer2::Core::Request->new( env => { HTTP_COOKIE => 'foo=bar&baz' } );
 

--- a/t/cookie.t
+++ b/t/cookie.t
@@ -27,49 +27,56 @@ sub run_test {
 
     note "Setting values";
 
-    is $cookie->value("foo") => "foo";
-    is $cookie->value        => "foo";
+    is $cookie->value("foo") => "foo", "Can set value";
+    is $cookie->value        => "foo", "Set value stuck";
 
     is $cookie . "bar", "foobar", "Stringifies to desired value";
 
-    ok $cookie->value( [qw(a b c)] );
-    is $cookie->value => 'a';
-    is_deeply [ $cookie->value ] => [qw(a b c)];
+    ok $cookie->value( [qw(a b c)] ), "can set multiple values";
+    is $cookie->value => 'a', "get first value in scalar context";
+    is_deeply [ $cookie->value ] => [qw(a b c)],
+        "get all values in list context";;
 
-    ok $cookie->value( { x => 1, y => 2 } );
+    ok $cookie->value( { x => 1, y => 2 } ), "can set values with a hashref";
     like $cookie->value => qr/^[xy]$/;    # hashes doesn't store order...
     is_deeply [ sort $cookie->value ] => [ sort ( 1, 2, 'x', 'y' ) ];
 
 
     note "accessors and defaults";
 
-    is $cookie->name        => 'foo';
-    is $cookie->name("bar") => "bar";
-    is $cookie->name        => 'bar';
+    is $cookie->name        => 'foo', "name is as expected";
+    is $cookie->name("bar") => "bar", "can change name";
+    is $cookie->name        => 'bar', "name change stuck";
 
-    ok !$cookie->domain;
-    is $cookie->domain("dancer.org") => "dancer.org";
-    is $cookie->domain               => "dancer.org";
-    is $cookie->domain("")           => "";
-    ok !$cookie->domain;
+    ok !$cookie->domain, "no domain set by default";
+    is $cookie->domain("dancer.org") => "dancer.org",
+        "setting domain returns new value";
+    is $cookie->domain               => "dancer.org",
+        "new domain valjue stuck";
+    is $cookie->domain("")           => "", "can clear domain";
+    ok !$cookie->domain, "no domain set now";
 
     is $cookie->path => '/', "by default, path is /";
     ok $cookie->has_path, "has_path";
-    is $cookie->path("/foo") => "/foo";
+    is $cookie->path("/foo") => "/foo", "setting path returns new value";
     ok $cookie->has_path, "has_path";
-    is $cookie->path => "/foo";
+    is $cookie->path => "/foo", "new path stuck";
 
-    ok !$cookie->secure;
-    is $cookie->secure(1) => 1;
-    is $cookie->secure    => 1;
-    is $cookie->secure(0) => 0;
-    ok !$cookie->secure;
+    ok !$cookie->secure, "no cookie secure flag by default";
+    is $cookie->secure(1) => 1, "enabling \$cookie->secure returns new value";
+    is $cookie->secure    => 1, "\$cookie->secure flag is enabled";
+    is $cookie->secure(0) => 0, "disabling \$cookie->secure returns new value";
+    ok !$cookie->secure, "\$cookie->secure flag is disabled";
 
-    ok !$cookie->http_only;
-    is $cookie->http_only(1) => 1;
-    is $cookie->http_only    => 1;
-    is $cookie->http_only(0) => 0;
-    ok !$cookie->http_only;
+    ok !$cookie->http_only, "no http_only by default";;
+    is $cookie->http_only(1) => 1,
+        "enabling \$cookie->http_only returns new value";;
+    is $cookie->http_only    => 1,
+        "\$cookie->http_only is now enabled";
+    is $cookie->http_only(0) => 0,
+        "disabling \$cookie->http_only returns new value";
+    ok !$cookie->http_only,
+        "\$cookie->http_only is now disabled";
 
     like exception { $cookie->same_site('foo') },
         qr/Value "foo" did not pass type constraint "Enum\["Strict","Lax"\]/;
@@ -111,7 +118,7 @@ sub run_test {
         my $want = $times{$exp};
 
         $cookie->expires($exp);
-        is $cookie->expires => $want;
+        is $cookie->expires => $want, "expiry $exp => $want";;
     }
 
 

--- a/t/cookie.t
+++ b/t/cookie.t
@@ -148,6 +148,13 @@ sub run_test {
             expected => "bar=foo; HttpOnly; Path=/",
         },
         {   cookie => {
+                name  => 'bar',
+                value => 'foo',
+                http_only => 0,
+            },
+            expected => "bar=foo; Path=/",
+        },
+        {   cookie => {
                 name      => 'same-site',
                 value     => 'strict',
                 same_site => 'Strict',


### PR DESCRIPTION
Fixes #1361 

We document that we set httpOnly on cookies by default, but we don't, for ones set using `cookie`; we do, however, for session cookies.

This PR makes us set httpOnly by default for cookies - but as per my comment on #1361, I'd like other's opinions on whether changing this behaviour now is reasonable.  There's a slight chance that people could get bitten by it, if they were accessing cookies set via `cookie()` from Javascript and it was working "by accident", but setting httpOnly by default as we documented that we did is more secure, and aligns with that we do for session cookies, so I think this is probably the best approach.

It should be mentioned clearly in the changelog if we go with this, though :)