### PR TITLE
Serializer mutable custom mapping

### DIFF
--- a/lib/Dancer2/Serializer/Mutable.pm
+++ b/lib/Dancer2/Serializer/Mutable.pm
@@ -120,15 +120,20 @@ sub _get_content_type {
 
 __END__
 
-=head1 NAME
-
-Dancer2::Serializer::Mutable - Serialize and deserialize content using the appropriate HTTP header
-(ported from Dancer)
-
 =head1 SYNOPSIS
 
     # in config.yml
     serializer: Mutable
+
+    engines:
+        serializer:
+            Mutable:
+                mapping:
+                    'text/x-yaml'        : YAML
+                    'text/html'          : YAML
+                    'text/x-data-dumper' : Dumper
+                    'text/x-json'        : JSON
+                    'application/json'   : JSON
 
     # in the app
     put '/something' => sub {

--- a/lib/Dancer2/Serializer/Mutable.pm
+++ b/lib/Dancer2/Serializer/Mutable.pm
@@ -173,6 +173,37 @@ uses is
     Dancer2::Serializer::Dumper | text/x-data-dumper
     Dancer2::Serializer::JSON   | text/x-json, application/json
 
+A different mapping can be provided via the config file. For example,
+the default mapping would be configured as
+
+    engines:
+        serializer:
+            Mutable:
+                mapping:
+                    'text/x-yaml'        : YAML
+                    'text/html'          : YAML
+                    'text/x-data-dumper' : Dumper
+                    'text/x-json'        : JSON
+                    'application/json'   : JSON
+
+The keys of the mapping are the content-types to serialize,
+and the values the serializers to use. Serialization for C<YAML>, C<Dumper>
+and C<JSON> are done using internal Dancer mechanisms. Any other serializer will
+be taken to be as Dancer2 serialization class (minus the C<Dancer2::Serializer::> prefix)
+and an instance of it will be used
+to serialize/deserialize data. For example, adding L<Dancer2::Serializer::XML>
+to the mapping would be:
+
+    engines:
+        serializer:
+            Mutable:
+                mapping:
+                    'text/x-yaml'        : YAML
+                    'text/html'          : YAML
+                    'text/x-data-dumper' : Dumper
+                    'text/x-json'        : JSON
+                    'text/xml'           : XML
+
 =head2 INTERNAL METHODS
 
 The following methods are used internally by C<Dancer2> and are not made

--- a/lib/Dancer2/Serializer/Mutable.pm
+++ b/lib/Dancer2/Serializer/Mutable.pm
@@ -38,11 +38,11 @@ has mapping => (
                 my $serializer_object = ('Dancer2::Serializer::'.$s)->new;
                 $serializer->{$s} = {
                     from => sub { shift; $serializer_object->deserialize(@_) },
-                    to   => sub { shift; use DDP; p @_; $serializer_object->serialize(@_) },
+                    to   => sub { shift; $serializer_object->serialize(@_)   },
                 };
             }
 
-            return p $mapping;
+            return $mapping;
         }
 
 

--- a/lib/Dancer2/Serializer/Mutable.pm
+++ b/lib/Dancer2/Serializer/Mutable.pm
@@ -8,14 +8,6 @@ with 'Dancer2::Core::Role::Serializer';
 
 has '+content_type' => ( default => sub {'application/json'} );
 
-my $formats = {
-    'text/x-yaml'        => 'YAML',
-    'text/html'          => 'YAML',
-    'text/x-data-dumper' => 'Dumper',
-    'text/x-json'        => 'JSON',
-    'application/json'   => 'JSON',
-};
-
 my $serializer = {
     'YAML'   => {
         to      => sub { Dancer2::Core::DSL::to_yaml(@_)   },
@@ -31,12 +23,46 @@ my $serializer = {
     },
 };
 
+has mapping => (
+    is   => 'ro',
+    lazy => 1,
+    default => sub {
+        my $self = shift;
+
+        if ( my $mapping = $self->config->{mapping} ) {
+            
+            # initialize non-default serializers
+            for my $s ( values %$mapping ) {
+                # TODO allow for arguments via the config
+                next if $serializer->{$s};
+                my $serializer_object = ('Dancer2::Serializer::'.$s)->new;
+                $serializer->{$s} = {
+                    from => sub { shift; $serializer_object->deserialize(@_) },
+                    to   => sub { shift; use DDP; p @_; $serializer_object->serialize(@_) },
+                };
+            }
+
+            return p $mapping;
+        }
+
+
+        return {
+            'text/x-yaml'        => 'YAML',
+            'text/html'          => 'YAML',
+            'text/x-data-dumper' => 'Dumper',
+            'text/x-json'        => 'JSON',
+            'application/json'   => 'JSON',
+        }
+    },
+);
+
+
 sub support_content_type {
     my ( $self, $ct ) = @_;
 
     # FIXME: are we getting full content type?
 
-    if ( $ct && grep +( $_ eq $ct ), keys %{$formats} ) {
+    if ( $ct && grep +( $_ eq $ct ), keys %{$self->mapping} ) {
         $self->set_content_type($ct);
 
         return 1;
@@ -64,7 +90,7 @@ sub deserialize {
     my ( $self, $content ) = @_;
 
     # The right content type should already be set
-    my $format = $formats->{$self->content_type};
+    my $format = $self->mapping->{$self->content_type};
 
     $format and return $serializer->{$format}{'from'}->( $self, $content );
 
@@ -79,9 +105,9 @@ sub _get_content_type {
     # specifies supported content.
     foreach my $method ( qw<content_type accept> ) {
         if ( my $value = $self->request->header($method) ) {
-            if ( exists $formats->{$value} ) {
+            if ( my $serializer = $self->mapping->{$value} ) {
                 $self->set_content_type($value);
-                return $formats->{$value};
+                return $serializer;
             }
         }
     }

--- a/t/serializer_mutable_custom.t
+++ b/t/serializer_mutable_custom.t
@@ -1,0 +1,126 @@
+=pod
+
+Same as t/serializer_mutable.t, but exercise the configurable
+mappings
+
+=cut
+
+use strict;
+use warnings;
+
+use Test::More tests => 5;
+use Dancer2::Serializer::Mutable;
+use Plack::Test;
+use HTTP::Request::Common;
+use Encode;
+use JSON::MaybeXS;
+use YAML;
+use Ref::Util qw<is_coderef>;
+
+{ 
+    package Dancer2::Serializer::Other;
+
+    use Moo;
+    with 'Dancer2::Core::Role::Serializer';
+
+    has '+content_type' => ( default => 'text/other' );
+
+    sub serialize   { '{thing}' }
+    sub deserialize { '{thing}' }
+
+}
+
+{
+    package MyApp;
+    use Dancer2;
+
+    BEGIN { 
+        setting engines => { serializer => { Mutable => { mapping => { 
+            'text/x-yaml'        => 'YAML',
+            'text/x-data-dumper' => 'Dumper',
+            'text/x-json'        => 'JSON',
+            'application/json'   => 'JSON',
+            'text/other'         => 'Other',
+        } } } };
+    }
+
+    use Ref::Util qw<is_hashref>;
+
+    set serializer => 'Mutable';
+
+    get '/serialize'     => sub { +{ bar => 'baz' } };
+    post '/deserialize'  => sub {
+        return request->data &&
+               is_hashref( request->data ) &&
+               request->data->{bar} ? { bar => request->data->{bar} } : { ret => '?' };
+    };
+}
+
+my $app = MyApp->to_app;
+ok is_coderef($app), 'Got app';
+
+test_psgi $app, sub {
+    my $cb = shift;
+
+    # Configure all test cases
+    my $d = {
+        yaml    => {
+                types       => [ qw(text/x-yaml) ],
+                value       => encode('UTF-8', YAML::Dump({ bar => 'baz' })),
+                last_val    => "---bar:baz",
+            },
+        other    => {
+                types       => [ qw(text/other) ],
+                value       => '{thing}',
+                last_val    => "{thing}",
+            },
+        dumper  => {
+                types       => [ qw(text/x-data-dumper) ],
+                value       => Data::Dumper::Dumper({ bar => 'baz' }),
+                last_val    => "\$VAR1={'bar'=>'baz'};",
+            },
+        json    => {
+                types       => [ qw(text/x-json application/json) ],
+                value       => JSON::MaybeXS::encode_json({ bar => 'baz' }),
+                last_val    => '{"bar":"baz"}',
+            },
+    };
+
+    for my $format (keys %$d) {
+        subtest "Format: $format" => sub {
+
+            my $s = $d->{$format};
+
+            # Response with implicit call to the serializer
+            for my $content_type ( @{ $s->{types} } ) {
+                subtest $content_type => sub {
+                    for my $ct (qw/Content-Type Accept/) {
+
+                        # Test getting the value serialized in the correct format
+                        my $res = $cb->( GET '/serialize', $ct => $content_type );
+
+                        is( $res->code, 200, "status" );
+                        is( $res->content, $s->{value}, "content" );
+                        is(
+                            $res->headers->content_type,
+                            $content_type,
+                            "content-type headers",
+                        );
+                    }
+
+                    # Test sending the value serialized in the correct format
+                    # needs to be de-serialized and returned
+                    my $req = $cb->( POST '/deserialize',
+                                        'Content-Type' => $content_type,
+                                        content        => $s->{value} );
+
+                    my $content = $req->content;
+                    $content =~ s/\s//g;
+                    is( $req->code, 200, "status" );
+                    is( $content, $s->{last_val}, "content" );
+                }
+            }
+        }
+    }
+
+}


### PR DESCRIPTION
Allows Dancer2::Serializer::Mutable to be configured with a different content-type/serializer mapping table.