### PR TITLE
Store route executing in request

### DIFF
--- a/lib/Dancer2/Core/App.pm
+++ b/lib/Dancer2/Core/App.pm
@@ -1452,6 +1452,8 @@ DISPATCH:
             my $match = $route->match($request)
                 or next ROUTE;
 
+            $request->route($route);
+
             $request->_set_route_params($match);
             $request->_set_route_parameters($match);
 

--- a/lib/Dancer2/Core/Request.pm
+++ b/lib/Dancer2/Core/Request.pm
@@ -653,6 +653,14 @@ sub _shallow_clone {
     return $new_request;
 }
 
+
+sub route {
+    my ($self, $route) = @_;
+    if ($route) { $self->{route_matched} = $route; }
+
+    return $self->{route_matched};
+}
+
 1;
 
 __END__
@@ -1005,6 +1013,10 @@ Alias to the C<method> accessor, for backward-compatibility with C<CGI> interfac
 =method request_uri
 
 Return the raw, undecoded request URI path.
+
+=method route
+
+Return the L<route|Dancer2::Core::Route> which this request matched.
 
 =method scheme
 


### PR DESCRIPTION
Currently, it seems there's no way for a hook / route handler to inspect which route the request matched, which is a limitation that is biting us at work in attempting to transition from Dancer1 to Dancer2.

It seems silly not to be able to do this - we were able to in Dancer1, and made good use of that ability.

This PR adds a `route` attribute to the D2::Core::Request object, which is populated with the D2::Core::Route object for the route the request matched by the dispatcher.