### PR TITLE
Remove middleware boilerplate from basic app

### DIFF
--- a/share/skel/bin/+app.psgi
+++ b/share/skel/bin/+app.psgi
@@ -11,14 +11,6 @@ use [d2% appname %2d];
 
 [d2% appname %2d]->to_app;
 
-use Plack::Builder;
-
-builder {
-    enable 'Deflater';
-    [d2% appname %2d]->to_app;
-}
-
-
 
 =begin comment
 # use this block if you want to include middleware such as Plack::Middleware::Deflater


### PR DESCRIPTION
the Deflater middleware is not a dependency requirement for Dancer2. The app fails to run if it is included in the skeleton script.