### PR TITLE
remove search.perl.org links on docs

### DIFF
--- a/lib/Dancer2/Manual.pod
+++ b/lib/Dancer2/Manual.pod
@@ -1909,17 +1909,17 @@ A number of Perl web servers supporting PSGI are available on CPAN:
 
 =over 4
 
-=item * L<Starman|http://search.cpan.org/dist/Starman/>
+=item * L<Starman>
 
 C<Starman> is a high performance web server, with support for preforking,
 signals, multiple interfaces, graceful restarts and dynamic worker pool
 configuration.
 
-=item * L<Twiggy|http://search.cpan.org/dist/Twiggy/>
+=item * L<Twiggy>
 
 C<Twiggy> is an C<AnyEvent> web server, it's light and fast.
 
-=item * L<Corona|http://search.cpan.org/dist/Corona/>
+=item * L<Corona>
 
 C<Corona> is a C<Coro> based web server.
 

--- a/lib/Dancer2/Manual/Deployment.pod
+++ b/lib/Dancer2/Manual/Deployment.pod
@@ -294,17 +294,17 @@ A number of Perl web servers supporting PSGI are available on cpan:
 
 =over 4
 
-=item L<Starman|http://search.cpan.org/dist/Starman/>
+=item L<Starman>
 
 C<Starman> is a high performance web server, with support for preforking,
 signals, multiple interfaces, graceful restarts and dynamic worker pool
 configuration.
 
-=item L<Twiggy|http://search.cpan.org/dist/Twiggy/>
+=item L<Twiggy>
 
 C<Twiggy> is an C<AnyEvent> web server, it's light and fast.
 
-=item L<Corona|http://search.cpan.org/dist/Corona/>
+=item L<Corona>
 
 C<Corona> is a C<Coro> based web server.
 


### PR DESCRIPTION
#1383 

I agree with @szabgab. Allow the parser to link to where it likes. Accordingly with the POD manual, not URL means to link to a module manpage.