### PR TITLE
Add "Default template variables" section to manual

### DIFF
--- a/lib/Dancer2/Manual.pod
+++ b/lib/Dancer2/Manual.pod
@@ -3087,8 +3087,8 @@ Or to request a specific layout, of course:
     };
 
 Some tokens are automatically added to your template (C<perl_version>,
-C<dancer_version>, C<settings>, C<request>, C<query_parameters>, C<body_parameters>, C<route_parameters>, C<vars> and, if you
-have sessions enabled, C<session>). Check L<Dancer2::Core::Role::Template>
+C<dancer_version>, C<settings>, C<request>, C<vars> and, if you
+have sessions enabled, C<session>). Check L<#Default Template Variables>
 for further details.
 
 =head2 to_dumper ($structure)

--- a/lib/Dancer2/Manual.pod
+++ b/lib/Dancer2/Manual.pod
@@ -1250,6 +1250,51 @@ template toolkit, your config file will look like this:
           ENCODING: utf8
 
 
+=head2 Default Template Variables
+
+Every template knows about the following variables, which are provided by
+L<Dancer2::Core::Role::Template>. Some are similar to the keywords you can
+use in the Perl part of your Dancer2 application.
+
+=over 4
+
+=item * B<perl_version>
+
+Current version of perl, effectively
+L<C<$^V>|http://perldoc.perl.org/perlvar.html#%24%5eV>.
+
+=item * B<dancer_version>
+
+Current version of Dancer2, effectively C<< Dancer2->VERSION >>.
+
+=item * B<settings>
+
+A hash of the application configuration. This is like
+the L<config|#config> keyword.
+
+=item * B<request>
+
+The current request object. This is like the L<request|#request> keyword.
+
+=item * B<params>
+
+A hash reference of all the parameters.
+
+Currently the equivalent of C<< $request->params >>, and like the
+L<params|#params> keyword.
+
+=item * B<vars>
+
+The list of request variables, which is what you would get if you
+called the L<vars|#vars> keyword.
+
+=item * B<session>
+
+The current session data, if a session exists. This is like
+the L<session|#session> keyword.
+
+=back
+
 =head1 STATIC FILES
 
 =head2 Static Directory


### PR DESCRIPTION
There was already something there about the vars, but that seemed to be outdated and in general way less information.