### PR TITLE
Honour no_server_tokens config in error responses

### DIFF
--- a/lib/Dancer2/Core/Error.pm
+++ b/lib/Dancer2/Core/Error.pm
@@ -202,7 +202,14 @@ has response => (
     default => sub {
         my $self = shift;
         my $serializer = $self->serializer;
+        # include server tokens in response ?
+        my $no_server_tokens = $self->has_app
+            ? $self->app->config->{'no_server_tokens'}
+            : defined $ENV{DANCER_NO_SERVER_TOKENS}
+                ? $ENV{DANCER_NO_SERVER_TOKENS}
+                : 0;
         return Dancer2::Core::Response->new(
+            server_tokens => !$no_server_tokens,
             ( serializer => $serializer )x!! $serializer
         );
     }

--- a/t/error.t
+++ b/t/error.t
@@ -182,6 +182,24 @@ subtest 'Error with exception object' => sub {
     like $err->content, qr/a test exception object/, 'Error content contains exception message';
 };
 
+subtest 'Errors without server tokens' => sub {
+    {
+        package AppNoServerTokens;
+        use Dancer2;
+        set serializer => 'JSON';
+        set no_server_tokens => 1;
+
+        get '/ohno' => sub {
+            die "oh no";
+        };
+    }
+
+    my $test = Plack::Test->create( AppNoServerTokens->to_app );
+    my $r = $test->request( GET '/ohno' );
+    is( $r->code, 500, "/ohno returned 500 response");
+    is( $r->header('server'), undef, "No server header when no_server_tokens => 1" );
+};
+
 done_testing;
 
 


### PR DESCRIPTION
For apps configured to NOT include server tokens in responses,
responses on error should do the same thing too. So ..

When the Error object has an app, use its no_server_tokens config setting,
or fall back to $ENV{DANCER_NO_SERVER_TOKENS} (as the Runner does) if
no app is present.

Resolves 1390.