### PR TITLE
Fix infinite recursion with circular refs

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -1,6 +1,7 @@
 requires 'App::Cmd::Setup';
 requires 'Attribute::Handlers';
 requires 'Carp';
+requires 'Clone';
 requires 'Config::Any';
 requires 'Digest::SHA';
 requires 'Encode';


### PR DESCRIPTION
I hit a particular edge case when working on [PearlBee](https://github.com/andrewalker/PearlBee). I added a component which used a circular reference (it used the application config, and then it went to the config itself). While maybe it's not a great idea to use circular references anyway, it made Dancer2 go into infinite recursion whenever an exception happened inside Dancer2.

To trigger the issue, the following has to happen:

- have a circular reference on the config or session;
- have show_errors enabled;
- have an exception somewhere in the stack;

`show_errors` will make Dancer2::Core::Error dump the stack trace, the settings of the app, the session, and the request environment. And before dumping, it will traverse the data and try to sensor things that look sensitive. When there are circular refs, it will traverse forever.

My fix is to use a `$visited` hashref in the _censor subroutine, so that it keeps track of the data structures it visited.