### PR TITLE
add Git Guide to a new section for listing project development resources

### DIFF
--- a/README.mkdn
+++ b/README.mkdn
@@ -79,6 +79,15 @@ complete outline on where to go for help.
     [Dancer2::Manual::Migration](https://metacpan.org/pod/Dancer2::Manual::Migration) provides the most up-to-date instruction on
     how to convert a Dancer (1) based application to Dancer2.
 
+## Project Development
+
+These are resources to help you contribute to the the Dancer2 open source project.
+
+- Dancer2 Git Guide
+
+    The [Git Guide](https://github.com/PerlDancer/Dancer2/blob/master/GitGuide.md) has step-by-step instructions for
+    setting up a development environment and making contributions to [Dancer2's GitHub repository](https://github.com/PerlDancer/Dancer2).
+
 # FUNCTIONS
 
 ## my $runner=runner();

--- a/README.mkdn
+++ b/README.mkdn
@@ -81,12 +81,24 @@ complete outline on where to go for help.
 
 ## Project Development
 
-These are resources to help you contribute to the the Dancer2 open source project.
+These are resources to help you contribute to the Dancer2 open source project. We welcome you
+and encourage you to join us.
 
 - Dancer2 Git Guide
 
     The [Git Guide](https://github.com/PerlDancer/Dancer2/blob/master/GitGuide.md) has step-by-step instructions for
     setting up a development environment and making contributions to [Dancer2's GitHub repository](https://github.com/PerlDancer/Dancer2).
+
+- Ways to Participate
+
+    You don't have to be a programmer to hlep move the Dancer2 project forward. [Visit our website](http://perldancer.org/contribute)
+    to learn other ways you can contribute your talents and resources.
+
+- Policy
+
+    The [Dancer2::Policy](http://search.cpan.org/perldoc?Dancer2%3A%3APolicy) man page outlines broad Standards of Conduct
+    for our developers and the wider Dancer2 community.
+    
 
 # FUNCTIONS
 

--- a/README.mkdn
+++ b/README.mkdn
@@ -87,12 +87,12 @@ and encourage you to join us.
 - Dancer2 Git Guide
 
     The [Git Guide](https://github.com/PerlDancer/Dancer2/blob/master/GitGuide.md) has step-by-step instructions for
-    setting up a development environment and making contributions to [Dancer2's GitHub repository](https://github.com/PerlDancer/Dancer2).
+    setting up a development environment and making contributions to Dancer2's GitHub repository.
 
-- Ways to Participate
+- Advancing Dancer2
 
-    You don't have to be a programmer to hlep move the Dancer2 project forward. [Visit our website](http://perldancer.org/contribute)
-    to learn other ways you can contribute your talents and resources.
+    [Visit our website](http://perldancer.org/contribute) to learn how you can contribute your talents and resources even if
+    you aren't a programmer.
 
 - Policy
 

--- a/lib/Dancer2/Manual.pod
+++ b/lib/Dancer2/Manual.pod
@@ -1375,8 +1375,14 @@ C<appdir/environments>. That way, the appropriate environment config file
 will be loaded according to the running environment (if none is specified,
 it will be 'development').
 
-Note that you can change the running environment using the C<--environment>
-command line switch.
+You can change the running environment when starting your app using the
+C<plackup> command's C<--env> or C<--E> switch:
+
+    plackup -E production bin/app.psgi
+
+Altenatively, you can set the
+L<C<DANCER_ENVIRONMENT>|https://metacpan.org/pod/Dancer2::Config#DANCER_ENVIRONMENT>
+environment variable in the shell or in your web server's configuration file.
 
 Typically, you'll want to set the following values in a development config
 file:

--- a/lib/Dancer2/Template/TemplateToolkit.pm
+++ b/lib/Dancer2/Template/TemplateToolkit.pm
@@ -183,6 +183,28 @@ The same approach should work for SERVICE (L<Template::Service>), CONTEXT (L<Tem
 PARSER (L<Template::Parser>) and GRAMMAR (L<Template::Grammar>). If you intend to replace
 several of these components in your app, it is suggested to create an app-specific subclass
 that handles all of them at the same time.
+
+=head2 Template Caching
+
+L<Template>::Tookit templates can be cached by adding the C<COMPILE_EXT> property to your
+template configuration settings:
+
+    # in config.yml
+    engines:
+      template_toolkit:
+        start_tag: '<%'
+        end_tag:   '%>'
+        COMPILE_EXT: '.tcc' # cached file extension
+
+Template caching will avoid the need to re-parse template files or blocks each time they are
+used. Cached templates are automatically updated when you update the original template file.
+
+By default, cached templates are saved in the same directory as your template. To save
+cached templates in a different directory, you can set the C<COMPILE_DIR property in your
+Dancer2 configuration file. 
+
+Please see L<Template::Manual::Config/Caching_and_Compiling_Options> for further
+details and more caching options.
             
 =head1 SEE ALSO
 

--- a/lib/Dancer2/Template/TemplateToolkit.pm
+++ b/lib/Dancer2/Template/TemplateToolkit.pm
@@ -200,7 +200,7 @@ Template caching will avoid the need to re-parse template files or blocks each t
 used. Cached templates are automatically updated when you update the original template file.
 
 By default, cached templates are saved in the same directory as your template. To save
-cached templates in a different directory, you can set the C<COMPILE_DIR property in your
+cached templates in a different directory, you can set the C<COMPILE_DIR> property in your
 Dancer2 configuration file. 
 
 Please see L<Template::Manual::Config/Caching_and_Compiling_Options> for further


### PR DESCRIPTION
My first commit to an open source project via GitHub. I'm not sure if I'm doing this right. Feel free to scream at me if I've screwed it up. :)

This is to address the issue created at https://github.com/PerlDancer/Dancer2/issues/1407

I added a new section to the README.mkdn file for Project Development to list resources for those interested in contributing to the project. For now, it contains only the Git Guide.