### PR TITLE
make it more convenient to create plain/text content with send_as

### DIFF
--- a/lib/Dancer2/Core/App.pm
+++ b/lib/Dancer2/Core/App.pm
@@ -943,7 +943,7 @@ sub send_as {
     $type or croak "Can not send_as using an undefined type";
 
     if ( lc($type) eq 'html' || lc($type) eq 'plain' ) {
-        if ( $type ne 'html' && $type ne 'plain' ) {
+        if ( $type ne lc $type ) {
             local $Carp::CarpLevel = 2;
             carp sprintf( "Please use %s as the type for 'send_as', not %s", lc($type), $type );
         }

--- a/lib/Dancer2/Core/App.pm
+++ b/lib/Dancer2/Core/App.pm
@@ -942,15 +942,15 @@ sub send_as {
 
     $type or croak "Can not send_as using an undefined type";
 
-    if ( lc($type) eq 'html' ) {
-        if ( $type ne 'html' ) {
+    if ( lc($type) eq 'html' || lc($type) eq 'plain' ) {
+        if ( $type ne 'html' && $type ne 'plain' ) {
             local $Carp::CarpLevel = 2;
-            carp "Please use 'html' as the type for 'send_as', not $type";
+            carp sprintf( "Please use %s as the type for 'send_as', not %s", lc($type), $type );
         }
 
         $options->{charset} = $self->config->{charset} || 'UTF-8';
         my $content = Encode::encode( $options->{charset}, $data );
-        $options->{content_type} ||= 'text/html';
+        $options->{content_type} ||= ($type eq lc('html') ? 'text/html' : 'text/plain');
         $self->send_file( \$content, %$options );     # returns from sub
     }
 

--- a/lib/Dancer2/Core/App.pm
+++ b/lib/Dancer2/Core/App.pm
@@ -950,7 +950,7 @@ sub send_as {
 
         $options->{charset} = $self->config->{charset} || 'UTF-8';
         my $content = Encode::encode( $options->{charset}, $data );
-        $options->{content_type} ||= ($type eq lc('html') ? 'text/html' : 'text/plain');
+        $options->{content_type} ||= join '/', 'text', lc $type;
         $self->send_file( \$content, %$options );     # returns from sub
     }
 

--- a/t/dsl/send_as.t
+++ b/t/dsl/send_as.t
@@ -35,6 +35,10 @@ use HTTP::Request::Common;
         send_as html => '<html></html>'
     };
 
+    get '/plain' => sub {
+        send_as plain => 'some plain text with <html></html>';
+    };
+
     get '/json/**' => sub {
         send_as JSON => splat;
     };
@@ -100,7 +104,6 @@ subtest "send_as json custom content-type" => sub {
     is $res->content, '["is","wonderful"]';
 };
 
-
 subtest "send_as html" => sub {
     my $res = $test->request( GET '/html' );
     is $res->code, '200';
@@ -108,6 +111,15 @@ subtest "send_as html" => sub {
     is $res->content_type_charset, 'UTF-8';
 
     is $res->content, '<html></html>';
+};
+
+subtest "send_as plain" => sub {
+    my $res = $test->request( GET '/plain' );
+    is $res->code, '200';
+    is $res->content_type, 'text/plain';
+    is $res->content_type_charset, 'UTF-8';
+
+    is $res->content, 'some plain text with <html></html>';
 };
 
 subtest "send_as error cases" => sub {


### PR DESCRIPTION
For #1418, second attempt, to fix earlier botched pull request.