### PR TITLE
Move section on modules for extra speed to Deployment

### DIFF
--- a/lib/Dancer2/Manual/Deployment.pod
+++ b/lib/Dancer2/Manual/Deployment.pod
@@ -675,5 +675,38 @@ Launch your application:
 
     plackup -s FCGI --listen /tmp/fcgi.sock bin/app.psgi
 
+
+=head2 Performance Improvements
+
+The following modules can be used to speed up an app in Dancer2:
+
+=over 4
+
+=item * L<URL::Encode::XS>
+
+=item * L<CGI::Deurl::XS>
+
+=item * L<HTTP::Parser::XS>
+
+=item * L<HTTP::XSCookies>
+
+=item * L<Scope::Upper>
+
+=item * L<Type::Tiny::XS>
+
+=back
+
+They would need to be installed separately. This is because L<Dancer2> does
+not incorporate any C code, but it can get C-code compiled as a module.
+Thus, these modules can be used for speed improvement provided:
+
+=over 4
+
+=item * You have access to a C interpreter
+
+=item * You don't need to fatpack your application
+
+=back
+
 =cut
 

--- a/lib/Dancer2/Manual/Migration.pod
+++ b/lib/Dancer2/Manual/Migration.pod
@@ -97,35 +97,8 @@ not be executed.
 See L<Dancer2::Cookbook|https://metacpan.org/pod/Dancer2::Cookbook#Using-the-prefix-feature-to-split-your-application>
 for details.
 
-2. The following modules can be used to speed up an app in Dancer2:
-
-=over 4
-
-=item * L<URL::Encode::XS>
-
-=item * L<CGI::Deurl::XS>
-
-=item * L<HTTP::Parser::XS>
-
-=item * L<HTTP::XSCookies>
-
-=item * L<Scope::Upper>
-
-=item * L<Type::Tiny::XS>
-
-=back
-
-They would need to be installed separately. This is because L<Dancer2> does
-not incorporate any C code, but it can get C-code compiled as a module.
-Thus, these modules can be used for speed improvement provided:
-
-=over 4
-
-=item * You have access to a C interpreter
-
-=item * You don't need to fatpack your application
-
-=back
+2. To speed up an app in Dancer2, install the recommended modules listed in the
+L<Dancer2::Manual::Deployment/"Performance Improvements"> section.
 
 =head2 Request
 


### PR DESCRIPTION
This section is important to both old Dancer1 users but also to new
Dancer2 users and the latter group would probably not read the
Migration page.

Moved the section from Migration to Deployment, and left a link
pointing to the new placement.