### PR TITLE
allow disabling of http only cookies using strings

### DIFF
--- a/lib/Dancer2/Core/Cookie.pm
+++ b/lib/Dancer2/Core/Cookie.pm
@@ -41,7 +41,7 @@ sub xs_to_header {
             path     => $self->path,
             domain   => $self->domain,
             expires  => $self->expires,
-            httponly => $self->http_only,
+            httponly => !!$self->http_only, # HTTP::XSCookies seems to distinguish between '"0"' and '0'
             secure   => $self->secure,
             samesite => $self->same_site,
         }

--- a/t/cookie.t
+++ b/t/cookie.t
@@ -155,6 +155,13 @@ sub run_test {
             expected => "bar=foo; Path=/",
         },
         {   cookie => {
+                name  => 'bar',
+                value => 'foo',
+                http_only => '0',
+            },
+            expected => "bar=foo; Path=/",
+        },
+        {   cookie => {
                 name      => 'same-site',
                 value     => 'strict',
                 same_site => 'Strict',


### PR DESCRIPTION
I had some issues disabling http_only cookies for the session cookie.

```YAML
session: YAML
engines:
    session:
        YAML:
            cookie_name: session.id
            is_http_only: 0
```

With a config like this the HttpOnly value would always get set in the cookie header string.
The HTTP::XSCookies module seems to handle strings different from numbers and does consider a string containing only '0' to be truthy.  This can be fixed by forcing boolean context on the value before passing it to the module. 

I added a fix for this and a test to make sure http_only can be disabled with a string.

