### PR TITLE
Use File::Share on top of File::ShareDir

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -11,7 +11,7 @@ requires 'File::Basename';
 requires 'File::Copy';
 requires 'File::Find';
 requires 'File::Path';
-requires 'File::ShareDir';
+requires 'File::Share';
 requires 'File::Spec';
 requires 'File::Temp';
 requires 'Hash::Merge::Simple';

--- a/lib/Dancer2/CLI/Command/gen.pm
+++ b/lib/Dancer2/CLI/Command/gen.pm
@@ -10,7 +10,7 @@ use HTTP::Tiny;
 use File::Find;
 use File::Path 'mkpath';
 use File::Spec::Functions;
-use File::ShareDir 'dist_dir';
+use File::Share 'dist_dir';
 use File::Basename qw/dirname basename/;
 use Dancer2::Template::Simple;
 use Module::Runtime 'require_module';


### PR DESCRIPTION
File::Share provides its own dist_dir()/dist_file() which also work
in local source directories. Otherwise it will delegate to File::ShareDir
as usual.

Currently the `dancer2 gen` command will not work from the source directory
if there is no Dancer2 installed yet.

See https://perlmonks.org/?node_id=1209472

