### PR TITLE
Support Content-Disposition of inline in send_file()

### DIFF
--- a/lib/Dancer2/Core/App.pm
+++ b/lib/Dancer2/Core/App.pm
@@ -1067,7 +1067,7 @@ sub send_file {
     # content disposition
     ( exists $options{filename} )
       and $self->response->header( 'Content-Disposition' =>
-          ($options{content_disposition} // "attachment") . "; filename=\"$options{filename}\"" );
+          ($options{content_disposition} || "attachment") . "; filename=\"$options{filename}\"" );
 
     # use a delayed response unless server does not support streaming
     my $use_streaming = exists $options{streaming} ? $options{streaming} : 1;

--- a/lib/Dancer2/Core/App.pm
+++ b/lib/Dancer2/Core/App.pm
@@ -1067,7 +1067,7 @@ sub send_file {
     # content disposition
     ( exists $options{filename} )
       and $self->response->header( 'Content-Disposition' =>
-          "attachment; filename=\"$options{filename}\"" );
+          ($options{content_disposition} // "attachment") . "; filename=\"$options{filename}\"" );
 
     # use a delayed response unless server does not support streaming
     my $use_streaming = exists $options{streaming} ? $options{streaming} : 1;

--- a/lib/Dancer2/Manual.pod
+++ b/lib/Dancer2/Manual.pod
@@ -2908,6 +2908,9 @@ use.
    send_file( \$data, content_type => 'image/png'
                       filename     => 'onion.png' );
 
+By default the Content-Disposition header uses the "attachment" type, which
+triggers a "Save" dialog in some browsers. Supply a C<content_disposition>
+attribute of "inline" to have the file displayed inline by the browser.
 
 =head2 set
 

--- a/t/dsl/send_file.t
+++ b/t/dsl/send_file.t
@@ -57,6 +57,14 @@ use Ref::Util qw<is_coderef>;
         my $file = File::Spec->rel2abs(__FILE__);
         send_file( $file, system_path => 1, streaming => 1 );
     };
+
+    get '/content_disposition/attachment' => sub {
+        send_file('1x1.png', filename => '1x1.png');
+    };
+
+    get '/content_disposition/inline' => sub {
+        send_file('1x1.png', filename => '1x1.png', content_disposition => 'inline');
+    };
 }
 
 my $app = StaticContent->to_app;
@@ -123,6 +131,18 @@ test_psgi $app, sub {
 
         ok($r->is_success, 'send_file returns success');
         is($r->content_type, 'image/png', 'send_file returns correct content_type');
+    };
+
+    subtest 'Content-Disposition defaults to "attachment"' => sub {
+        my $r = $cb->( GET '/content_disposition/attachment' );
+        ok($r->is_success, 'send_file returns success');
+        is($r->header('Content-Disposition'), 'attachment; filename="1x1.png"', 'send_file returns correct attachment Content-Disposition');
+    };
+
+    subtest 'Content-Disposition supports "inline"' => sub {
+        my $r = $cb->( GET '/content_disposition/inline' );
+        ok($r->is_success, 'send_file returns success');
+        is($r->header('Content-Disposition'), 'inline; filename="1x1.png"', 'send_file returns correct inline Content-Disposition');
     };
 };
 


### PR DESCRIPTION
When called with a "filename" arg, send_file() sets the
Content-Disposition header type to "attachment". This triggers a "Save"
dialogue in some browsers when opening a link in a new tab or window.

+ Add an optional "content_disposition" argument to send_file() which can be
set to "inline" to have the browser display the file inline.

+ Add a note to the manual about this new behaviour.

+ Add tests for "attachment" and "inline" behaviours.