### PR TITLE
Handle XSCookies to return an arrayref of values

### DIFF
--- a/lib/Dancer2/Core/Request.pm
+++ b/lib/Dancer2/Core/Request.pm
@@ -598,7 +598,8 @@ sub _build_cookies {
     while (my ($name, $value) = each %{$cookies}) {
         $cookies->{$name} = Dancer2::Core::Cookie->new(
             name  => $name,
-            value => [split(/[&;]/, $value)]
+            # HTTP::XSCookies v0.17+ will do the split and return an arrayref
+            value => (is_arrayref($value) ? $value : [split(/[&;]/, $value)])
         );
     }
     return $cookies;


### PR DESCRIPTION
Both Cookie::Baker and Cookie::Baker::XS return a string for the cookie
value, for which we then split on `&` for handling multiple values. The
alternative XS implementation for cookie crushing, HTTP::XSCookies does
the split, returning an arrayref.

Update the cookie object construction code to accept a string (which we
split), or an arrayref of values (which we leave alone). Allows use of
Cookie::Baker(::XS) or HTTP::XSCookies with minimal code to maintain.

Closes #1435.