### PR TITLE
Min version of HTTP::Headers::Fast in v0.21

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -17,7 +17,7 @@ requires 'File::Temp';
 requires 'Hash::Merge::Simple';
 requires 'Hash::MultiValue';
 requires 'HTTP::Date';
-requires 'HTTP::Headers::Fast';
+requires 'HTTP::Headers::Fast', '0.21';
 requires 'HTTP::Tiny';
 requires 'Import::Into';
 requires 'JSON::MaybeXS';


### PR DESCRIPTION
Dancer2::Core::Request may call `psgi_flatten_without_sort` which was
added to HTTP::Headers::Fast in v0.21. Explicitly state that version
dependency in our cpanfile.

Closes #1445.