### PR TITLE
Engines should respect log level

### DIFF
--- a/lib/Dancer2/Core/App.pm
+++ b/lib/Dancer2/Core/App.pm
@@ -244,7 +244,7 @@ sub _build_session_engine {
         %{$engine_options},
         postponed_hooks => $self->postponed_hooks,
 
-        log_cb => sub { $weak_self->logger_engine->log(@_) },
+        log_cb => sub { $weak_self->log(@_) },
     );
 }
 
@@ -277,7 +277,7 @@ sub _build_template_engine {
         %{$engine_attrs},
         postponed_hooks => $self->postponed_hooks,
 
-        log_cb => sub { $weak_self->logger_engine->log(@_) },
+        log_cb => sub { $weak_self->log(@_) },
     );
 }
 
@@ -302,7 +302,7 @@ sub _build_serializer_engine {
         config          => $engine_options,
         postponed_hooks => $self->postponed_hooks,
 
-        log_cb => sub { $weak_self->logger_engine->log(@_) },
+        log_cb => sub { $weak_self->log(@_) },
     );
 }
 


### PR DESCRIPTION
This hopefully fixes #1328. The logger callback log_cb which is set on the engines should include the code which checks that only messages which are at a sufficiently high log level are actually logged.