### PR TITLE
Serializer mutable with custom mapping

### DIFF
--- a/lib/Dancer2/Core/App.pm
+++ b/lib/Dancer2/Core/App.pm
@@ -367,7 +367,8 @@ sub set_request {
     $defined_engines ||= $self->defined_engines;
     # populate request in app and all engines
     $self->_set_request($request);
-    $_->set_request( $request ) for @{$defined_engines};
+    Scalar::Util::weaken( my $weak_request = $request );
+    $_->set_request( $weak_request ) for @{$defined_engines};
 }
 
 has response => (

--- a/lib/Dancer2/Core/Request.pm
+++ b/lib/Dancer2/Core/Request.pm
@@ -199,6 +199,10 @@ sub deserialize {
         $serializer_fail = $_[1];
         $serializer_log_cb->(@_);
     };
+    # work-around to resolve a chicken-and-egg issue when instantiating a
+    # request object; the serializer needs that request object to deserialize
+    # the body params.
+    $self->serializer->has_request || $self->serializer->set_request($self);
     my $data = $serializer->deserialize($body);
     die $serializer_fail if $serializer_fail;
 

--- a/lib/Dancer2/Core/Request.pm
+++ b/lib/Dancer2/Core/Request.pm
@@ -202,7 +202,8 @@ sub deserialize {
     # work-around to resolve a chicken-and-egg issue when instantiating a
     # request object; the serializer needs that request object to deserialize
     # the body params.
-    $self->serializer->has_request || $self->serializer->set_request($self);
+    Scalar::Util::weaken( my $request = $self );
+    $self->serializer->has_request || $self->serializer->set_request($request);
     my $data = $serializer->deserialize($body);
     die $serializer_fail if $serializer_fail;
 

--- a/lib/Dancer2/Core/Role/Serializer.pm
+++ b/lib/Dancer2/Core/Role/Serializer.pm
@@ -74,16 +74,6 @@ around deserialize => sub {
     return $data;
 };
 
-# most serializer don't have to overload this one
-sub support_content_type {
-    my ( $self, $ct ) = @_;
-    return unless $ct;
-
-    my @toks = split /;/, $ct;
-    $ct = lc( $toks[0] );
-    return $ct eq $self->content_type;
-}
-
 1;
 
 __END__

--- a/lib/Dancer2/Serializer/Mutable.pm
+++ b/lib/Dancer2/Serializer/Mutable.pm
@@ -56,21 +56,6 @@ has mapping => (
     },
 );
 
-
-sub support_content_type {
-    my ( $self, $ct ) = @_;
-
-    # FIXME: are we getting full content type?
-
-    if ( $ct && grep +( $_ eq $ct ), keys %{$self->mapping} ) {
-        $self->set_content_type($ct);
-
-        return 1;
-    }
-
-    return 0;
-}
-
 sub serialize {
     my ( $self, $entity ) = @_;
 

--- a/lib/Dancer2/Serializer/Mutable.pm
+++ b/lib/Dancer2/Serializer/Mutable.pm
@@ -120,15 +120,20 @@ sub _get_content_type {
 
 __END__
 
-=head1 NAME
-
-Dancer2::Serializer::Mutable - Serialize and deserialize content using the appropriate HTTP header
-(ported from Dancer)
-
 =head1 SYNOPSIS
 
     # in config.yml
     serializer: Mutable
+
+    engines:
+        serializer:
+            Mutable:
+                mapping:
+                    'text/x-yaml'        : YAML
+                    'text/html'          : YAML
+                    'text/x-data-dumper' : Dumper
+                    'text/x-json'        : JSON
+                    'application/json'   : JSON
 
     # in the app
     put '/something' => sub {

--- a/lib/Dancer2/Serializer/Mutable.pm
+++ b/lib/Dancer2/Serializer/Mutable.pm
@@ -173,6 +173,37 @@ uses is
     Dancer2::Serializer::Dumper | text/x-data-dumper
     Dancer2::Serializer::JSON   | text/x-json, application/json
 
+A different mapping can be provided via the config file. For example,
+the default mapping would be configured as
+
+    engines:
+        serializer:
+            Mutable:
+                mapping:
+                    'text/x-yaml'        : YAML
+                    'text/html'          : YAML
+                    'text/x-data-dumper' : Dumper
+                    'text/x-json'        : JSON
+                    'application/json'   : JSON
+
+The keys of the mapping are the content-types to serialize,
+and the values the serializers to use. Serialization for C<YAML>, C<Dumper>
+and C<JSON> are done using internal Dancer mechanisms. Any other serializer will
+be taken to be as Dancer2 serialization class (minus the C<Dancer2::Serializer::> prefix)
+and an instance of it will be used
+to serialize/deserialize data. For example, adding L<Dancer2::Serializer::XML>
+to the mapping would be:
+
+    engines:
+        serializer:
+            Mutable:
+                mapping:
+                    'text/x-yaml'        : YAML
+                    'text/html'          : YAML
+                    'text/x-data-dumper' : Dumper
+                    'text/x-json'        : JSON
+                    'text/xml'           : XML
+
 =head2 INTERNAL METHODS
 
 The following methods are used internally by C<Dancer2> and are not made

--- a/t/classes/Dancer2-Core-Role-Serializer/with.t
+++ b/t/classes/Dancer2-Core-Role-Serializer/with.t
@@ -1,6 +1,6 @@
 use strict;
 use warnings;
-use Test::More tests => 5;
+use Test::More tests => 4;
 use Test::Fatal;
 
 use_ok('Dancer2::Core::Hook');
@@ -119,49 +119,6 @@ subtest 'Unsuccessful' => sub {
             'Correct error message',
         );
     }
-};
-
-{
-    package Serializer::Generic;
-    use Moo;
-    with 'Dancer2::Core::Role::Serializer';
-    has '+content_type' => ( default => 'plain/test' );
-    sub serialize   {1}
-    sub deserialize {1}
-}
-
-subtest 'support_content_type' => sub {
-    plan tests => 7;
-
-    my $srl = Serializer::Generic->new;
-    isa_ok( $srl, 'Serializer::Generic'  );
-    can_ok( $srl, 'support_content_type' );
-
-    is( $srl->support_content_type(), undef, 'Empty returns undef' );
-
-    is(
-        $srl->support_content_type('plain/foo;plain/bar'),
-        '',
-        'Content type not supported',
-    );
-
-    is(
-        $srl->support_content_type('plain/foo;plain/test'),
-        '',
-        'Content type not supported (because not first)',
-    );
-
-    is(
-        $srl->support_content_type('plain/test'),
-        1,
-        'Content type supported when single',
-    );
-
-    is(
-        $srl->support_content_type('plain/test;plain/foo'),
-        1,
-        'Content type supported when first',
-    );
 };
 
 {

--- a/t/serializer_mutable.t
+++ b/t/serializer_mutable.t
@@ -1,7 +1,8 @@
 use strict;
 use warnings;
 
-use Test::More tests => 41;
+use Test::More tests => 5
+;
 use Dancer2::Serializer::Mutable;
 use Plack::Test;
 use HTTP::Request::Common;
@@ -25,66 +26,92 @@ use Ref::Util qw<is_coderef>;
     };
 }
 
-my $app = MyApp->to_app;
-ok( is_coderef($app), 'Got app' );
+my $test = Plack::Test->create( MyApp->to_app );
 
-test_psgi $app, sub {
-    my $cb = shift;
+subtest "serializer returns to default state" => sub {
 
-    # Configure all test cases
-    my $d = {
-        yaml    => {
-                types       => [ qw(text/x-yaml text/html) ],
-                value       => encode('UTF-8', YAML::Dump({ bar => 'baz' })),
-                last_val    => "---bar:baz",
-            },
-        dumper  => {
-                types       => [ qw(text/x-data-dumper) ],
-                value       => Data::Dumper::Dumper({ bar => 'baz' }),
-                last_val    => "\$VAR1={'bar'=>'baz'};",
-            },
-        json    => {
-                types       => [ qw(text/x-json application/json) ],
-                value       => JSON::MaybeXS::encode_json({ bar => 'baz' }),
-                last_val    => '{"bar":"baz"}',
-            },
-    };
+    my $res = $test->request( GET '/serialize' );
+    is(
+        $res->headers->content_type,
+        'application/json',
+        "Default content-type header",
+    );
 
-    {
-        for my $format (keys %$d) {
-            note("Format: $format");
+    $res = $test->request( GET '/serialize', 'Accept' => 'text/x-data-dumper' );
+    is(
+        $res->headers->content_type,
+        'text/x-data-dumper',
+        "Correct content-type header",
+    );
+    $res = $test->request( GET '/serialize' );
+    is(
+        $res->headers->content_type,
+        'application/json',
+        "Correct default content-type header after a request that used another",
+    );
+};
 
-            my $s = $d->{$format};
 
-            # Response with implicit call to the serializer
-            for my $content_type ( @{ $s->{types} } ) {
 
-                for my $ct (qw/Content-Type Accept/) {
+# Configure test content-type cases
+my $d = {
+    yaml    => {
+            types       => [ qw(text/x-yaml text/html) ],
+            value       => encode('UTF-8', YAML::Dump({ bar => 'baz' })),
+            last_val    => "---bar:baz",
+        },
+    dumper  => {
+            types       => [ qw(text/x-data-dumper) ],
+            value       => Data::Dumper::Dumper({ bar => 'baz' }),
+            last_val    => "\$VAR1={'bar'=>'baz'};",
+        },
+    json    => {
+            types       => [ qw(text/x-json application/json) ],
+            value       => JSON::MaybeXS::encode_json({ bar => 'baz' }),
+            last_val    => '{"bar":"baz"}',
+        },
+    default => {
+            types       => [ '*/*', '' ],
+            value       => JSON::MaybeXS::encode_json({ bar => 'baz' }),
+            last_val    => '{"bar":"baz"}',
+            return_content_type => 'application/json',
+        },
+};
 
-                    # Test getting the value serialized in the correct format
-                    my $res = $cb->( GET '/serialize', $ct => $content_type );
+for my $format (keys %$d) {
 
-                    is( $res->code, 200, "[/$format] Correct status" );
-                    is( $res->content, $s->{value}, "[/$format] Correct content" );
-                    is(
-                        $res->headers->content_type,
-                        $content_type,
-                        "[/$format] Correct content-type headers",
-                    );
-                }
+    subtest "Format: $format" => sub {
+        my $s = $d->{$format};
 
-                # Test sending the value serialized in the correct format
-                # needs to be de-serialized and returned
-                my $req = $cb->( POST '/deserialize',
-                                 'Content-Type' => $content_type,
-                                 content        => $s->{value} );
+        # Response with implicit call to the serializer
+        for my $content_type ( @{ $s->{types} } ) {
 
-                my $content = $req->content;
-                $content =~ s/\s//g;
-                is( $req->code, 200, "[/$format] Correct status" );
-                is( $content, $s->{last_val}, "[/$format] Correct content" );
-            } #/ for my $content_type
-        } #/ for my $format
-    }
+            for my $ct (qw/Content-Type Accept/) {
 
-}
+                # Test getting the value serialized in the correct format
+                my $res = $test->request( GET '/serialize', $ct => $content_type );
+
+                is( $res->code, 200, "[/$format] Correct status" );
+                is( $res->content, $s->{value}, "[/$format] Correct content" );
+                is(
+                    $res->headers->content_type,
+                    $s->{return_content_type} || $content_type,
+                    "[/$format] Correct content-type headers",
+                );
+            }
+
+            # Test sending the value serialized in the correct format
+            # needs to be de-serialized and returned
+            my $req = $test->request( POST '/deserialize',
+                             'Content-Type' => $content_type,
+                             content        => $s->{value} );
+
+            my $content = $req->content;
+            $content =~ s/\s//g;
+            is( $req->code, 200, "[/$format] Deserialize: correct status" );
+            is( $content, $s->{last_val}, "[/$format] Deserialize: correct content" );
+
+        } #/ for my $content_type
+    }; #/ subtest
+
+} #/ for my $format

--- a/t/serializer_mutable_custom.t
+++ b/t/serializer_mutable_custom.t
@@ -1,0 +1,126 @@
+=pod
+
+Same as t/serializer_mutable.t, but exercise the configurable
+mappings
+
+=cut
+
+use strict;
+use warnings;
+
+use Test::More tests => 5;
+use Dancer2::Serializer::Mutable;
+use Plack::Test;
+use HTTP::Request::Common;
+use Encode;
+use JSON::MaybeXS;
+use YAML;
+use Ref::Util qw<is_coderef>;
+
+{
+    package Dancer2::Serializer::Other;
+
+    use Moo;
+    with 'Dancer2::Core::Role::Serializer';
+
+    has '+content_type' => ( default => 'text/other' );
+
+    sub serialize   { '{thing}' }
+    sub deserialize { '{thing}' }
+
+}
+
+{
+    package MyApp;
+    use Dancer2;
+
+    BEGIN {
+        setting engines => { serializer => { Mutable => { mapping => {
+            'text/x-yaml'        => 'YAML',
+            'text/x-data-dumper' => 'Dumper',
+            'text/x-json'        => 'JSON',
+            'application/json'   => 'JSON',
+            'text/other'         => 'Other',
+        } } } };
+    }
+
+    use Ref::Util qw<is_hashref>;
+
+    set serializer => 'Mutable';
+
+    get '/serialize'     => sub { +{ bar => 'baz' } };
+    post '/deserialize'  => sub {
+        return request->data &&
+               is_hashref( request->data ) &&
+               request->data->{bar} ? { bar => request->data->{bar} } : { ret => '?' };
+    };
+}
+
+my $app = MyApp->to_app;
+ok is_coderef($app), 'Got app';
+
+test_psgi $app, sub {
+    my $cb = shift;
+
+    # Configure all test cases
+    my $d = {
+        yaml    => {
+                types       => [ qw(text/x-yaml) ],
+                value       => encode('UTF-8', YAML::Dump({ bar => 'baz' })),
+                last_val    => "---bar:baz",
+            },
+        other    => {
+                types       => [ qw(text/other) ],
+                value       => '{thing}',
+                last_val    => "{thing}",
+            },
+        dumper  => {
+                types       => [ qw(text/x-data-dumper) ],
+                value       => Data::Dumper::Dumper({ bar => 'baz' }),
+                last_val    => "\$VAR1={'bar'=>'baz'};",
+            },
+        json    => {
+                types       => [ qw(text/x-json application/json) ],
+                value       => JSON::MaybeXS::encode_json({ bar => 'baz' }),
+                last_val    => '{"bar":"baz"}',
+            },
+    };
+
+    for my $format (keys %$d) {
+        subtest "Format: $format" => sub {
+
+            my $s = $d->{$format};
+
+            # Response with implicit call to the serializer
+            for my $content_type ( @{ $s->{types} } ) {
+                subtest $content_type => sub {
+                    for my $ct (qw/Content-Type Accept/) {
+
+                        # Test getting the value serialized in the correct format
+                        my $res = $cb->( GET '/serialize', $ct => $content_type );
+
+                        is( $res->code, 200, "status" );
+                        is( $res->content, $s->{value}, "content" );
+                        is(
+                            $res->headers->content_type,
+                            $content_type,
+                            "content-type headers",
+                        );
+                    }
+
+                    # Test sending the value serialized in the correct format
+                    # needs to be de-serialized and returned
+                    my $req = $cb->( POST '/deserialize',
+                                        'Content-Type' => $content_type,
+                                        content        => $s->{value} );
+
+                    my $content = $req->content;
+                    $content =~ s/\s//g;
+                    is( $req->code, 200, "status" );
+                    is( $content, $s->{last_val}, "content" );
+                }
+            }
+        }
+    }
+
+}


### PR DESCRIPTION
Its about time the mutable serializer "just worked".  This PR pulls together several existing branches and PR's to ensure the mutable serializer does indeed work as it should, but maintains back-compatibility.

* Built from a cleaned-up (and rebased) version of @yanick's PR #1365 that allows for customising the content-type/serializer mapping table
* Includes the tests by @dboehmer from #805 ensuring intended fixes the mutable serializer are indeed fixed.
* Removes the unused `support_content_type` method (see #973).
* Add the request object to the current serializer (if we hadn't done so already), resolving the chicken-and-egg issues that the mutable serializer needs the request headers to function. This should also help resolve #973. May need @shumphrey's feedback on that. 

Also resolves #901.