### PR TITLE
Allow layout_dir to by configured by set keyword

### DIFF
--- a/lib/Dancer2/Core/App.pm
+++ b/lib/Dancer2/Core/App.pm
@@ -153,6 +153,12 @@ has '+local_triggers' => (
                 $self->template_engine->layout($value);
             },
 
+            layout_dir => sub {
+                my $self  = shift;
+                my $value = shift;
+                $self->template_engine->layout_dir($value);
+            },
+
             log => sub {
                 my ( $self, $value, $config ) = @_;
 
@@ -268,7 +274,9 @@ sub _build_template_engine {
     my $engine_attrs = { config => $engine_options };
     $engine_attrs->{layout} ||= $config->{layout};
     $engine_attrs->{views}  ||= $config->{views}
-        || path( $self->location, 'views' );
+                            || path( $self->location, 'views' );
+    $engine_attrs->{layout_dir} ||= $config->{layout_dir}
+                                || 'layouts';
 
     Scalar::Util::weaken( my $weak_self = $self );
 

--- a/lib/Dancer2/Core/Role/Template.pm
+++ b/lib/Dancer2/Core/Role/Template.pm
@@ -54,16 +54,6 @@ has default_tmpl_ext => (
     default => sub { shift->config->{extension} || 'tt' },
 );
 
-has views => (
-    is  => 'rw',
-    isa => Maybe [Str],
-);
-
-has layout => (
-    is  => 'rw',
-    isa => Maybe [Str],
-);
-
 has engine => (
     is      => 'ro',
     isa     => Object,
@@ -79,10 +69,23 @@ has settings => (
     writer  => 'set_settings',
 );
 
+# The attributes views, layout and layout_dir have triggers in
+# Dancer2::Core::App that enable their values to be modified by
+# the `set` keyword. As such, these are defined as read-write attrs.
+
+has views => (
+    is  => 'rw',
+    isa => Maybe [Str],
+);
+
+has layout => (
+    is  => 'rw',
+    isa => Maybe [Str],
+);
+
 has layout_dir => (
-    is      => 'ro',
-    isa     => Str,
-    default => sub {'layouts'},
+    is  => 'rw',
+    isa => Maybe [Str],
 );
 
 sub _template_name {

--- a/t/template.t
+++ b/t/template.t
@@ -19,6 +19,7 @@ my $views =
 my $tt = Dancer2::Template::TemplateToolkit->new(
     views  => $views,
     layout => 'main.tt',
+    layout_dir => 'layouts',
 );
 
 isa_ok $tt, 'Dancer2::Template::TemplateToolkit';
@@ -118,6 +119,11 @@ content added in after_layout_render";
     get '/default_views'          => sub { set 'views' };
     get '/set_views_via_settings' => sub { set views => '/other/path' };
     get '/get_views_via_settings' => sub { set 'views' };
+
+    get '/default_layout_dir'          => sub { app->template_engine->layout_dir };
+    get '/set_layout_dir_via_settings' => sub { set layout_dir => 'alt_layout' };
+    get '/get_layout_dir_via_settings' => sub { set 'layout_dir' };
+
 }
 
 subtest "modify views - absolute paths" => sub {
@@ -137,6 +143,25 @@ subtest "modify views - absolute paths" => sub {
         $test->request( GET '/get_views_via_settings' )->content,
         '/other/path',
         '[GET /get_views_via_settings] Correct content',
+    );
+};
+
+subtest "modify layout_dir" => sub {
+    my $test = Plack::Test->create( Foo->to_app );
+
+    is(
+        $test->request( GET '/default_layout_dir' )->content,
+        'layouts',
+        '[GET /default_layout_dir] Correct layout dir',
+    );
+
+    # trigger a test via a route
+    $test->request( GET '/set_layout_dir_via_settings' );
+
+    is(
+        $test->request( GET '/get_layout_dir_via_settings' )->content,
+        'alt_layout',
+        '[GET /get_layout_dir_via_settings] Correct content',
     );
 };
 


### PR DESCRIPTION
Ensure `set layout_dir => 'foo';` updates config and the app's template engine if its been instantiated.

  * `layout_dir` attribute in Role::Template is now read-write
  * `config->{layout_dir}` passed to template engine when being instantiated
  * Added a trigger to update an existing template engine's `layout_dir` attribute.

Resolves #1427.