### PR TITLE
Relax redirect() to match RFC 7231

### DIFF
--- a/lib/Dancer2/Core/App.pm
+++ b/lib/Dancer2/Core/App.pm
@@ -1273,16 +1273,6 @@ sub redirect {
     my $destination = shift;
     my $status      = shift;
 
-    # RFC 2616 requires an absolute URI with a scheme,
-    # turn the URI into that if it needs it
-
-    # Scheme grammar as defined in RFC 2396
-    #  scheme = alpha *( alpha | digit | "+" | "-" | "." )
-    my $scheme_re = qr{ [a-z][a-z0-9\+\-\.]* }ix;
-    if ( $destination !~ m{^ $scheme_re : }x ) {
-        $destination = $self->request->uri_for( $destination, {}, 1 );
-    }
-
     $self->response->redirect( $destination, $status );
 
     # Short circuit any remaining before hook / route code


### PR DESCRIPTION
Remove code in redirect() that tried to ensure we only return full
URLs with a host as RFC 2616 required. This RFC has since been
superceeded by RFC 7231 which relaxes this rule.

By deleting this code we both simplify the code greatly, win, and
fix a bug where URI encoded hostless URLs were decoded prior to
sending.

Fixes #1460