### PR TITLE
Show support resources after generating new app

### DIFF
--- a/lib/Dancer2/CLI/Command/gen.pm
+++ b/lib/Dancer2/CLI/Command/gen.pm
@@ -110,10 +110,19 @@ NOYAML
     }
 
     print <<HOWTORUN;
-The application is ready to serve; to run it, do:
+
+Your new application is ready! To run it:
 
         cd $app_path
         plackup bin/app.psgi
+
+If you need community assistance, the following resources are available:
+- Dancer website: http://perldancer.org
+- Mailing list: http://lists.preshweb.co.uk/mailman/listinfo/dancer-users
+- IRC: irc.perl.org#dancer
+
+Happy Dancing!
+
 HOWTORUN
 
     return 0;


### PR DESCRIPTION
For new users, it may be handy to have a little reminder of the
resources they have available to them when help is needed.

This was - somehow - inspired by the default MOTD you get after
installing FreeBSD.