### PR TITLE
Route params with types

### DIFF
--- a/lib/Dancer2/Core/App.pm
+++ b/lib/Dancer2/Core/App.pm
@@ -1222,8 +1222,11 @@ sub add_route {
     my $self        = shift;
     my %route_attrs = @_;
 
-    my $route =
-      Dancer2::Core::Route->new( %route_attrs, prefix => $self->prefix );
+    my $route = Dancer2::Core::Route->new(
+        type_library => $self->config->{type_library},
+        %route_attrs,
+        prefix => $self->prefix,
+    );
 
     my $method = $route->method;
 

--- a/lib/Dancer2/Manual.pod
+++ b/lib/Dancer2/Manual.pod
@@ -233,6 +233,54 @@ Tokens can be optional, for example:
         "Hello there, $name";
     };
 
+=head3 Named matching with type constraints
+
+Type constraints can be added to tokens.
+
+    get '/user/:id[Int]' => sub {
+        # matches /user/34 but not /user/jamesdean
+        my $user_id = route_parameters->get('id');
+    };
+
+    get '/user/:username[Str]' => sub {
+        # matches /user/jamesdean but not /user/34 since that is caught
+        # by previous route
+        my $username = route_parameters->get('username');
+    };
+
+You can even use type constraints to add a regexp check:
+
+    get '/book/:date[StrMatch[qr{\d\d\d\d-\d\d-\d\d}]]' => sub {
+        # matches /book/2014-02-04
+        my $date = route_parameters->get('date');
+    };
+
+The default type library is L<Dancer2::Core::Types> but any type library
+built using L<Type::Tiny>'s L<Type::Library> can be used instead.
+If you'd like to use a different default type library you must declare it
+in the configuration file, for example:
+
+    type_library: My::Type::Library
+
+Alternatively you can specify the type library in which the type is defined
+as part of the route definition:
+
+    get '/user/:username[My::Type::Library::Username]' => sub {
+        my $username = route_parameters->get('username');
+    };
+
+This will load C<My::Type::Library> and from it use the type C<Username>. This
+allows types to be used that are not part of the type library defined by config's
+C<type_library>.
+
+More complex constructs are allowed such as:
+
+    get '/some/:thing[Int|MyDate]' => sub {
+        ...;
+    };
+
+See L<Type::Registry/lookup($name)> for more details.
+
 =head3 Wildcard Matching
 
 A route can contain a wildcard (represented by a C<*>). Each wildcard match

--- a/t/lib/TestTypeLibrary.pm
+++ b/t/lib/TestTypeLibrary.pm
@@ -1,0 +1,8 @@
+package TestTypeLibrary;
+use Type::Library -base, -declare => ('MyDate');
+use Type::Utils -all;
+BEGIN { extends "Dancer2::Core::Types" };
+
+declare MyDate, as StrMatch [qr{\d\d\d\d-\d\d-\d\d}];
+
+1;


### PR DESCRIPTION
Hopefully this PR will generate some discussion as to how we would like to proceed with typed params. This code his been around for > 2 years and PR created after I was pinged about it by @cromedome.

Allows types to be specified in route param definitions allowing such things as:

```
get '/thing/:id[Int]' => sub {};

# if not Int then perhaps a Num...
get '/thing/:id[Num]' => sub {};
```

In original issue @yanick suggested:
> Interesting venue to explore. We could even do something like (off-the-cuff pseudo-code below)

```
subtype UserId => as Int => validate { };  # don't remember the real Types::Tiny syntax

get '/api/user/!UserId' => sub { 
  ...;
  # dancer magic would use the type name to populate the right param name
  param('UserId'); 
};
```

This is not currently possible in current implementation but could be added later.

See also @xsawyerx's [Dancer2::Plugin::ParamTypes](https://metacpan.org/pod/Dancer2::Plugin::ParamTypes).