### PR TITLE
remove arbitrary 5.10 requirements from tests

### DIFF
--- a/t/examples/hello_world.t
+++ b/t/examples/hello_world.t
@@ -1,6 +1,5 @@
 use strict;
 use warnings;
-use 5.010;
 
 use FindBin ();
 

--- a/t/examples/simple_calculator.t
+++ b/t/examples/simple_calculator.t
@@ -1,6 +1,5 @@
 use strict;
 use warnings;
-use 5.010;
 
 use FindBin ();
 


### PR DESCRIPTION
Dancer2 works on 5.8.8+ (earlier perl versions cannot install Template Toolkit due to the AppConfig requirement). These tests should not arbitrarily require 5.10.