### PR TITLE
Correct dynamic HTTP::XSCookies requirement

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -56,8 +56,6 @@ recommends 'Class::XSAccessor';
 recommends 'Cpanel::JSON::XS';
 recommends 'Crypt::URandom';
 recommends 'HTTP::XSCookies', '0.000007';
-# GH#1332 if old HTTP::XSCookies is installed we need to upgrade
-eval "require HTTP::XSCookies" && requires 'HTTP::XSCookies', '0.000007';
 recommends 'HTTP::XSHeaders';
 recommends 'Math::Random::ISAAC::XS';
 recommends 'MooX::TypeTiny';

--- a/dist.ini
+++ b/dist.ini
@@ -39,6 +39,11 @@ eumm_version = 7.1101
 -phase = build
 ExtUtils::MakeMaker= 7.1101
 
+[DynamicPrereqs]
+; GH#1332 if old HTTP::XSCookies is installed we need to upgrade
+-condition = has_module('HTTP::XSCookies')
+-body = requires('HTTP::XSCookies', '0.000007')
+
 ; -- static meta-information
 [MetaResources]
 homepage        = http://perldancer.org/


### PR DESCRIPTION
Dynamic prereqs cannot be specified in `cpanfile`. The cpanfile is not used on the installing system, the prereqs are only read from the generated META.json and the MYMETA.json that gets generated by ExtUtils::MakeMaker on the installing system. The current code will only be run by whoever is running `dzil release` and ends up inserting a hard HTTP::XSCookies requirement in the resulting distribution. So to specify this prereq dynamically for the installer we need to use [DynamicPrereqs].