### PR TITLE
add Route attribute for storing extra data

### DIFF
--- a/lib/Dancer2/Core/Route.pm
+++ b/lib/Dancer2/Core/Route.pm
@@ -42,6 +42,12 @@ has options => (
     predicate => 1,
 );
 
+has xt_data => (
+    is => 'ro',
+    isa => HashRef,
+    predicate => 1,
+);
+
 sub _check_options {
     my ( $self, $options ) = @_;
     return 1 unless defined $options;


### PR DESCRIPTION
This is a simple patch to `Dancer2::Core::Route` I'd like to have considered. It would be useful to me in the development of a plugin for attaching additional information associated with routes. In my case, I'd like to associate routes with a title for a menu item.

This patch proposes adding a new attribute, `xt_data`, for storing a hash reference for containing this kind of "extra data".