### PR TITLE
change module requirement to allow Plack to be installed on Windows

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -22,6 +22,7 @@ install:
   - cpanm Dist::Zilla::PluginBundle::Git
   - cpanm Dist::Zilla::PluginBundle::Dancer
   - cpanm Dist::Zilla::Plugin::Prereqs::FromCPANfile
+  - cpanm --notest Test::Time  # Needed until issue at https://github.com/cho45/Test-Time/issues/10 is resolved
   - cpanm --installdeps .
 
 build_script:

--- a/cpanfile
+++ b/cpanfile
@@ -82,6 +82,10 @@ test_requires 'Test::EOL';
 test_requires 'Test::Fatal';
 test_requires 'Test::More';
 test_requires 'Test::More', '0.92';
+
+# Temporary fix until issue with Test::Time is resolved
+# See https://github.com/cho45/Test-Time/issues/10 for details
+# Author of Test::Time was emailed on 2018-11-11
 test_requires 'Test::Time', '< 0.06';
 
 author_requires 'AnyEvent';

--- a/cpanfile
+++ b/cpanfile
@@ -82,6 +82,7 @@ test_requires 'Test::EOL';
 test_requires 'Test::Fatal';
 test_requires 'Test::More';
 test_requires 'Test::More', '0.92';
+test_requires 'Test::Time', '< 0.06';
 
 author_requires 'AnyEvent';
 author_requires 'CBOR::XS';


### PR DESCRIPTION
Attempt at a fix for https://github.com/PerlDancer/Dancer2/issues/1483. After applying this patch locally, I was able to get Dancer2 installed on my Windows machine. (Note that there was a failing cookie test, however. I just commented that out but that commented out code is not in this patch).