### PR TITLE
Appveyor - install dzil deps from authordeps

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -18,10 +18,7 @@ install:
   - set PATH=C:\strawberry\perl\bin;C:\strawberry\perl\site\bin;C:\strawberry\c\bin;%PATH%
   - cd C:\projects\%APPVEYOR_PROJECT_NAME%
   - cpanm -v Dist::Zilla
-  - cpanm -v Dist::Zilla::PluginBundle::Starter
-  - cpanm -v Dist::Zilla::PluginBundle::Git
-  - cpanm -v Dist::Zilla::PluginBundle::Dancer
-  - cpanm -v Dist::Zilla::Plugin::Prereqs::FromCPANfile
+  - dzil authordeps --missing | cpanm -v
   - cpanm --installdeps .
 
 build_script:


### PR DESCRIPTION
Instead of a static list of dzil plugins, install whatever authordeps indicates is needed. This should fix builds after PR #1480 added [DynamicPrereqs].