### PR TITLE
Fix body not being send on forward

### DIFF
--- a/lib/Dancer2/Core/Request.pm
+++ b/lib/Dancer2/Core/Request.pm
@@ -566,11 +566,6 @@ sub _shallow_clone {
     # in $self, then merge any overridden values
     my $env = { %{ $self->env }, %{ $options || {} } };
 
-    # request body fh has been read till end
-    # delete CONTENT_LENGTH in new request (no need to parse body again)
-    # and merge existing params
-    delete $env->{CONTENT_LENGTH};
-
     my $new_request = __PACKAGE__->new(
         env         => $env,
         body_params => {},
@@ -591,7 +586,6 @@ sub _shallow_clone {
     $new_request->{_params}       = $new_params;
     $new_request->{_body_params}  = $self->{_body_params};
     $new_request->{_route_params} = $self->{_route_params};
-    $new_request->{body}          = $self->body;
     $new_request->{headers}       = $self->headers;
 
     # Copy remaining settings


### PR DESCRIPTION
According to my use cases forward does not forward the body which seems to happen because `_shallow_clone` assumes that the body is fully read and cached. This assumption appears to be wrong though.  Thus `delete $env->{CONTENT_LENGTH};` prevents the body from being accessible at all in the forwarded route.

Furthermore later in `_shallow_clone` the new requests hash gets `body ` set to the old body. To my knowledge this hash key is never accessed anywhere. Neither in Plack nor in Dancer2. I removed it in order to reduce dead and potentially misleading code.

I am using Starman as web server and a pretty trivial test case.
Note that it does not matter whether the body is used within the old route or not; neither does explicitly setting the method to post.
```Perl
prefix '/old_prefix';
post '/route/:variable' => sub {
    my $variable        = route_parameters->get('variable');
    forward "/$NEW_PREFIX/route/$variable";
};
```