### PR TITLE
Remove references to strict_config, Dancer2::Config::Object

### DIFF
--- a/lib/Dancer2/Config.pod
+++ b/lib/Dancer2/Config.pod
@@ -360,11 +360,6 @@ Default: B<layouts>.
 
 =head2 Logging, debugging and error handling
 
-=head3 strict_config (boolean, default: false)
-
-If true, C<config> will return an object instead of a hash reference. See
-L<Dancer2::Config::Object> for more information.
-
 =head3 startup_info (boolean)
 
 If set to true, prints a banner at the server start with information such as


### PR DESCRIPTION
This is meant to fix PerlDancer/Dancer2#1492. Note that that issue
only mentions `Dancer2::Config::Object` being a non-existent module,
but since the `strict_config` property does not seem to exist at all
either, I just dropped the whole documentation subsection.