### PR TITLE
Proposed fix for FAIL report where cookie value is missing.

### DIFF
--- a/lib/Dancer2/Core/Request.pm
+++ b/lib/Dancer2/Core/Request.pm
@@ -549,11 +549,14 @@ sub _build_cookies {
 
     # convert to objects
     while (my ($name, $value) = each %{$cookies}) {
+        my $cookie_value;
+        if (defined $value) {
+            # HTTP::XSCookies v0.17+ will do the split and return an arrayref
+            $cookie_value = (is_arrayref($value) ? $value : [split(/[&;]/, $value)]);
+        }
         $cookies->{$name} = Dancer2::Core::Cookie->new(
             name  => $name,
-            # HTTP::XSCookies v0.17+ will do the split and return an arrayref
-            value => (is_arrayref($value) ? $value : [split(/[&;]/, $value)])
-        );
+            value => $cookie_value);
     }
     return $cookies;
 }


### PR DESCRIPTION
Hi Team Dancer2,

Please review the PR.

https://www.cpantesters.org/cpan/report/d3d83d54-e862-11e8-b9e4-d3d34df7d3e2

       Use of uninitialized value $value in split at /home/cpansand/.cpan/build/2018111422/Dancer2- 
       0.207000-1/blib/lib/Dancer2/Core/Request.pm line 552.
       Modification of non-creatable hash value attempted, subscript "no.value.cookie" at 
       /home/cpansand/.cpan/build/2018111422/Dancer2-0.207000-1/blib/lib/Dancer2/Core/Request.pm 
       line 552.
       # Tests were run but no plan was declared and done_testing() was not seen.
       # Looks like your test exited with 255 just after 26.
       t/request.t ............................................ 

Many Thanks.
Best Regards,
Mohammad S Anwar