### PR TITLE
load Encode so we can use Loggers standalone without bang

### DIFF
--- a/lib/Dancer2/Core/Role/Logger.pm
+++ b/lib/Dancer2/Core/Role/Logger.pm
@@ -5,6 +5,7 @@ use Dancer2::Core::Types;
 
 use Moo::Role;
 use POSIX 'strftime';
+use Encode ();
 use Data::Dumper;
 
 with 'Dancer2::Core::Role::Engine';


### PR DESCRIPTION
When working on my Dancer2::Logger::Console::Colored module I spotted that Encode is missing in the Logger role. Talked to Pete on IRC too.