### PR TITLE
don't decode already decoded date strings

### DIFF
--- a/lib/Dancer2/Core/Role/Logger.pm
+++ b/lib/Dancer2/Core/Role/Logger.pm
@@ -81,10 +81,7 @@ sub format_message {
     my $block_handler = sub {
         my ( $block, $type ) = @_;
         if ( $type eq 't' ) {
-            return Encode::decode(
-                $config->{'charset'} || 'UTF-8',
-                POSIX::strftime( $block, localtime(time) )
-            );
+            return POSIX::strftime( $block, localtime(time) );
         }
         elsif ( $type eq 'h' ) {
             return ( $request && $request->header($block) ) || '-';
@@ -97,19 +94,9 @@ sub format_message {
 
     my $chars_mapping = {
         a => sub { $self->app_name },
-        t => sub {
-            Encode::decode(
-                $config->{'charset'} || 'UTF-8',
-                POSIX::strftime( "%d/%b/%Y %H:%M:%S", localtime(time) )
-            );
-        },
+        t => sub { POSIX::strftime( "%d/%b/%Y %H:%M:%S", localtime(time) ) },
         T => sub { POSIX::strftime( "%Y-%m-%d %H:%M:%S", localtime(time) ) },
-        u => sub {
-            Encode::decode(
-                $config->{'charset'} || 'UTF-8',
-                POSIX::strftime( "%d/%b/%Y %H:%M:%S", gmtime(time) )
-            );
-        },
+        u => sub { POSIX::strftime( "%d/%b/%Y %H:%M:%S", gmtime(time) ) },
         U => sub { POSIX::strftime( "%Y-%m-%d %H:%M:%S", gmtime(time) ) },
         P => sub {$$},
         L => sub {$level},


### PR DESCRIPTION
Consider the following program.

```
$ LC_ALL=ko_KR.UTF-8 perl -e '
package App;
use Dancer2;
set logger => "Console";
config->{logger}->log_format("%t: %l");
get "/" => sub { debug "foo" };
dance;
'
>> Dancer2 v0.207000 server 32023 listening on http://0.0.0.0:3000
```

Now do a request.

```
$ curl localhost:3000/
Internal Server Error

Wide character at /home/simbabque/perl5/perlbrew/perls/perl-5.26.1/lib/site_perl/5.26.1/Dancer2/Core/Role/Logger.pm line 102.
```

There is no error message in the console output of the web app.

This blows up in certain locales, such as `ru_RU.UTF-8` or `ko_KR.UTF-8` or `he_IL.UTF-8`. I think it's mostly UTF-8 based non Latin character locales, but I am not sure.

I've talked about it on IRC with @SysPete , and I've discussed it at https://stackoverflow.com/q/55240390/1331451, where we concluded that the problem is that it's decoding things that are already decoded, and therefore dies. As Encode does not show the error message by default, this just silently fails.

Here's a test that you can use to verify my change does not break on any other locale. I've also run the entire test suite against the locales I've mentioned above.

```perl
#t/logger_console_encoding.t 
use strict;
use warnings;
use Test::More;
use Test::Exception;
use Capture::Tiny 'capture_stderr';
use Dancer2::Logger::Console;
use POSIX 'locale_h';

my $file = __FILE__;
my %logger = (
    t => Dancer2::Logger::Console->new(
        app_name   => 'test',
        log_level  => 'core',
        log_format => '%t',
    ),
    T => Dancer2::Logger::Console->new(
        app_name   => 'test',
        log_level  => 'core',
        log_format => '%T',
    ),
    u => Dancer2::Logger::Console->new(
        app_name   => 'test',
        log_level  => 'core',
        log_format => '%u',
    ),
    U => Dancer2::Logger::Console->new(
        app_name   => 'test',
        log_level  => 'core',
        log_format => '%U',
    ),
);

my @locales = `locale -a`;
chomp @locales;

for my $locale (@locales) {
#for my $locale (qw/ko_KR.UTF8 de_DE.UTF8 zh_CN.GB18030 sv_FI ru_RU.KOI8-R/) {
    setlocale(LC_ALL, $locale);
    for my $format (qw{t T u U}) {
        for my $level (qw{core debug info warning error}) {
            lives_ok { 
                capture_stderr { 
                    $logger{$format}->$level("$level") 
                } 
            } "$level with '$format' in '$locale' lives";
        }
    }
}

done_testing;
```

It will pull all your locales in. You might need to generate a few other locales too. I've run it against the following list.

```
locale -a
C
C.UTF-8
de_DE.utf8
en_AG
en_AG.utf8
en_AU.utf8
en_BW.utf8
en_CA.utf8
en_DK.utf8
en_GB.utf8
en_HK.utf8
en_IE.utf8
en_IN
en_IN.utf8
en_NG
en_NG.utf8
en_NZ.utf8
en_PH.utf8
en_SG.utf8
en_US.utf8
en_ZA.utf8
en_ZM
en_ZM.utf8
en_ZW.utf8
he_IL.utf8
hy_AM
hy_AM.utf8
ka_GE
ka_GE.georgianps
ko_KR.utf8
pl_PL.utf8
POSIX
ru_RU.koi8r
ru_RU.utf8
russian
sv_FI
sv_FI.iso88591
uk_UA
uk_UA.koi8u
zh_CN.gb18030
```

You can install additional ones with this command.

```
$ locale-gen <locale>
```

A list of all supported locales for your system can be found in `/usr/share/i18n/SUPPORTED`.

I am not completely confident about this fix, as I don't know enough about either locales or encoding, but it appears to work, so I guess it's a good start. 

Since this `%t` log format seems not to be very popular this might not have been spotted before.