### PR TITLE
Dancer2::Compat: Add compatibility wrapper module

### DIFF
--- a/lib/Dancer2/Compat.pm
+++ b/lib/Dancer2/Compat.pm
@@ -1,0 +1,112 @@
+package Dancer2::Compat;
+# ABSTRACT: Compatibilty wrappers for newer module functions
+
+use strict;
+use warnings;
+
+our @ISA = qw(Exporter);
+our @EXPORT_OK = qw(
+    encode_base64url
+    pairgrep
+    pairmap
+);
+
+sub import {
+    my $self = shift;
+
+    # This function is basically a dispatch table that executes
+    # an anonymous sub for each matching import requested. Within
+    # each sub an attempt is made to require and import the
+    # wrapped function - and if the import fails (because the
+    # function doens't exist), a wrapper version will be shimmed
+    # into the symbol table and exported as normal. The only change
+    # required on the caller's end is to use this module rather than
+    # the original module being wrapped.
+
+    {
+        # MIME::Base64::encode_base64url (3.11+)
+        encode_base64url => sub {
+            require MIME::Base64;
+            eval  { MIME::Base64->import('encode_base64url') };
+            return unless ($@);
+
+            *encode_base64url = sub {
+                my $e = MIME::Base64::encode_base64(shift, "");
+                   $e =~ s/=+\z//;
+                   $e =~ tr[+/][-_];
+                return $e;
+            };
+        },
+
+        # List::Util::pairmap (1.29+)
+        pairmap => sub {
+            require List::Util;
+            eval  { List::Util->import('pairmap') };
+            return unless ($@);
+
+            *pairmap = sub(&@) {
+                my $code = shift;
+                my $caller = caller;
+
+                # Localize $a and $b
+                no strict 'refs';
+                local *{"${caller}::a"} = \my $a;
+                local *{"${caller}::b"} = \my $b;
+
+                # Generate array of pairs
+                my @pairs;
+                while (my @tmp = splice(@_, 0, 2)) { push @pairs, \@tmp }
+
+                return map { ($a, $b) = @$_; &$code } @pairs;
+            };
+        },
+
+        # List::Util::pairgrep (1.29+)
+        pairgrep => sub {
+            require List::Util;
+            eval  { List::Util->import('pairgrep') };
+            return unless ($@);
+
+            *pairgrep = sub(&@) {
+                my $code = shift;
+                my $caller = caller;
+
+                # Localize $a and $b
+                no strict 'refs';
+                local *{"${caller}::a"} = \my $a;
+                local *{"${caller}::b"} = \my $b;
+
+                # Generate array of pairs
+                my @pairs;
+                while (my @tmp = splice(@_, 0, 2)) { push @pairs, \@tmp }
+
+                # In scalar context return the count of matching *pairs*
+                my @res = grep { ($a, $b) = @$_; &$code } @pairs;
+                return wantarray ? map @$_, @res : scalar @res;
+            };
+        },
+
+    }->{$_}() foreach (@_);
+
+    # Use Exporter's export_to_level method since this is a custom import
+    # method and hence Exporter's inherited import method cannot be used.
+    __PACKAGE__->export_to_level(1, $self, @_);
+}
+
+1;
+
+__END__
+
+=func encode_base64url
+
+Compatibility wrapper for MIME::Base64::encode_base64url
+
+=func pairmap
+
+Compatibility wrapper for List::Util::pairmap
+
+=func pairgrep
+
+Compatibility wrapper for List::Util::pairgrep
+
+=cut

--- a/lib/Dancer2/Core/HTTP.pm
+++ b/lib/Dancer2/Core/HTTP.pm
@@ -5,7 +5,7 @@ package Dancer2::Core::HTTP;
 use strict;
 use warnings;
 
-use List::Util qw/ pairmap pairgrep /;
+use Dancer2::Compat qw/pairmap pairgrep/;
 
 my $HTTP_CODES = {
 

--- a/lib/Dancer2/Core/Role/SessionFactory.pm
+++ b/lib/Dancer2/Core/Role/SessionFactory.pm
@@ -7,9 +7,9 @@ with 'Dancer2::Core::Role::Engine';
 use Carp 'croak';
 use Dancer2::Core::Session;
 use Dancer2::Core::Types;
+use Dancer2::Compat 'encode_base64url';
 use Digest::SHA 'sha1';
 use List::Util 'shuffle';
-use MIME::Base64 'encode_base64url';
 use Module::Runtime 'require_module';
 use Ref::Util qw< is_ref is_arrayref is_hashref >;
 

--- a/t/compat.t
+++ b/t/compat.t
@@ -1,0 +1,34 @@
+use strict;
+use warnings;
+use utf8;
+
+use Test::More tests => 5;
+
+no warnings 'redefine','once';
+
+BEGIN {
+    # Force use of wrapper versions by explicitly breaking import methods
+    require MIME::Base64;
+    require List::Util;
+
+    local *MIME::Base64::import = sub { die };
+    local *List::Util::import = sub { die };
+
+    require Dancer2::Compat;
+    Dancer2::Compat->import(qw/encode_base64url pairgrep pairmap/);
+}
+
+my $encoded = encode_base64url('https://foo.bar.com?p=1&q=2');
+is($encoded, 'aHR0cHM6Ly9mb28uYmFyLmNvbT9wPTEmcT0y', 'encode_base64url wrapper');
+
+my $pairmap = [ pairmap { $a + $b } (1,2,3,4) ];
+is_deeply($pairmap, [ 3, 7 ], 'pairmap wrapper');
+
+my $pairmap_s = scalar pairmap { $a + $b } (1,2,3,4);
+is($pairmap_s, 2, 'pairmap wrapper (scalar)');
+
+my $pairgrep = [ pairgrep { $a & 0x1 } (1,2,4,3,2,2,3,3) ];
+is_deeply($pairgrep, [ 1, 2, 3, 3 ], 'pairgrep wrapper');
+
+my $pairgrep_s = scalar pairgrep { $a & 0x1 } (1,2,4,3,2,2,3,3);
+is($pairgrep_s, 2, 'pairgrep wrapper (scalar)');


### PR DESCRIPTION
* MIME::Base64::encode_base64url: This is only available in v3.11+
  of MIME::Base64 and as far as I can tell Perl 5.14+ (where it is
  a core module).

* List::Util::pairmap/pairgrep: Both of these are only available
  in 1.29+ and as a core module didn't show up until Perl 5.20+.

* The general approach is to use a separate module (this one) with
  it's own import routine which will attempt to use the original
  functions if available, and if not, export a wrapper version
  providing the equivalent functionality.

Background:

  This is an attempt to defend against a few module functions used
  by Dancer2 that are only available if running more recent versions
  of Perl and/or List::Util. In our case, we have *many* RHEL6 hosts
  which are still locked to Perl 5.10.x as the major version and in
  the case of some modules (notably both involved in this change) are
  packaged with perl itself - making it slightly more difficult to
  simply build and deploy newer packages for them. Up until now
  we've been making locally patched builds to work around the
  issues but in the spirit of opensource and wider compatibility
  for everyone, I figured a formal patch would be better.