### PR TITLE
set :raw layer when copying files to a new skeleton project

### DIFF
--- a/lib/Dancer2/CLI/Command/gen.pm
+++ b/lib/Dancer2/CLI/Command/gen.pm
@@ -182,7 +182,7 @@ sub _copy_templates {
 
         {
             local $/;
-            open(my $fh, '<', $from) or die "unable to open file `$from' for reading: $!";
+            open(my $fh, '<:raw', $from) or die "unable to open file `$from' for reading: $!";
             $content = <$fh>;
             close $fh;
         }
@@ -191,7 +191,7 @@ sub _copy_templates {
             $content = _process_template($content, $vars);
         }
 
-        open(my $fh, '>', $to) or die "unable to open file `$to' for writing: $!";
+        open(my $fh, '>:raw', $to) or die "unable to open file `$to' for writing: $!";
         print $fh $content;
         close $fh;
 


### PR DESCRIPTION
This prevents corruption of binary files (such as images) under Windows.

The screenshot below illustrates how the lack of `:raw` layer was corrupting the images:
![screenshot](https://i.imgur.com/ExPbzW8.png)