### PR TITLE
Implement prepare_app keyword

### DIFF
--- a/lib/Dancer2/Core/App.pm
+++ b/lib/Dancer2/Core/App.pm
@@ -609,18 +609,6 @@ has routes => (
     },
 );
 
-has 'calling_class' => (
-    'is'      => 'ro',
-    'isa'     => Str,
-    'default' => sub {
-        my $class = ( caller(2) )[0] ||
-                    ( caller(1) )[0] ||
-                    ( caller(0) )[0];
-
-        return $class;
-    },
-);
-
 # add_hook will add the hook to the first "hook candidate" it finds that support
 # it. If none, then it will try to add the hook to the current application.
 around add_hook => sub {

--- a/lib/Dancer2/Core/App.pm
+++ b/lib/Dancer2/Core/App.pm
@@ -482,6 +482,12 @@ has destroyed_session => (
     clearer   => 'clear_destroyed_session',
 );
 
+has 'prep_apps' => (
+    'is'      => 'ro',
+    'isa'     => ArrayRef,
+    'default' => sub { [] },
+);
+
 sub find_plugin {
     my ( $self, $name ) = @_;
     my $plugin = List::Util::first { ref($_) eq $name } @{ $self->plugins };
@@ -1134,10 +1140,9 @@ sub finish {
             $self->postponed_hooks
         );
 
-    $self->calling_class->can('prepare_app')
-      and warn "WARNING: You have a subroutine in your "
-      . "app called 'prepare_app'. In the future "
-      . "this will automatically be called by Dancer2.";
+    foreach my $prep_cb ( @{ $self->prep_apps } ) {
+        $prep_cb->($self);
+    }
 }
 
 sub init_route_handlers {

--- a/lib/Dancer2/Core/DSL.pm
+++ b/lib/Dancer2/Core/DSL.pm
@@ -90,6 +90,9 @@ sub dsl_keywords {
         path                 => { is_global => 1 },
         post                 => { is_global => 1 },
         prefix               => { is_global => 1 },
+        prepare_app          => {
+            is_global => 1, prototype => '&',
+        },
         psgi_app             => { is_global => 1 },
         push_header          => { is_global => 0 },
         push_response_header => { is_global => 0 },
@@ -214,6 +217,8 @@ sub options { shift->_normalize_route( [qw/options /], @_ ) }
 sub patch   { shift->_normalize_route( [qw/patch   /], @_ ) }
 sub post    { shift->_normalize_route( [qw/post    /], @_ ) }
 sub put     { shift->_normalize_route( [qw/put     /], @_ ) }
+
+sub prepare_app { push @{ shift->app->prep_apps }, @_ }
 
 sub any {
     my $self = shift;

--- a/lib/Dancer2/Manual.pod
+++ b/lib/Dancer2/Manual.pod
@@ -2528,6 +2528,26 @@ name.
         # will result in two headers "x-my-header" in the response
     }
 
+=head2 prepare_app
+
+You can introduce code you want to run when your app is loaded, similar to the
+C<prepare_app> in L<Plack::Middleware>.
+
+    prepare_app {
+        my $app = shift;
+
+        ... # do your thing
+    };
+
+You should not close over the App instance, since you receive it as a first
+argument. If you close over it, you B<will> have a memory leak.
+
+    my $app = app();
+
+    prepare_app {
+        do_something_with_app($app); # MEMORY LEAK
+    };
+
 =head2 hook
 
 Adds a hook at some position. For example :

--- a/t/prepare_app.t
+++ b/t/prepare_app.t
@@ -3,55 +3,59 @@ use warnings;
 use Plack::Test;
 use HTTP::Request::Common;
 use Test::More 'tests' => 2;
-use Capture::Tiny qw< capture_stderr capture_merged >;
 
 {
-    package App;
+    package Foo;
     use Dancer2;
-    sub prepare_app {1}
+
+    prepare_app {
+        set 'app_1' => 'called 1';
+    };
+
     get '/' => sub {'OK'};
 }
 
 {
     package Bar;
-    use Dancer2 'appname' => 'App';
-    sub prepare_app {2}
+    use Dancer2 'appname' => 'Foo';
+
+    prepare_app {
+        set 'app_2' => 'called 2';
+    };
+
     get '/' => sub {'OK'};
 }
 
-my $msg = qr{
-    ^ WARNING: \s You \s have \s a \s subroutine \s in \s your
-    \s app \s called \s 'prepare_app' \.
-    \s In \s the \s future \s this \s will \s automatically
-    \s be \s called \s by \s Dancer2 \.
-}xms;
-
-subtest 'App' => sub {
-    my $app;
-    like(
-        capture_stderr { $app = App->to_app; },
-        $msg,
-        'Got warning on prepare_app sub',
+subtest 'Foo' => sub {
+    my $app = Foo->to_app;
+    is(
+        Foo->config()->{'app_1'},
+        'called 1',
+        'App 1 had prepare_app called',
     );
 
     my $test = Plack::Test->create($app);
-    my $res;
-    my $out;
-    capture_merged { $res = $test->request( GET '/' )->content },
+    my $res  = $test->request( GET '/' )->content();
     is(
         $res,
         'OK',
         'Correct content',
     );
-
-    is( $out, undef, 'No extra warnings or output' );
 };
 
 subtest 'Bar' => sub {
-    my $app;
-    like(
-        capture_stderr { $app = Bar->to_app; },
-        $msg,
-        'Got warning on prepare_app sub',
+    my $app = Bar->to_app;
+    is(
+        Bar->config()->{'app_2'},
+        'called 2',
+        'App 2 had prepare_app called',
+    );
+
+    my $test = Plack::Test->create($app);
+    my $res  = $test->request( GET '/' )->content();
+    is(
+        $res,
+        'OK',
+        'Correct content',
     );
 };


### PR DESCRIPTION
The new `prepare_app` keyword allows the user to have a setup method for their code.

If you have an app based on another app, both `prepare_app`s will be run, which I think would be correct behavior.

GH #1320 