### PR TITLE
Request instantiation fails throw 400 Bad Response

### DIFF
--- a/lib/Dancer2/Core/App.pm
+++ b/lib/Dancer2/Core/App.pm
@@ -1441,15 +1441,12 @@ sub dispatch {
     # Catch bad content causing deserialization to fail when building the request
     if ( ! $request_built_successfully ) {
         my $err = $@;
-        if ($self->has_serializer_engine && $err =~ m!^Failed to deserialize content! ) {
-            Scalar::Util::weaken(my $app = $self);
-            return Dancer2::Core::Error->new(
-                app     => $app,
-                message => $err,
-            )->throw;
-        }
-        # Rethrow error
-        die $err;
+        Scalar::Util::weaken(my $app = $self);
+        return Dancer2::Core::Error->new(
+            app     => $app,
+            message => $err,
+            status  => 400,    # 400 Bad request (dont send again), rather than 500
+        )->throw;
     }
 
     my $cname = $self->session_engine->cookie_name;

--- a/lib/Dancer2/Core/Error.pm
+++ b/lib/Dancer2/Core/Error.pm
@@ -140,14 +140,15 @@ END_TEMPLATE
     return $output;
 }
 
+# status and message are 'rw' to permit modification in core.error.before hooks
 has status => (
-    is      => 'ro',
+    is      => 'rw',
     default => sub {500},
     isa     => Num,
 );
 
 has message => (
-    is      => 'ro',
+    is      => 'rw',
     isa     => Str,
     lazy    => 1,
     default => sub { '' },

--- a/t/issues/gh-794.t
+++ b/t/issues/gh-794.t
@@ -22,6 +22,6 @@ is(
 
 is(
     $test->request( POST '/', Content => 'invalid' )->code,
-    500,
+    400,
     'Failed to decode invalid content',
 );


### PR DESCRIPTION
This started out as a patch for 1056; permitting deserialisation fails to use before hooks to alter the error thrown.

Since then, issues like #1496 and #1507 highlight that we want something more general in this regard. This PR changes behaviour, as what was previously a 500 Internal Server error when request object creation failed is now a 400 Bad Response error in line with the above issues.

Putting this out here for feedback and seeing if this is how we'd like to solve this.