### PR TITLE
execute_hook: Improve logging

### DIFF
--- a/lib/Dancer2/Core/Role/Hookable.pm
+++ b/lib/Dancer2/Core/Role/Hookable.pm
@@ -108,11 +108,14 @@ sub execute_hook {
     croak "Hook '$name' does not exist"
       if !$self->has_hook($name);
 
-    $self->$_isa('Dancer2::Core::App') &&
-      $self->log( core => "Entering hook $name" );
-
     for my $hook ( @{ $self->hooks->{$name} } ) {
+        $self->$_isa('Dancer2::Core::App') &&
+          $self->log( core => "Entering hook $name [$hook]" );
+
         $hook->(@_);
+
+        $self->$_isa('Dancer2::Core::App') &&
+          $self->log( core => "Exited hook $name [$hook]" );
     }
 }
 


### PR DESCRIPTION
* Provide *per*-hook entry and exit logging around each hook called.
  This came out of a debugging experience where client code was
  adding the same hook twice at different stages of execution but it
  wasn't immediately apparent from debugging output to even look in
  that direction.

Example output:
```
core @2019-07-25 17:04:06> Entering hook core.app.before_request [CODE(0x55f96d8dbac0)] in (eval 221) l. 1
core @2019-07-25 17:04:06> Exited hook core.app.before_request [CODE(0x55f96d8dbac0)] in (eval 221) l. 1
```