### PR TITLE
Add Types::Standard to cpanfile. 

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -40,6 +40,7 @@ requires 'Template';
 requires 'Template::Tiny';
 requires 'Test::Builder';
 requires 'Test::More';
+requires 'Types::Standard';
 requires 'Type::Tiny', '1.000006';
 requires 'URI::Escape';
 


### PR DESCRIPTION
Add Types::Standard to cpanfile, which is a dependency for Dancer2::Core::Types.

Closes #1515