### PR TITLE
Add test and update doc for pluggable route handlers

### DIFF
--- a/lib/Dancer2/Manual.pod
+++ b/lib/Dancer2/Manual.pod
@@ -750,10 +750,19 @@ there is loaded. Thus, any random handler can be added to your app.
 For example, the default config file for any Dancer2 application is as follows:
 
     route_handlers:
-      File:
-        public_dir: /path/to/public
-      AutoPage: 1
+      -
+        - AutoPage
+        - 1
+      -
+        - File
+        - public_dir: /path/to/public
 
+The second item in the sequence for each handler can be either just "1" (or any
+string) if your handler has no configration options, or a hash of option key-
+value pairs if it does.
+
+(Note that currently adding a route handler does not work if you start your 
+app with C<< ->to_app >>, but only when starting with C<dance>.)
 
 =head1 ERRORS
 

--- a/t/pluggable_route_handlers.t
+++ b/t/pluggable_route_handlers.t
@@ -1,0 +1,50 @@
+use strict;
+use warnings;
+use Test::More tests => 2;
+use Plack::Test;
+use HTTP::Request::Common;
+
+package Dancer2::Handler::TestHandler {
+    use Moo::Role;
+    with 'Dancer2::Core::Role::Handler';
+
+    sub regexp {'/**?'}
+    sub methods {'get'}
+
+    sub register {
+        my ( $self, $app ) = @_;
+        return unless $app->config->{test_handler};
+
+        $app->add_route(
+            method => $_,
+            regexp => $self->regexp,
+            code   => $self->code,
+        ) for $self->methods;
+    }
+
+    sub code { sub {'I was handled'} }
+};
+
+
+package TestApp {
+    use Dancer2;
+    use Dancer2::Handler::TestHandler;
+
+    set config => {
+        route_handlers => [[ TestHandler => 1 ]],
+        test_handler => 1,
+    };
+};
+
+my $app = TestApp->to_app;
+
+test_psgi $app, sub {
+    my $cb = shift;
+    my $res  = $cb->( GET '/foo' );
+
+    TODO: {
+        local $TODO = "Route handlers not loaded correctly under to_app";
+        ok( $res->is_success,                 'request to /foo was successful' );
+        is( $res->content, 'I was handled',   'page content is as expected' );
+    };
+};


### PR DESCRIPTION
Corrects bad doc on how to configure a pluggable route handler. Adds a test for a pluggable route handler, but wraps the tests in `TODO` since pluggable route handlers currently don't get registered when you run the app with `to_app` (if you start with `dance` in a script, they are registered and work OK).

Issue: (https://github.com/PerlDancer/Dancer2/issues/1518)