### PR TITLE
remove use of Return::MultiLevel, and implement stack frame jumping manually

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -32,7 +32,6 @@ requires 'Plack::Middleware::FixMissingBodyInRedirect';
 requires 'Plack::Middleware::RemoveRedundantBody';
 requires 'POSIX';
 requires 'Ref::Util';
-requires 'Return::MultiLevel';
 requires 'Role::Tiny', '2.000000';
 requires 'Safe::Isa';
 requires 'Sub::Quote';

--- a/lib/Dancer2/Core/Dispatcher.pm
+++ b/lib/Dancer2/Core/Dispatcher.pm
@@ -100,10 +100,9 @@ object and an env as input arguments.
 
 C<dispatch> returns a response object of L<Dancer2::Core::Response>.
 
-Any before hook and matched route code is wrapped using L<Return::MultiLevel>
-to allow DSL keywords such as forward and redirect to short-circuit remaining code
-without having to throw an exception. L<Return::MultiLevel> will use L<Scope::Upper>
-(an XS module) if it is available.
+Any before hook and matched route code is wrapped to allow DSL keywords such
+as forward and redirect to short-circuit remaining code, returning across
+multiple stack frames without having to throw an exception.
 
 =head2 response_internal_error
 


### PR DESCRIPTION
Return::MultiLevel obscures the fact that returning across multiple
stack frames is very evil.  Rather than hide the evil we are doing, just
embed the stack breaking via a label and last.

This avoids a Return::MultiLevel dependency, which avoids pulling in
Scope::Upper, another module with too much magic in it.  It also is
slightly faster, although that is a very minor benefit.