### PR TITLE
docs: Mention that TT2 config start_tag/end_tag need escaping

### DIFF
--- a/lib/Dancer2.pm
+++ b/lib/Dancer2.pm
@@ -262,6 +262,7 @@ We are also on IRC: #dancer on irc.perl.org.
     chenchen000
     Chi Trinh
     Christian Walde
+    Christopher White
     Colin Kuskie
     cym0n
     Dale Gallagher

--- a/lib/Dancer2/Template/TemplateToolkit.pm
+++ b/lib/Dancer2/Template/TemplateToolkit.pm
@@ -105,13 +105,17 @@ setting it manually with C<set>:
 
 Most configuration variables available when creating a new instance of a
 L<Template>::Toolkit object can be declared inside the template toolkit
-section on the engines configuration (see your config.yml file):
+section on the engines configuration in your config.yml file.  For example:
 
   engines:
     template:
       template_toolkit:
         start_tag: '<%'
         end_tag:   '%>'
+
+(Note: C<start_tag> and C<end_tag> are regexes.  If you want to use PHP-style
+tags, you will need to list them as C<< <\? >> and C<< \?> >>.)
+See L<Template::Manual::Config> for the configuration variables.
 
 In addition to the standard configuration variables, the option C<show_private_variables>
 is also available. Template::Toolkit, by default, do not render private variables


### PR DESCRIPTION
Sawyer, Jason, it was a pleasure to meet you earlier this year at TPCiP!  I am trying out Dancer2 and tripped over a minor documentation point.  This is my first PR, and attempts to help others avoid what confused me.

Context: I am trying to use TT2 with PHP-style tags (`<? ?>`).

Dancer2::Template::TemplateToolkit does not mention that the TT2 `start_tag` and `end_tag` are regexes, so need backslash escapes. This commit adds that mention, and also a direct link to Template::Manual::Config.

Noted (and tested) with Dancer2 v0.208001, Cygwin x64, running under plackup.

Thank you for considering this PR!