### PR TITLE
update travis dist to 'trusty'

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+dist: trusty
 language: perl
 
 perl:


### PR DESCRIPTION
travis moved to using 'xenial' dist by default a few months ago
and for 'xenial' there are no support of perl less than 5.22
  https://docs.travis-ci.com/user/reference/xenial#perl-support
for 'trusty' using perlbrew with any version of perl is still ok
  https://docs.travis-ci.com/user/reference/trusty#perl-images