### PR TITLE
skel/config.yml: Note that "engines:" must be merged

### DIFF
--- a/share/skel/config.yml
+++ b/share/skel/config.yml
@@ -2,6 +2,8 @@
 # env-related settings should go to environments/$env.yml
 # all the settings in this file will be loaded at Dancer's startup.
 
+# === Basic configuration ===
+
 # Your application's name
 appname: "[d2% appname %2d]"
 
@@ -14,6 +16,13 @@ layout: "main"
 # about unicode within your app when this setting is set (recommended).
 charset: "UTF-8"
 
+# === Engines ===
+#
+# NOTE: All the engine configurations need to be under a single "engines:"
+# key.  If you uncomment engine configurations below, make sure to delete
+# all "engines:" lines except the first.  Otherwise, only the last
+# "engines:" block will take effect.
+
 # template engine
 # simple: default and very basic template engine
 # template_toolkit: TT
@@ -24,6 +33,7 @@ template: "simple"
 # engines:
 #   template:
 #     template_toolkit:
+#       # Note: start_tag and end_tag are regexes
 #       start_tag: '<%'
 #       end_tag:   '%>'
 


### PR DESCRIPTION
Another thing that tripped me up, and that I would like to save others from.  If config.yml has:

    engines:
      template:
        ...
    engines:
      session:
        ...

(i.e., two `engines:` keys), only the session-engine configuration will be loaded.  The template-engine configuration will be silently discarded when the YAML file is loaded.  This commit updates `share/skel/config.yml` to tell readers that you instead need to use:

    engines:
      template:
        ...
      session:
        ...

This commit also adds a note about TT2 start_tag and end_tag being regexes, per #1526.