### PR TITLE
Fix storing objects in YAML sessions

### DIFF
--- a/lib/Dancer2/Session/YAML.pm
+++ b/lib/Dancer2/Session/YAML.pm
@@ -22,6 +22,7 @@ sub _freeze_to_handle {
 
 sub _thaw_from_handle {
     my ( $self, $fh ) = @_;
+    local $YAML::LoadBlessed = 1;
     return YAML::LoadFile($fh);
 }
 

--- a/t/session_yaml_object.t
+++ b/t/session_yaml_object.t
@@ -1,0 +1,28 @@
+use strict;
+use warnings;
+
+use Dancer2::Session::YAML ();
+use File::Temp ();
+use IO::File ();
+
+use Test::More;
+
+my $tempdir = File::Temp->newdir;
+
+my $engine = Dancer2::Session::YAML->new( session_dir => $tempdir->dirname );
+my $session_id = do {
+    my $session = $engine->create;
+    isa_ok $session, 'Dancer2::Core::Session', 'Create a session';
+    ok $session->write( uvw => 7 ), 'Store a session value';
+    ok $session->write( xyz => $tempdir ), 'Store a session object';
+    ok $engine->flush( session => $session ), 'Flush the session store';
+    $session->id;
+};
+{
+    my $session = $engine->retrieve( id => $session_id );
+    isa_ok $session, 'Dancer2::Core::Session', 'Retrieve the session';
+    is $session->read('uvw'), 7, 'The session has stored the value';
+    isa_ok $session->read('xyz'),'File::Temp::Dir', 'The session has stored the object';
+}
+
+done_testing();


### PR DESCRIPTION
This worked fine, until YAML version 1.30 disabled loading blessed objects by default.  In many circumstances that makes sense.  Untrusted user input should not refer to Perl objects.  However, sessions are always created by the application, so it seems reasonable to trust their contents.  Preventing developers from storing objects in sessions is a regression and removes a useful feature.