### PR TITLE
Documentation fix (Named matching)

### DIFF
--- a/lib/Dancer2.pm
+++ b/lib/Dancer2.pm
@@ -360,6 +360,7 @@ We are also on IRC: #dancer on irc.perl.org.
     Snigdha
     Steve Dondley
     Tatsuhiko Miyagawa
+    Timothy Alexis Vass
     Tina Müller
     Tom Hukins
     Upasana Shukla

--- a/lib/Dancer2/Manual.pod
+++ b/lib/Dancer2/Manual.pod
@@ -229,7 +229,7 @@ match will be set in the route parameters.
 Tokens can be optional, for example:
 
     get '/hello/:name?' => sub {
-        my $name = route_parameters->get('name') //= 'Whoever you are';
+        my $name = route_parameters->get('name') // 'Whoever you are';
         "Hello there, $name";
     };
 

--- a/lib/Dancer2/Manual.pod
+++ b/lib/Dancer2/Manual.pod
@@ -223,14 +223,14 @@ Each token found in a route pattern is used as a named-pattern match. Any
 match will be set in the route parameters.
 
     get '/hello/:name' => sub {
-        "Hey " . route_parameters->get('name') . ", welcome here!";
+        return "Hey " . route_parameters->get('name') . ", welcome here!";
     };
 
 Tokens can be optional, for example:
 
     get '/hello/:name?' => sub {
         my $name = route_parameters->get('name') // 'Whoever you are';
-        "Hello there, $name";
+        return "Hello there, $name";
     };
 
 =head3 Named matching with type constraints


### PR DESCRIPTION
This is issue #1538 

Thank you @TimothyAlexisVass 

defined or assignment in docs should be defined without assignment