### PR TITLE
fix broken test that is skipped under CI

### DIFF
--- a/t/issues/gh-811.t
+++ b/t/issues/gh-811.t
@@ -40,13 +40,13 @@ subtest 'Creating a session' => sub {
     my $res = $test->request( GET "$url/set" );
     ok( $res->is_redirect, 'Request causes redirect' );
     ($redir) = $res->header('Location');
-    is( $redir, "$url/get", 'Redirects to correct url' );
+    is( $redir, "/get", 'Redirects to correct url' );
     $jar->extract_cookies($res);
     ok( $jar->as_string, 'Received a session cookie' );
 };
 
 subtest 'Retrieving a session' => sub {
-    my $req = GET $redir;
+    my $req = GET "$url/get";
     $jar->add_cookie_header($req);
     my $res = $test->request($req);
     ok( $res->is_success, 'Successful request' );


### PR DESCRIPTION
This is issue #1541 

Fix test that was broken by switch to RFC 7231 (#1461).

My original PR pulled in an authordep on Dancer2::Session::Cookie, which of course caused a circular dependency on D2 itself, so that was removed.