### PR TITLE
Feature/session cookie same site

### DIFF
--- a/lib/Dancer2/Config.pod
+++ b/lib/Dancer2/Config.pod
@@ -499,6 +499,7 @@ The session engine is configured in the C<engines> section.
        Simple:
          cookie_name: dance.set
          cookie_duration: '24 hours'
+         cookie_same_site: Lax
          is_secure: 1
          is_http_only: 1
 
@@ -537,6 +538,15 @@ only be sent over HTTPS connections.
 This setting defaults to 1 and instructs the session cookie to be created
 with the C<HttpOnly> option active, meaning that JavaScript will not be able
 to access to its value.
+
+=head2 cookie_same_site
+
+Restricts the session cookie to a first-party or same-site context. Valid
+values are C<Strict>, C<Lax>, or C<None>.
+
+Refer to
+L<RFC6265bis|https://tools.ietf.org/html/draft-ietf-httpbis-cookie-same-site>
+for further details regarding same-site context.
 
 =head2 auto_page (boolean)
 

--- a/lib/Dancer2/Core/Cookie.pm
+++ b/lib/Dancer2/Core/Cookie.pm
@@ -134,7 +134,7 @@ has http_only => (
 
 has same_site => (
     is       => 'rw',
-    isa      => Enum[qw[Strict Lax]],
+    isa      => Enum[qw[Strict Lax None]],
     required => 0,
 );
 

--- a/lib/Dancer2/Core/Role/SessionFactory.pm
+++ b/lib/Dancer2/Core/Role/SessionFactory.pm
@@ -85,6 +85,13 @@ has is_http_only => (
     default => sub {1},
 );
 
+has cookie_same_site => (
+    is        => 'ro',
+    isa       => Str,
+    predicate => 1,
+    coerce    => sub { ucfirst $_[0] },
+);
+
 sub create {
     my ($self) = @_;
 
@@ -254,6 +261,9 @@ sub cookie {
         secure    => $self->is_secure,
         http_only => $self->is_http_only,
     );
+
+    $cookie{same_site} = $self->cookie_same_site
+      if $self->has_cookie_same_site;
 
     $cookie{domain} = $self->cookie_domain
       if $self->has_cookie_domain;

--- a/t/cookie.t
+++ b/t/cookie.t
@@ -75,7 +75,7 @@ sub run_test {
         "\$cookie->http_only is now disabled";
 
     like exception { $cookie->same_site('foo') },
-        qr/Value "foo" did not pass type constraint "Enum\["Strict","Lax"\]/;
+        qr/Value "foo" did not pass type constraint "Enum\["Strict","Lax","None"\]/;
 
     note "expiration strings";
 

--- a/t/session_config.t
+++ b/t/session_config.t
@@ -13,10 +13,11 @@ use HTTP::Request::Common;
         engines => {
             session => {
                 Simple => {
-                    cookie_name     => 'dancer.sid',
-                    cookie_path     => '/foo',
-                    cookie_duration => '1 hour',
-                    is_http_only    => 0, # will not show up in cookie
+                    cookie_name      => 'dancer.sid',
+                    cookie_path      => '/foo',
+                    cookie_duration  => '1 hour',
+                    cookie_same_site => 'Strict',
+                    is_http_only     => 0, # will not show up in cookie
                 },
             },
         }
@@ -70,6 +71,7 @@ subtest 'Set session' => sub {
     is $domain, 'localhost.local', "cookie domain set";
     is $path, '/foo', "cookie path set";
     is $httponly, undef, "cookie has not set HttpOnly";
+    is $opts->{SameSite}, 'Strict', "cookie has same site set to strict";
 
     # read value back
 };

--- a/t/session_config.t
+++ b/t/session_config.t
@@ -59,7 +59,7 @@ subtest 'Set session' => sub {
 
     my ( $expires, $domain, $path, $opts );
     my $cookie = $jar->scan( sub {
-        ( $expires, $domain, $path, $opts ) = @_[ 8, 4, 3 ];
+        ( $expires, $domain, $path, $opts ) = @_[ 8, 4, 3, 10 ];
     } );
 
     my $httponly = $opts->{'HttpOnly'};


### PR DESCRIPTION
Permit D2 session cookies' `SameSite` attribute to be configured ( #1547 ).

* Valid values are "Strict", "Lax", or "None" ('None' is a recent addition to RFC6265bis).
* Docs + tests included.