### PR TITLE
bump dep on Role::Tiny to 2.000008

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -32,7 +32,7 @@ requires 'Plack::Middleware::FixMissingBodyInRedirect';
 requires 'Plack::Middleware::RemoveRedundantBody';
 requires 'POSIX';
 requires 'Ref::Util';
-requires 'Role::Tiny', '2.000000';
+requires 'Role::Tiny', '>=2.000000, !=2.000007';
 requires 'Safe::Isa';
 requires 'Sub::Quote';
 requires 'Template';


### PR DESCRIPTION
Avoids issue with Role::Tiny 2.000007 and Types::Standard undefined warnings

See: https://github.com/PerlDancer/Dancer2/issues/1515#issuecomment-518305067