### PR TITLE
Pr/remove workaround for fixed http xscookies bug

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -55,7 +55,7 @@ recommends 'CGI::Deurl::XS';
 recommends 'Class::XSAccessor';
 recommends 'Cpanel::JSON::XS';
 recommends 'Crypt::URandom';
-recommends 'HTTP::XSCookies', '0.000007';
+recommends 'HTTP::XSCookies', '0.000015';
 recommends 'HTTP::XSHeaders';
 recommends 'Math::Random::ISAAC::XS';
 recommends 'MooX::TypeTiny';

--- a/lib/Dancer2/Core/Cookie.pm
+++ b/lib/Dancer2/Core/Cookie.pm
@@ -41,7 +41,7 @@ sub xs_to_header {
             path     => $self->path,
             domain   => $self->domain,
             expires  => $self->expires,
-            httponly => !!$self->http_only, # HTTP::XSCookies seems to distinguish between '"0"' and '0'
+            httponly => $self->http_only,
             secure   => $self->secure,
             samesite => $self->same_site,
         }


### PR DESCRIPTION
Hey,

in #1428 I worked with @bigpresh on a workaround for a bug in `HTTP::XSCookies`.

The bug has since been fixed in version `0.000015` of `HTTP::XSCookies` by the original author. The issue has been reported in Issue https://github.com/gonzus/http-xscookies/issues/7.

This pull requests increases the minimum version on the recommended dependency to ` 0.000015`  and reverts the hack from #1428. The testcase from #1428 still passes with these changes.