### PR TITLE
Request uri_base method have to return URI object in all cases

### DIFF
--- a/lib/Dancer2/Core/Request.pm
+++ b/lib/Dancer2/Core/Request.pm
@@ -258,13 +258,6 @@ sub to_string {
     return "[#" . $self->id . "] " . $self->method . " " . $self->path;
 }
 
-sub base {
-    my $self = shift;
-    my $uri  = $self->_common_uri;
-
-    return $uri->canonical;
-}
-
 sub _common_uri {
     my $self = shift;
 
@@ -279,19 +272,20 @@ sub _common_uri {
     $uri->authority( $host || "$server:$port" );
     $uri->path( $path      || '/' );
 
-    return $uri;
+    return $uri->canonical;
 }
 
-sub uri_base {
-    my $self  = shift;
-    my $uri   = $self->_common_uri;
-    my $canon = $uri->canonical;
+sub base { return $_[0]->_common_uri; }
 
-    if ( $canon->path eq '/' ) {
-        $canon->path('');
+sub uri_base {
+    my $self = shift;
+    my $uri  = $self->_common_uri;
+
+    if ( $uri->path eq '/' ) {
+        $uri->path('');
     }
 
-    return $canon;
+    return $uri;
 }
 
 sub dispatch_path {

--- a/lib/Dancer2/Core/Request.pm
+++ b/lib/Dancer2/Core/Request.pm
@@ -287,8 +287,8 @@ sub uri_base {
     my $uri   = $self->_common_uri;
     my $canon = $uri->canonical;
 
-    if ( $uri->path eq '/' ) {
-        $canon =~ s{/$}{};
+    if ( $canon->path eq '/' ) {
+        $canon->path('');
     }
 
     return $canon;


### PR DESCRIPTION
 The PR makes consistency better in cases of:
     - with the 'base' method, now both return URI objects
     - in various cases of '/' at end

The issue was that `=~` converts the value into a scalar in case of '/' at the end.