### PR TITLE
Bugfix/1546 static handler mime types

### DIFF
--- a/lib/Dancer2/Core/App.pm
+++ b/lib/Dancer2/Core/App.pm
@@ -1396,7 +1396,7 @@ sub to_app {
         # Use App::File to "serve" the static content
         my $static_app = Plack::App::File->new(
             root         => $self->config->{public_dir},
-            content_type => sub { $self->mime_type->for_name(shift) },
+            content_type => sub { $self->mime_type->for_file( $_[0] ) },
         )->to_app;
         # Conditionally use the static handler wrapped with ConditionalGET
         # when the file exists. Otherwise the request passes into our app.

--- a/t/dsl/mime.t
+++ b/t/dsl/mime.t
@@ -1,0 +1,44 @@
+use strict;
+use warnings;
+use Test::More tests => 2;
+use Plack::Test;
+use HTTP::Request::Common;
+
+{
+    package App::MIME;
+    use Dancer2;
+
+    # set some MIME aliases...
+    mime->add_type( foo => 'text/foo' );
+    mime->add_alias( f => 'foo' );
+
+    # Set default mime type
+    set 'default_mime_type' => 'text/bar';
+
+    # test static corpus
+    set static_handler => 1;
+    set public_dir => 't/corpus/static';
+
+    # added type
+    get '/foo' => sub {
+        send_file 'empty.foo';
+    };
+
+}
+
+my $app = Plack::Test->create( App::MIME->to_app );
+
+
+subtest 'send_file content type' => sub {
+    my $res = $app->request( GET '/foo' );
+    ok( $res->is_success, 'Successful request' );
+    is( $res->content_type, 'text/foo', '.. and correct mime type');
+    
+};
+
+# Ref: #1546
+subtest 'static handler content type' => sub {
+    my $res = $app->request( GET '/empty.foo' );
+    ok( $res->is_success, 'Successful request via static handler' );
+    is( $res->content_type, 'text/foo', '.. and correct mime type');
+};


### PR DESCRIPTION
* Change static content handler from `mime_type->from_name` to `mime_type->from_file` so the extension is used to determine the content type of the file.
* Minor optimisation to use `$_[0]` rather than shift.
* Tests for dsl `mime` keyword 

Resolves #1546.
