### PR TITLE
Add script_name to redirects beginning with /

### DIFF
--- a/lib/Dancer2/Core/App.pm
+++ b/lib/Dancer2/Core/App.pm
@@ -1273,6 +1273,14 @@ sub redirect {
     my $destination = shift;
     my $status      = shift;
 
+    if ($destination =~ m{^/[^/]}) {
+        # If the app is mounted to something other than "/", we must
+        # preserve its path.
+        my $script_name = $self->request->script_name;
+        $script_name =~ s{/$}{}; # Remove trailing slash (if present).
+        $destination = $script_name . $destination;
+    }
+
     $self->response->redirect( $destination, $status );
 
     # Short circuit any remaining before hook / route code

--- a/t/issues/gh-1564.t
+++ b/t/issues/gh-1564.t
@@ -1,0 +1,93 @@
+#!/usr/bin/env perl
+
+use strict;
+use warnings;
+
+use Test::More tests => 2;
+use Plack::Test;
+use Plack::Builder;
+use HTTP::Request::Common;
+
+{
+    package App;
+    use Dancer2;
+
+    get '/leading_slash' => sub { redirect '/expected'; };
+    get '/relative' => sub { redirect 'expected'; };
+    get '/relative/one-dot' => sub { redirect './expected'; };
+    get '/relative/two-dots' => sub { redirect '../expected'; };
+    get '/absolute' => sub { redirect 'http://expected' };
+    get '/schemeless' => sub { redirect '//expected' };
+}
+
+my $app = builder {
+    mount '/' => App->to_app();
+    mount '/other-mount-point' => App->to_app();
+};
+
+my @common_tests = (
+    [ 'Relative redirect', '/relative', 'expected' ],
+    [ 'Relative redirect with ./', '/relative/one-dot', './expected' ],
+    [ 'Relative redirect with ../', '/relative/two-dots', '../expected' ],
+    [ 'Absolute URL redirect', '/absolute', 'http://expected' ],
+    [ 'Schemeless redirect', '/schemeless', '//expected' ],
+);
+
+subtest 'Testing app mounted to /' => sub {
+    test_psgi $app, sub {
+        my $cb = shift;
+
+        subtest 'Redirecting with a leading slash' => sub {
+            my $res = $cb->( GET '/leading_slash' );
+            is($res->code, 302, 'Correct code');
+            is(
+                $res->headers->header('Location'),
+                '/expected',
+                'Correct location header'
+            );
+        };
+        foreach my $test (@common_tests) {
+            my ($name, $url, $expected) = @$test;
+            subtest $name => sub {
+                my $res = $cb->( GET $url );
+                is($res->code, 302, 'Correct code');
+                is(
+                    $res->headers->header('Location'),
+                    $expected,
+                    'Correct location header'
+                );
+            }
+        }
+    };
+};
+
+subtest 'Testing app mounted to /other-mount-point' => sub {
+    test_psgi $app, sub {
+        my $cb = shift;
+
+        subtest 'Redirecting with a leading slash' => sub {
+            my $res = $cb->( GET '/other-mount-point/leading_slash' );
+            is($res->code, 302, 'Correct code');
+            is(
+                $res->headers->header('Location'),
+                '/other-mount-point/expected',
+                'Correct location header'
+            );
+        };
+        foreach my $test (@common_tests) {
+            my ($name, $url, $expected) = @$test;
+            $url = "other-mount-point$url";
+            subtest $name => sub {
+                my $res = $cb->( GET $url );
+                is($res->code, 302, 'Correct code');
+                is(
+                    $res->headers->header('Location'),
+                    $expected,
+                    'Correct location header'
+                );
+            }
+        }
+    };
+};
+
+note 'DONE!';


### PR DESCRIPTION
Hey! I'm not sure if this is the best solution, but at least the test script shows the problem.

I thought about copying some of the logic from uri_for, but you guys deliberately removed it in the first place. This keeps the developer responsible for the actual location, but will prefix the path if necessary.

EDIT: This is a potential fix for #1564 