### PR TITLE
Fixed CSS so error message does not display outside of <pre> html element

### DIFF
--- a/share/skel/public/css/error.css
+++ b/share/skel/public/css/error.css
@@ -81,5 +81,6 @@ pre.error {
     border-left: 1px solid #000;
     border-right: 1px solid #eee;
     border-bottom: 1px solid #eee;
+    overflow-x: auto;
 }
 


### PR DESCRIPTION
The error messages where displaying outside of the `<pre>` tag. Minor CSS fix.

### **Before**
![before-css-fix](https://user-images.githubusercontent.com/7544799/102292417-1b4ea700-3f13-11eb-91d0-68cf6b141211.png)



### **After**
![after-css-fix](https://user-images.githubusercontent.com/7544799/102292425-1ee22e00-3f13-11eb-887b-0e3f75ca64f6.png)

