### PR TITLE
Add test to check whether all DSL keywords appear in the manual

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -72,6 +72,7 @@ suggests 'MIME::Types';
 test_requires 'Capture::Tiny', '0.12';
 test_requires 'HTTP::Cookies';
 test_requires 'HTTP::Headers';
+test_requires 'Pod::Simple::SimpleTree';
 test_requires 'Template';
 test_requires 'Test::Builder';
 test_requires 'Test::EOL';

--- a/t/dsl/pod.t
+++ b/t/dsl/pod.t
@@ -1,0 +1,52 @@
+use strict;
+use warnings;
+use Test::More;
+
+use Dancer2::Core::DSL;
+use Pod::Simple::SimpleTree;
+
+{
+    package App;
+    use Dancer2;
+}
+
+my $dsl_keywords = Dancer2::Core::DSL->new(app => App->to_app)->dsl_keywords;
+
+isa_ok($dsl_keywords, 'HASH', 'Check whether keywords are present');
+
+my $podpa = Pod::Simple::SimpleTree->new->parse_file('lib/Dancer2/Manual.pod')->root;
+
+my $in_section = 0;
+
+for my $entry (@$podpa) {
+    if (ref($entry) eq 'ARRAY') {
+        if ($entry->[0] eq 'head1') {
+            if ($entry->[2] eq 'DSL KEYWORDS') {
+                # keywords following that entry
+                $in_section = 1;
+            }
+            elsif ($in_section == 1) {
+                # end of keywords section
+                last;
+            }
+        }
+
+        if ($in_section && $entry->[0] eq 'head2') {
+            # get the bare keyword and compare with the authoritative list
+            my $title = $entry->[2];
+            $title =~ /^\s*(\S+)/;
+            my $keyword = $1;
+
+            if (exists $dsl_keywords->{$keyword}) {
+                $dsl_keywords->{$keyword}->{found} = $entry->[1]->{startline};
+            }
+        }
+    }
+}
+
+# go through the authoritative list and test we have a corresponding POD entry
+for my $keyword ( sort keys %$dsl_keywords ) { 
+    ok( exists $dsl_keywords->{$keyword}->{found}, "Checking for keyword $keyword" );
+}
+
+done_testing;


### PR DESCRIPTION
The following keywords are missing according to this test:
```

not ok 3 - Checking for keyword app
not ok 9 - Checking for keyword context
not ok 13 - Checking for keyword dancer_app
not ok 14 - Checking for keyword dancer_major_version
not ok 19 - Checking for keyword delayed
not ok 21 - Checking for keyword done
not ok 22 - Checking for keyword dsl
not ok 27 - Checking for keyword flush
not ok 34 - Checking for keyword header
not ok 35 - Checking for keyword headers
not ok 38 - Checking for keyword log
not ok 50 - Checking for keyword push_header
not ok 57 - Checking for keyword response
not ok 61 - Checking for keyword runner

```