### PR TITLE
Bugfix: mutable serializer & yaml dsl helpers loading depencendies.

### DIFF
--- a/lib/Dancer2/Serializer/Mutable.pm
+++ b/lib/Dancer2/Serializer/Mutable.pm
@@ -4,6 +4,7 @@ package Dancer2::Serializer::Mutable;
 use Moo;
 use Carp 'croak';
 use Encode;
+use Module::Runtime 'require_module';
 with 'Dancer2::Core::Role::Serializer';
 
 use constant DEFAULT_CONTENT_TYPE => 'application/json';
@@ -37,7 +38,9 @@ has mapping => (
             for my $s ( values %$mapping ) {
                 # TODO allow for arguments via the config
                 next if $serializer->{$s};
-                my $serializer_object = ('Dancer2::Serializer::'.$s)->new;
+                my $serializer_class = "Dancer2::Serializer::$s";
+                require_module($serializer_class);
+                my $serializer_object = $serializer_class->new;
                 $serializer->{$s} = {
                     from => sub { shift; $serializer_object->deserialize(@_) },
                     to   => sub { shift; $serializer_object->serialize(@_)   },

--- a/t/dsl/yaml.t
+++ b/t/dsl/yaml.t
@@ -1,0 +1,20 @@
+use strict;
+use warnings;
+use Test::More tests => 2;
+use Plack::Test;
+use HTTP::Request::Common;
+
+{
+    package App;
+    use Dancer2;
+    get '/' => sub {
+        my $app = app;
+
+        my %test = (foo => 'bar');
+
+        ::is( to_yaml(\%test), "---\nfoo: bar\n", 'to_yaml works' );
+        ::is_deeply( from_yaml(to_yaml(\%test)), \%test, 'from_yaml works' );
+    };
+}
+
+Plack::Test->create( App->to_app )->request( GET '/' );


### PR DESCRIPTION
🎄 ADD: Advent Driven Development 🎄

The easy part:
* `require` non-core serializers before calling serializer_class->new

The core tries hard to not load YAML.pm when it is not needed. This makes it possible to call the to/from yaml DSL methods without YAML loaded leading to silent serialization failures. Those helpers are also used by the mutable serializer.
* Use deferred subs to load YAML when called as class methods. 
* Tests for `to_yaml` and `from_yaml` dsl keywords, which also require YAML to be loaded.

Resolves #1568.