### PR TITLE
Feature/engine namespaces 1323

### DIFF
--- a/lib/Dancer2/Core/App.pm
+++ b/lib/Dancer2/Core/App.pm
@@ -322,9 +322,15 @@ sub _get_config_for_engine {
     defined $config->{'engines'} && defined $config->{'engines'}{$engine}
         or return {};
 
-    # try both camelized name and regular name
+    # try name, camelized name and fully-qualified name (without plus)
+    my $full_name = $name;
+    my $was_fully_qualified = ( $full_name =~ s/^\+// );  # strip any leading '+'
     my $engine_config = {};
-    foreach my $engine_name ( $name, Dancer2::Core::camelize($name) ) {
+    foreach my $engine_name (
+        $name,
+        Dancer2::Core::camelize($name),
+        ( $was_fully_qualified ? $full_name : () )
+    ) {
         if ( defined $config->{'engines'}{$engine}{$engine_name} ) {
             $engine_config = $config->{'engines'}{$engine}{$engine_name};
             last;

--- a/lib/Dancer2/Core/Factory.pm
+++ b/lib/Dancer2/Core/Factory.pm
@@ -11,7 +11,8 @@ sub create {
 
     $type = Dancer2::Core::camelize($type);
     $name = Dancer2::Core::camelize($name);
-    my $component_class = "Dancer2::${type}::${name}";
+    my $was_fully_qualified = ( $name =~ s/^\+// );  # strip any leading '+'
+    my $component_class = ( $was_fully_qualified ) ? $name : "Dancer2::${type}::${name}";
 
     eval { use_module($component_class); 1; }
         or croak "Unable to load class for $type component $name: $@";

--- a/t/app.t
+++ b/t/app.t
@@ -197,12 +197,19 @@ is_deeply(
     'Empty configuration for nonexistent engine',
 );
 
-# TODO: not such an intelligent check, this one...
+# TODO: not such an intelligent check, these ones...
 # set configuration for an engine
 $app->config->{'engines'}{'template'}{'Tiny'}{'hello'} = 'world';
+$app->config->{'engines'}{'template'}{'Some::Other::Template::Namespace'}{'hello'} = 'world';
 
 is_deeply(
     $app->_get_config_for_engine( template => 'Tiny', $app->config ),
+    { hello => 'world' },
+    '_get_config_for_engine can find the right configuration',
+);
+
+is_deeply(
+    $app->_get_config_for_engine( template => '+Some::Other::Template::Namespace', $app->config ),
     { hello => 'world' },
     '_get_config_for_engine can find the right configuration',
 );

--- a/t/classes/Dancer2-Core-Factory/new.t
+++ b/t/classes/Dancer2-Core-Factory/new.t
@@ -1,6 +1,6 @@
 use strict;
 use warnings;
-use Test::More tests => 5;
+use Test::More tests => 7;
 
 use_ok('Dancer2::Core::Factory');
 
@@ -8,9 +8,13 @@ my $factory = Dancer2::Core::Factory->new;
 isa_ok( $factory, 'Dancer2::Core::Factory' );
 can_ok( $factory, 'create' );
 
-my $template = Dancer2::Core::Factory->create(
-    'template', 'template_toolkit', layout => 'mylayout'
-);
+for my $class ('template_toolkit', '+Dancer2::Template::TemplateToolkit') {
 
-isa_ok( $template, 'Dancer2::Template::TemplateToolkit' );
-is( $template->{'layout'}, 'mylayout', 'Correct layout set in the template' );
+    my $template = Dancer2::Core::Factory->create(
+        'template', $class, layout => 'mylayout'
+    );
+
+    isa_ok( $template, 'Dancer2::Template::TemplateToolkit' );
+    is( $template->{'layout'}, 'mylayout', 'Correct layout set in the template' );
+}
+


### PR DESCRIPTION
Draft implementation to allow fully qualified namespaces for all engines, as discussed some time ago in #1323.

Draft PR before I go write more tests / documentation to ensure this is where we want to go:
```
  set engines => {
    serialier => {
      'My::Awesome::Serializer => { ... },
    },
    template => {
      'My::Template::DWIM => { ... }.
    },
  };
  set serializer => `+My::Awesome::Serializer`;
  set template => `+My::Template::DWIM`;
```

