### PR TITLE
Improve install/documentation of XS modules

### DIFF
--- a/lib/Dancer2/Manual/Deployment.pod
+++ b/lib/Dancer2/Manual/Deployment.pod
@@ -686,8 +686,6 @@ The following modules can be used to speed up an app in Dancer2:
 
 =over 4
 
-=item * L<CBOR::XS>
-
 =item * L<CGI::Deurl::XS>
 
 =item * L<Class::XSAccessor>
@@ -696,8 +694,6 @@ The following modules can be used to speed up an app in Dancer2:
 
 =item * L<Crypt::URandom>
 
-=item * L<HTTP::Parser::XS>
-
 =item * L<HTTP::XSCookies>
 
 =item * L<HTTP::XSHeaders>
@@ -705,8 +701,6 @@ The following modules can be used to speed up an app in Dancer2:
 =item * L<Math::Random::ISAAC::XS>
 
 =item * L<MooX::TypeTiny>
-
-=item * L<Scope::Upper>
 
 =item * L<Type::Tiny::XS>
 

--- a/lib/Dancer2/Manual/Deployment.pod
+++ b/lib/Dancer2/Manual/Deployment.pod
@@ -686,31 +686,46 @@ The following modules can be used to speed up an app in Dancer2:
 
 =over 4
 
-=item * L<URL::Encode::XS>
+=item * L<CBOR::XS>
 
 =item * L<CGI::Deurl::XS>
+
+=item * L<Class::XSAccessor>
+
+=item * L<Cpanel::JSON::XS>
+
+=item * L<Crypt::URandom>
 
 =item * L<HTTP::Parser::XS>
 
 =item * L<HTTP::XSCookies>
 
+=item * L<HTTP::XSHeaders>
+
+=item * L<Math::Random::ISAAC::XS>
+
+=item * L<MooX::TypeTiny>
+
 =item * L<Scope::Upper>
 
 =item * L<Type::Tiny::XS>
 
-=back
+=item * L<URL::Encode::XS>
 
-They would need to be installed separately. This is because L<Dancer2> does
-not incorporate any C code, but it can get C-code compiled as a module.
-Thus, these modules can be used for speed improvement provided:
-
-=over 4
-
-=item * You have access to a C interpreter
-
-=item * You don't need to fatpack your application
+=item * L<YAML::XS>
 
 =back
+
+If you generated your application with C<dancer2 gen>, you can easily install
+these with the following command:
+    
+    cpanm --installdeps . --with-feature=accelerate
+
+To build them, you will need access to a C compiler, and using these modules
+will prevent you from fatpacking your application.
+
+These modules are installed by default when building a Docker container 
+containing your application.
 
 =cut
 

--- a/share/skel/cpanfile
+++ b/share/skel/cpanfile
@@ -1,9 +1,37 @@
 requires "Dancer2" => "[d2% dancer_version %2d]";
 
-recommends "YAML"             => "0";
-recommends "URL::Encode::XS"  => "0";
-recommends "CGI::Deurl::XS"   => "0";
-recommends "HTTP::Parser::XS" => "0";
+recommends "YAML"                    => "0";
+recommends "URL::Encode::XS"         => "0";
+recommends "CGI::Deurl::XS"          => "0";
+recommends "HTTP::Parser::XS"        => "0";
+recommends "CBOR::XS"                => "0";
+recommends "YAML::XS"                => "0";
+recommends "Class::XSAccessor"       => "0";
+recommends "Cpanel::JSON::XS"        => "0";
+recommends "Crypt::URandom"          => "0";
+recommends "HTTP::XSCookies"         => "0";
+recommends "HTTP::XSHeaders"         => "0";
+recommends "Math::Random::ISAAC::XS" => "0";
+recommends "MooX::TypeTiny"          => "0";
+recommends "Scope::Upper"            => "0";
+recommends "Type::Tiny::XS"          => "0";
+
+feature 'accelerate', 'Accelerate Dancer2 app performance with XS modules' => sub {
+    requires "URL::Encode::XS"         => "0";
+    requires "CGI::Deurl::XS"          => "0";
+    requires "HTTP::Parser::XS"        => "0";
+    requires "CBOR::XS"                => "0";
+    requires "YAML::XS"                => "0";
+    requires "Class::XSAccessor"       => "0";
+    requires "Cpanel::JSON::XS"        => "0";
+    requires "Crypt::URandom"          => "0";
+    requires "HTTP::XSCookies"         => "0";
+    requires "HTTP::XSHeaders"         => "0";
+    requires "Math::Random::ISAAC::XS" => "0";
+    requires "MooX::TypeTiny"          => "0";
+    requires "Scope::Upper"            => "0";
+    requires "Type::Tiny::XS"          => "0";
+};
 
 on "test" => sub {
     requires "Test::More"            => "0";

--- a/share/skel/cpanfile
+++ b/share/skel/cpanfile
@@ -3,24 +3,19 @@ requires "Dancer2" => "[d2% dancer_version %2d]";
 recommends "YAML"                    => "0";
 recommends "URL::Encode::XS"         => "0";
 recommends "CGI::Deurl::XS"          => "0";
-recommends "HTTP::Parser::XS"        => "0";
 recommends "CBOR::XS"                => "0";
 recommends "YAML::XS"                => "0";
 recommends "Class::XSAccessor"       => "0";
-recommends "Cpanel::JSON::XS"        => "0";
 recommends "Crypt::URandom"          => "0";
 recommends "HTTP::XSCookies"         => "0";
 recommends "HTTP::XSHeaders"         => "0";
 recommends "Math::Random::ISAAC::XS" => "0";
 recommends "MooX::TypeTiny"          => "0";
-recommends "Scope::Upper"            => "0";
 recommends "Type::Tiny::XS"          => "0";
 
 feature 'accelerate', 'Accelerate Dancer2 app performance with XS modules' => sub {
     requires "URL::Encode::XS"         => "0";
     requires "CGI::Deurl::XS"          => "0";
-    requires "HTTP::Parser::XS"        => "0";
-    requires "CBOR::XS"                => "0";
     requires "YAML::XS"                => "0";
     requires "Class::XSAccessor"       => "0";
     requires "Cpanel::JSON::XS"        => "0";
@@ -29,7 +24,6 @@ feature 'accelerate', 'Accelerate Dancer2 app performance with XS modules' => su
     requires "HTTP::XSHeaders"         => "0";
     requires "Math::Random::ISAAC::XS" => "0";
     requires "MooX::TypeTiny"          => "0";
-    requires "Scope::Upper"            => "0";
     requires "Type::Tiny::XS"          => "0";
 };
 


### PR DESCRIPTION
This came up in discussing #1589 with @racke. This is really an independent fix from the Docker enhancement.

Make it easier to install the XS modules for the performance boost. Change the deployment pod to reflect this change. The Docker PR uses the new feature tag in `cpanfile` to install the XS modules when building the container image.