### PR TITLE
Pin App::Cmd::Setup to 0.331 or less.

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -1,4 +1,4 @@
-requires 'App::Cmd::Setup';
+requires 'App::Cmd::Setup', '<= 0.331';
 requires 'Attribute::Handlers';
 requires 'Carp';
 requires 'Clone';


### PR DESCRIPTION
rjbs informed me that the latest version of App::Cmd would be supporting only Perl 5.24 and beyond, but later backed off to 5.20. This still doesn't get us Perl 5.10 support though, so pinning Dancer2 to v0.331 at least gets us installable on older versions of Perl.

Going forward, we should move to something like MooX::Options or CLI::Osprey.