### PR TITLE
Bundle App::Cmd 0.331

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -1,4 +1,3 @@
-requires 'App::Cmd::Setup';
 requires 'Attribute::Handlers';
 requires 'Carp';
 requires 'Clone';

--- a/dist.ini
+++ b/dist.ini
@@ -89,3 +89,10 @@ match    = \.(png|ico|jpg)$ ; these are all binary files
 
 [ ReadmeAnyFromPod / MarkdownInRoot ]
 filename = README.mkdn
+
+
+# For anything we've had to bundle our own copy of with Dancer2, we have
+# bundled it for our own use, and don't want it indexed by CPAN and appearing
+# when people search for the original dist.
+[MetaNoIndex]
+directory = lib/Dancer2/Bundled

--- a/lib/Dancer2/Bundled/App/Cmd.pm
+++ b/lib/Dancer2/Bundled/App/Cmd.pm
@@ -1,0 +1,1168 @@
+use strict;
+use warnings;
+use 5.006;
+
+package Dancer2::Bundled::App::Cmd;
+$Dancer2::Bundled::App::Cmd::VERSION = '0.331';
+use Dancer2::Bundled::App::Cmd::ArgProcessor;
+BEGIN { our @ISA = 'Dancer2::Bundled::App::Cmd::ArgProcessor' };
+# ABSTRACT: write command line apps with less suffering
+
+use File::Basename ();
+use Module::Pluggable::Object ();
+use Class::Load ();
+
+use Sub::Exporter -setup => {
+  collectors => {
+    -ignore  => \'_setup_ignore',
+    -command => \'_setup_command',
+    -run     => sub {
+      warn "using -run to run your command is deprecated\n";
+      $_[1]->{class}->run; 1
+    },
+  },
+};
+
+sub _setup_command {
+  my ($self, $val, $data) = @_;
+  my $into = $data->{into};
+
+  Carp::confess "Dancer2::Bundled::App::Cmd -command setup requested for already-setup class"
+    if $into->isa('Dancer2::Bundled::App::Cmd::Command');
+
+  {
+    my $base = $self->_default_command_base;
+    Class::Load::load_class($base);
+    no strict 'refs';
+    push @{"$into\::ISA"}, $base;
+  }
+
+  $self->_register_command($into);
+
+  for my $plugin ($self->_plugin_plugins) {
+    $plugin->import_from_plugin({ into => $into });
+  }
+
+  1;
+}
+
+sub _setup_ignore {
+  my ($self, $val, $data ) = @_;
+  my $into = $data->{into};
+
+  Carp::confess "Dancer2::Bundled::App::Cmd -ignore setup requested for already-setup class"
+    if $into->isa('Dancer2::Bundled::App::Cmd::Command');
+
+  $self->_register_ignore($into);
+
+  1;
+}
+
+sub _plugin_plugins { return }
+
+#pod =head1 SYNOPSIS
+#pod
+#pod in F<yourcmd>:
+#pod
+#pod   use YourApp;
+#pod   YourApp->run;
+#pod
+#pod in F<YourApp.pm>:
+#pod
+#pod   package YourApp;
+#pod   use Dancer2::Bundled::App::Cmd::Setup -app;
+#pod   1;
+#pod
+#pod in F<YourApp/Command/blort.pm>:
+#pod
+#pod   package YourApp::Command::blort;
+#pod   use YourApp -command;
+#pod   use strict; use warnings;
+#pod
+#pod   sub abstract { "blortex algorithm" }
+#pod
+#pod   sub description { "Long description on blortex algorithm" }
+#pod
+#pod   sub opt_spec {
+#pod     return (
+#pod       [ "blortex|X",  "use the blortex algorithm" ],
+#pod       [ "recheck|r",  "recheck all results"       ],
+#pod     );
+#pod   }
+#pod
+#pod   sub validate_args {
+#pod     my ($self, $opt, $args) = @_;
+#pod
+#pod     # no args allowed but options!
+#pod     $self->usage_error("No args allowed") if @$args;
+#pod   }
+#pod
+#pod   sub execute {
+#pod     my ($self, $opt, $args) = @_;
+#pod
+#pod     my $result = $opt->{blortex} ? blortex() : blort();
+#pod
+#pod     recheck($result) if $opt->{recheck};
+#pod
+#pod     print $result;
+#pod   }
+#pod
+#pod and, finally, at the command line:
+#pod
+#pod   knight!rjbs$ yourcmd blort --recheck
+#pod
+#pod   All blorts successful.
+#pod
+#pod =head1 DESCRIPTION
+#pod
+#pod Dancer2::Bundled::App::Cmd is intended to make it easy to write complex command-line applications
+#pod without having to think about most of the annoying things usually involved.
+#pod
+#pod For information on how to start using Dancer2::Bundled::App::Cmd, see L<Dancer2::Bundled::App::Cmd::Tutorial>.
+#pod
+#pod =method new
+#pod
+#pod   my $cmd = Dancer2::Bundled::App::Cmd->new(\%arg);
+#pod
+#pod This method returns a new Dancer2::Bundled::App::Cmd object.  During initialization, command
+#pod plugins will be loaded.
+#pod
+#pod Valid arguments are:
+#pod
+#pod   no_commands_plugin - if true, the command list plugin is not added
+#pod
+#pod   no_help_plugin     - if true, the help plugin is not added
+#pod
+#pod   no_version_plugin  - if true, the version plugin is not added
+#pod
+#pod   show_version_cmd -   if true, the version command will be shown in the
+#pod                        command list
+#pod
+#pod   plugin_search_path - The path to search for commands in. Defaults to
+#pod                        results of plugin_search_path method
+#pod
+#pod If C<no_commands_plugin> is not given, L<Dancer2::Bundled::App::Cmd::Command::commands> will be
+#pod required, and it will be registered to handle all of its command names not
+#pod handled by other plugins.
+#pod
+#pod If C<no_help_plugin> is not given, L<Dancer2::Bundled::App::Cmd::Command::help> will be required,
+#pod and it will be registered to handle all of its command names not handled by
+#pod other plugins. B<Note:> "help" is the default command, so if you do not load
+#pod the default help plugin, you should provide your own or override the
+#pod C<default_command> method.
+#pod
+#pod If C<no_version_plugin> is not given, L<Dancer2::Bundled::App::Cmd::Command::version> will be
+#pod required to show the application's version with command C<--version>. By
+#pod default, the version command is not included in the command list. Pass
+#pod C<show_version_cmd> to include the version command in the list.
+#pod
+#pod =cut
+
+sub new {
+  my ($class, $arg) = @_;
+
+  my $arg0 = $0;
+  my $base = File::Basename::basename $arg0;
+
+  my $self = {
+    command      => $class->_command($arg),
+    arg0         => $base,
+    full_arg0    => $arg0,
+    show_version => $arg->{show_version_cmd} || 0,
+  };
+
+  bless $self => $class;
+}
+
+# effectively, returns the command-to-plugin mapping guts of a Cmd
+# if called on a class or on a Cmd with no mapping, construct a new hashref
+# suitable for use as the object's mapping
+sub _command {
+  my ($self, $arg) = @_;
+  return $self->{command} if ref $self and $self->{command};
+
+  # TODO _default_command_base can be wrong if people are not using
+  # ::Setup and have no ::Command :(
+  #
+  #  my $want_isa = $self->_default_command_base;
+  # -- kentnl, 2010-12
+  my $want_isa = 'Dancer2::Bundled::App::Cmd::Command';
+
+  my %plugin;
+  for my $plugin ($self->_plugins) {
+
+    Class::Load::load_class($plugin);
+
+    # relies on either the plugin itself registering as ignored
+    # during compile ( use MyDancer2::Bundled::App::Cmd -ignore )
+    # or being explicitly registered elsewhere ( blacklisted )
+    # via $app_cmd->_register_ignore( $class )
+    #  -- kentnl, 2011-09
+    next if $self->should_ignore( $plugin );
+
+    die "$plugin is not a " . $want_isa
+      unless $plugin->isa($want_isa);
+
+    next unless $plugin->can("command_names");
+
+    foreach my $command (map { lc } $plugin->command_names) {
+      die "two plugins for command $command: $plugin and $plugin{$command}\n"
+        if exists $plugin{$command};
+
+      $plugin{$command} = $plugin;
+    }
+  }
+
+  $self->_load_default_plugin($_, $arg, \%plugin) for qw(commands help version);
+
+  if ($self->allow_any_unambiguous_abbrev) {
+    # add abbreviations to list of authorized commands
+    require Text::Abbrev;
+    my %abbrev = Text::Abbrev::abbrev( keys %plugin );
+    @plugin{ keys %abbrev } = @plugin{ values %abbrev };
+  }
+
+  return \%plugin;
+}
+
+# ->_plugins won't be called more than once on any given Dancer2::Bundled::App::Cmd, but since
+# finding plugins can be a bit expensive, we'll do a lousy cache here.
+# -- rjbs, 2007-10-09
+my %plugins_for;
+sub _plugins {
+  my ($self) = @_;
+  my $class = ref $self || $self;
+
+  return @{ $plugins_for{$class} } if $plugins_for{$class};
+
+  my $finder = Module::Pluggable::Object->new(
+    search_path => $self->plugin_search_path,
+    $self->_module_pluggable_options,
+  );
+
+  my @plugins = $finder->plugins;
+  $plugins_for{$class} = \@plugins;
+
+  return @plugins;
+}
+
+sub _register_command {
+  my ($self, $cmd_class) = @_;
+  $self->_plugins;
+
+  my $class = ref $self || $self;
+  push @{ $plugins_for{ $class } }, $cmd_class
+    unless grep { $_ eq $cmd_class } @{ $plugins_for{ $class } };
+}
+
+my %ignored_for;
+
+sub should_ignore {
+  my ( $self , $cmd_class ) = @_;
+  my $class = ref $self || $self;
+  for ( @{ $ignored_for{ $class } } ) {
+    return 1 if $_ eq $cmd_class;
+  }
+  return;
+}
+
+sub _register_ignore {
+  my ($self, $cmd_class) = @_;
+  my $class = ref $self || $self;
+  push @{ $ignored_for{ $class } }, $cmd_class
+    unless grep { $_ eq $cmd_class } @{ $ignored_for{ $class } };
+}
+
+sub _module_pluggable_options {
+  # my ($self) = @_; # no point in creating these ops, just to toss $self
+  return;
+}
+
+# load one of the stock plugins, unless requested to squash; unlike normal
+# plugin loading, command-to-plugin mapping conflicts are silently ignored
+sub _load_default_plugin {
+  my ($self, $plugin_name, $arg, $plugin_href) = @_;
+  unless ($arg->{"no_$plugin_name\_plugin"}) {
+    my $plugin = "Dancer2::Bundled::App::Cmd::Command::$plugin_name";
+    Class::Load::load_class($plugin);
+    for my $command (map { lc } $plugin->command_names) {
+      $plugin_href->{$command} ||= $plugin;
+    }
+  }
+}
+
+#pod =method run
+#pod
+#pod   $cmd->run;
+#pod
+#pod This method runs the application.  If called the class, it will instantiate a
+#pod new Dancer2::Bundled::App::Cmd object to run.
+#pod
+#pod It determines the requested command (generally by consuming the first
+#pod command-line argument), finds the plugin to handle that command, parses the
+#pod remaining arguments according to that plugin's rules, and runs the plugin.
+#pod
+#pod It passes the contents of the global argument array (C<@ARGV>) to
+#pod L</C<prepare_command>>, but C<@ARGV> is not altered by running an Dancer2::Bundled::App::Cmd.
+#pod
+#pod =cut
+
+sub run {
+  my ($self) = @_;
+
+  # We should probably use Class::Default.
+  $self = $self->new unless ref $self;
+
+  # prepare the command we're going to run...
+  my @argv = $self->prepare_args();
+  my ($cmd, $opt, @args) = $self->prepare_command(@argv);
+
+  # ...and then run it
+  $self->execute_command($cmd, $opt, @args);
+}
+
+#pod =method prepare_args
+#pod
+#pod Normally Dancer2::Bundled::App::Cmd uses C<@ARGV> for its commandline arguments. You can override
+#pod this method to change that behavior for testing or otherwise.
+#pod
+#pod =cut
+
+sub prepare_args {
+  my ($self) = @_;
+  return scalar(@ARGV)
+    ? (@ARGV)
+    : (@{$self->default_args});
+}
+
+#pod =method default_args
+#pod
+#pod If C<L</prepare_args>> is not changed and there are no arguments in C<@ARGV>,
+#pod this method is called and should return an arrayref to be used as the arguments
+#pod to the program.  By default, it returns an empty arrayref.
+#pod
+#pod =cut
+
+use constant default_args => [];
+
+#pod =method abstract 
+#pod
+#pod    sub abstract { "command description" }
+#pod
+#pod Defines the command abstract: a short description that will be printed in the
+#pod main command options list.
+#pod
+#pod =method description
+#pod
+#pod    sub description { "Long description" }
+#pod
+#pod Defines a longer command description that will be shown when the user asks for
+#pod help on a specific command.
+#pod
+#pod =method arg0
+#pod
+#pod =method full_arg0
+#pod
+#pod   my $program_name = $app->arg0;
+#pod
+#pod   my $full_program_name = $app->full_arg0;
+#pod
+#pod These methods return the name of the program invoked to run this application.
+#pod This is determined by inspecting C<$0> when the Dancer2::Bundled::App::Cmd object is
+#pod instantiated, so it's probably correct, but doing weird things with Dancer2::Bundled::App::Cmd
+#pod could lead to weird values from these methods.
+#pod
+#pod If the program was run like this:
+#pod
+#pod   knight!rjbs$ ~/bin/rpg dice 3d6
+#pod
+#pod Then the methods return:
+#pod
+#pod   arg0      - rpg
+#pod   full_arg0 - /Users/rjbs/bin/rpg
+#pod
+#pod These values are captured when the Dancer2::Bundled::App::Cmd object is created, so it is safe to
+#pod assign to C<$0> later.
+#pod
+#pod =cut
+
+sub arg0      { $_[0]->{arg0} }
+sub full_arg0 { $_[0]->{full_arg0} }
+
+#pod =method prepare_command
+#pod
+#pod   my ($cmd, $opt, @args) = $app->prepare_command(@ARGV);
+#pod
+#pod This method will load the plugin for the requested command, use its options to
+#pod parse the command line arguments, and eventually return everything necessary to
+#pod actually execute the command.
+#pod
+#pod =cut
+
+sub prepare_command {
+  my ($self, @args) = @_;
+
+  # figure out first-level dispatch
+  my ($command, $opt, @sub_args) = $self->get_command(@args);
+
+  # set up the global options (which we just determined)
+  $self->set_global_options($opt);
+
+  # find its plugin or else call default plugin (default default is help)
+  if ($command) {
+    $self->_prepare_command($command, $opt, @sub_args);
+  } else {
+    $self->_prepare_default_command($opt, @sub_args);
+  }
+}
+
+sub _prepare_command {
+  my ($self, $command, $opt, @args) = @_;
+  if (my $plugin = $self->plugin_for($command)) {
+    return $plugin->prepare($self, @args);
+  } else {
+    return $self->_bad_command($command, $opt, @args);
+  }
+}
+
+sub _prepare_default_command {
+  my ($self, $opt, @sub_args) = @_;
+  $self->_prepare_command($self->default_command, $opt, @sub_args);
+}
+
+sub _bad_command {
+  my ($self, $command, $opt, @args) = @_;
+  print "Unrecognized command: $command.\n\nUsage:\n" if defined($command);
+
+  # This should be class data so that, in Bizarro World, two Dancer2::Bundled::App::Cmds will not
+  # conflict.
+  our $_bad++;
+  $self->prepare_command(qw(commands --stderr));
+}
+
+END { exit 1 if our $_bad };
+
+#pod =method default_command
+#pod
+#pod This method returns the name of the command to run if none is given on the
+#pod command line.  The default default is "help"
+#pod
+#pod =cut
+
+sub default_command { "help" }
+
+#pod =method execute_command
+#pod
+#pod   $app->execute_command($cmd, \%opt, @args);
+#pod
+#pod This method will invoke C<validate_args> and then C<run> on C<$cmd>.
+#pod
+#pod =cut
+
+sub execute_command {
+  my ($self, $cmd, $opt, @args) = @_;
+
+  local our $active_cmd = $cmd;
+
+  $cmd->validate_args($opt, \@args);
+  $cmd->execute($opt, \@args);
+}
+
+#pod =method plugin_search_path
+#pod
+#pod This method returns the plugin_search_path as set.  The default implementation,
+#pod if called on "YourDancer2::Bundled::App::Cmd" will return "YourDancer2::Bundled::App::Cmd::Command"
+#pod
+#pod This is a method because it's fun to override it with, for example:
+#pod
+#pod   use constant plugin_search_path => __PACKAGE__;
+#pod
+#pod =cut
+
+sub _default_command_base {
+  my ($self) = @_;
+  my $class = ref $self || $self;
+  return "$class\::Command";
+}
+
+sub _default_plugin_base {
+  my ($self) = @_;
+  my $class = ref $self || $self;
+  return "$class\::Plugin";
+}
+
+sub plugin_search_path {
+  my ($self) = @_;
+
+  my $dcb = $self->_default_command_base;
+  my $ccb = $dcb eq 'Dancer2::Bundled::App::Cmd::Command'
+          ? $self->Dancer2::Bundled::App::Cmd::_default_command_base
+          : $self->_default_command_base;
+
+  my @default = ($ccb, $self->_default_plugin_base);
+
+  if (ref $self) {
+    return $self->{plugin_search_path} ||= \@default;
+  } else {
+    return \@default;
+  }
+}
+
+#pod =method allow_any_unambiguous_abbrev
+#pod
+#pod If this method returns true (which, by default, it does I<not>), then any
+#pod unambiguous abbreviation for a registered command name will be allowed as a
+#pod means to use that command.  For example, given the following commands:
+#pod
+#pod   reticulate
+#pod   reload
+#pod   rasterize
+#pod
+#pod Then the user could use C<ret> for C<reticulate> or C<ra> for C<rasterize> and
+#pod so on.
+#pod
+#pod =cut
+
+sub allow_any_unambiguous_abbrev { return 0 }
+
+#pod =method global_options
+#pod
+#pod   if ($cmd->app->global_options->{verbose}) { ... }
+#pod
+#pod This method returns the running application's global options as a hashref.  If
+#pod there are no options specified, an empty hashref is returned.
+#pod
+#pod =cut
+
+sub global_options {
+	my $self = shift;
+	return $self->{global_options} ||= {} if ref $self;
+  return {};
+}
+
+#pod =method set_global_options
+#pod
+#pod   $app->set_global_options(\%opt);
+#pod
+#pod This method sets the global options.
+#pod
+#pod =cut
+
+sub set_global_options {
+  my ($self, $opt) = @_;
+  return $self->{global_options} = $opt;
+}
+
+#pod =method command_names
+#pod
+#pod   my @names = $cmd->command_names;
+#pod
+#pod This returns the commands names which the Dancer2::Bundled::App::Cmd object will handle.
+#pod
+#pod =cut
+
+sub command_names {
+  my ($self) = @_;
+  keys %{ $self->_command };
+}
+
+#pod =method command_groups
+#pod
+#pod   my @groups = $cmd->commands_groups;
+#pod
+#pod This method can be implemented to return a grouped list of command names with
+#pod optional headers. Each group is given as arrayref and each header as string.
+#pod If an empty list is returned, the commands plugin will show two groups without
+#pod headers: the first group is for the "help" and "commands" commands, and all
+#pod other commands are in the second group.
+#pod
+#pod =cut
+
+sub command_groups { }
+
+#pod =method command_plugins
+#pod
+#pod   my @plugins = $cmd->command_plugins;
+#pod
+#pod This method returns the package names of the plugins that implement the
+#pod Dancer2::Bundled::App::Cmd object's commands.
+#pod
+#pod =cut
+
+sub command_plugins {
+  my ($self) = @_;
+  my %seen = map {; $_ => 1 } values %{ $self->_command };
+  keys %seen;
+}
+
+#pod =method plugin_for
+#pod
+#pod   my $plugin = $cmd->plugin_for($command);
+#pod
+#pod This method returns the plugin (module) for the given command.  If no plugin
+#pod implements the command, it returns false.
+#pod
+#pod =cut
+
+sub plugin_for {
+  my ($self, $command) = @_;
+  return unless $command;
+  return unless exists $self->_command->{ $command };
+
+  return $self->_command->{ $command };
+}
+
+#pod =method get_command
+#pod
+#pod   my ($command_name, $opt, @args) = $app->get_command(@args);
+#pod
+#pod Process arguments and into a command name and (optional) global options.
+#pod
+#pod =cut
+
+sub get_command {
+  my ($self, @args) = @_;
+
+  my ($opt, $args, %fields)
+    = $self->_process_args(\@args, $self->_global_option_processing_params);
+
+  # map --help to help command
+  if ($opt->{help}) {
+      unshift @$args, 'help';
+      delete $opt->{help};
+  }
+
+  my ($command, $rest) = $self->_cmd_from_args($args);
+
+  $self->{usage} = $fields{usage};
+
+  return ($command, $opt, @$rest);
+}
+
+sub _cmd_from_args {
+  my ($self, $args) = @_;
+
+  my $command = shift @$args;
+  return ($command, $args);
+}
+
+sub _global_option_processing_params {
+  my ($self, @args) = @_;
+
+  return (
+    $self->usage_desc(@args),
+    $self->global_opt_spec(@args),
+    { getopt_conf => [qw/pass_through/] },
+  );
+}
+
+#pod =method usage
+#pod
+#pod   print $self->app->usage->text;
+#pod
+#pod Returns the usage object for the global options.
+#pod
+#pod =cut
+
+sub usage { $_[0]{usage} };
+
+#pod =method usage_desc
+#pod
+#pod The top level usage line. Looks something like
+#pod
+#pod   "yourapp <command> [options]"
+#pod
+#pod =cut
+
+sub usage_desc {
+  # my ($self) = @_; # no point in creating these ops, just to toss $self
+  return "%c <command> %o";
+}
+
+#pod =method global_opt_spec
+#pod
+#pod Returns a list with help command unless C<no_help_plugin> has been specified or
+#pod an empty list. Can be overridden for pre-dispatch option processing.  This is
+#pod useful for flags like --verbose.
+#pod
+#pod =cut
+
+sub global_opt_spec {
+  my ($self) = @_;
+
+  my $cmd = $self->{command};
+  my %seen;
+  my @help = grep { ! $seen{$_}++ }
+             reverse sort map { s/^--?//; $_ }
+             grep { $cmd->{$_} eq 'Dancer2::Bundled::App::Cmd::Command::help' } keys %$cmd;
+
+  return (@help ? [ join('|', @help) => "show help" ] : ());
+}
+
+#pod =method usage_error
+#pod
+#pod   $self->usage_error("Something's wrong!");
+#pod
+#pod Used to die with nice usage output, during C<validate_args>.
+#pod
+#pod =cut
+
+sub usage_error {
+  my ($self, $error) = @_;
+  die "Error: $error\nUsage: " . $self->_usage_text;
+}
+
+sub _usage_text {
+  my ($self) = @_;
+  my $text = $self->usage->text;
+  $text =~ s/\A(\s+)/!/;
+  return $text;
+}
+
+#pod =head1 TODO
+#pod
+#pod =for :list
+#pod * publish and bring in Log::Speak (simple quiet/verbose output)
+#pod * publish and use our internal enhanced describe_options
+#pod * publish and use our improved simple input routines
+#pod
+#pod =cut
+
+1;
+
+__END__
+
+=pod
+
+=encoding UTF-8
+
+=head1 NAME
+
+Dancer2::Bundled::App::Cmd - write command line apps with less suffering
+
+=head1 VERSION
+
+version 0.331
+
+=head1 SYNOPSIS
+
+in F<yourcmd>:
+
+  use YourApp;
+  YourApp->run;
+
+in F<YourApp.pm>:
+
+  package YourApp;
+  use Dancer2::Bundled::App::Cmd::Setup -app;
+  1;
+
+in F<YourApp/Command/blort.pm>:
+
+  package YourApp::Command::blort;
+  use YourApp -command;
+  use strict; use warnings;
+
+  sub abstract { "blortex algorithm" }
+
+  sub description { "Long description on blortex algorithm" }
+
+  sub opt_spec {
+    return (
+      [ "blortex|X",  "use the blortex algorithm" ],
+      [ "recheck|r",  "recheck all results"       ],
+    );
+  }
+
+  sub validate_args {
+    my ($self, $opt, $args) = @_;
+
+    # no args allowed but options!
+    $self->usage_error("No args allowed") if @$args;
+  }
+
+  sub execute {
+    my ($self, $opt, $args) = @_;
+
+    my $result = $opt->{blortex} ? blortex() : blort();
+
+    recheck($result) if $opt->{recheck};
+
+    print $result;
+  }
+
+and, finally, at the command line:
+
+  knight!rjbs$ yourcmd blort --recheck
+
+  All blorts successful.
+
+=head1 DESCRIPTION
+
+Dancer2::Bundled::App::Cmd is intended to make it easy to write complex command-line applications
+without having to think about most of the annoying things usually involved.
+
+For information on how to start using Dancer2::Bundled::App::Cmd, see L<Dancer2::Bundled::App::Cmd::Tutorial>.
+
+=head1 METHODS
+
+=head2 new
+
+  my $cmd = Dancer2::Bundled::App::Cmd->new(\%arg);
+
+This method returns a new Dancer2::Bundled::App::Cmd object.  During initialization, command
+plugins will be loaded.
+
+Valid arguments are:
+
+  no_commands_plugin - if true, the command list plugin is not added
+
+  no_help_plugin     - if true, the help plugin is not added
+
+  no_version_plugin  - if true, the version plugin is not added
+
+  show_version_cmd -   if true, the version command will be shown in the
+                       command list
+
+  plugin_search_path - The path to search for commands in. Defaults to
+                       results of plugin_search_path method
+
+If C<no_commands_plugin> is not given, L<Dancer2::Bundled::App::Cmd::Command::commands> will be
+required, and it will be registered to handle all of its command names not
+handled by other plugins.
+
+If C<no_help_plugin> is not given, L<Dancer2::Bundled::App::Cmd::Command::help> will be required,
+and it will be registered to handle all of its command names not handled by
+other plugins. B<Note:> "help" is the default command, so if you do not load
+the default help plugin, you should provide your own or override the
+C<default_command> method.
+
+If C<no_version_plugin> is not given, L<Dancer2::Bundled::App::Cmd::Command::version> will be
+required to show the application's version with command C<--version>. By
+default, the version command is not included in the command list. Pass
+C<show_version_cmd> to include the version command in the list.
+
+=head2 run
+
+  $cmd->run;
+
+This method runs the application.  If called the class, it will instantiate a
+new Dancer2::Bundled::App::Cmd object to run.
+
+It determines the requested command (generally by consuming the first
+command-line argument), finds the plugin to handle that command, parses the
+remaining arguments according to that plugin's rules, and runs the plugin.
+
+It passes the contents of the global argument array (C<@ARGV>) to
+L</C<prepare_command>>, but C<@ARGV> is not altered by running an Dancer2::Bundled::App::Cmd.
+
+=head2 prepare_args
+
+Normally Dancer2::Bundled::App::Cmd uses C<@ARGV> for its commandline arguments. You can override
+this method to change that behavior for testing or otherwise.
+
+=head2 default_args
+
+If C<L</prepare_args>> is not changed and there are no arguments in C<@ARGV>,
+this method is called and should return an arrayref to be used as the arguments
+to the program.  By default, it returns an empty arrayref.
+
+=head2 abstract 
+
+   sub abstract { "command description" }
+
+Defines the command abstract: a short description that will be printed in the
+main command options list.
+
+=head2 description
+
+   sub description { "Long description" }
+
+Defines a longer command description that will be shown when the user asks for
+help on a specific command.
+
+=head2 arg0
+
+=head2 full_arg0
+
+  my $program_name = $app->arg0;
+
+  my $full_program_name = $app->full_arg0;
+
+These methods return the name of the program invoked to run this application.
+This is determined by inspecting C<$0> when the Dancer2::Bundled::App::Cmd object is
+instantiated, so it's probably correct, but doing weird things with Dancer2::Bundled::App::Cmd
+could lead to weird values from these methods.
+
+If the program was run like this:
+
+  knight!rjbs$ ~/bin/rpg dice 3d6
+
+Then the methods return:
+
+  arg0      - rpg
+  full_arg0 - /Users/rjbs/bin/rpg
+
+These values are captured when the Dancer2::Bundled::App::Cmd object is created, so it is safe to
+assign to C<$0> later.
+
+=head2 prepare_command
+
+  my ($cmd, $opt, @args) = $app->prepare_command(@ARGV);
+
+This method will load the plugin for the requested command, use its options to
+parse the command line arguments, and eventually return everything necessary to
+actually execute the command.
+
+=head2 default_command
+
+This method returns the name of the command to run if none is given on the
+command line.  The default default is "help"
+
+=head2 execute_command
+
+  $app->execute_command($cmd, \%opt, @args);
+
+This method will invoke C<validate_args> and then C<run> on C<$cmd>.
+
+=head2 plugin_search_path
+
+This method returns the plugin_search_path as set.  The default implementation,
+if called on "YourDancer2::Bundled::App::Cmd" will return "YourDancer2::Bundled::App::Cmd::Command"
+
+This is a method because it's fun to override it with, for example:
+
+  use constant plugin_search_path => __PACKAGE__;
+
+=head2 allow_any_unambiguous_abbrev
+
+If this method returns true (which, by default, it does I<not>), then any
+unambiguous abbreviation for a registered command name will be allowed as a
+means to use that command.  For example, given the following commands:
+
+  reticulate
+  reload
+  rasterize
+
+Then the user could use C<ret> for C<reticulate> or C<ra> for C<rasterize> and
+so on.
+
+=head2 global_options
+
+  if ($cmd->app->global_options->{verbose}) { ... }
+
+This method returns the running application's global options as a hashref.  If
+there are no options specified, an empty hashref is returned.
+
+=head2 set_global_options
+
+  $app->set_global_options(\%opt);
+
+This method sets the global options.
+
+=head2 command_names
+
+  my @names = $cmd->command_names;
+
+This returns the commands names which the Dancer2::Bundled::App::Cmd object will handle.
+
+=head2 command_groups
+
+  my @groups = $cmd->commands_groups;
+
+This method can be implemented to return a grouped list of command names with
+optional headers. Each group is given as arrayref and each header as string.
+If an empty list is returned, the commands plugin will show two groups without
+headers: the first group is for the "help" and "commands" commands, and all
+other commands are in the second group.
+
+=head2 command_plugins
+
+  my @plugins = $cmd->command_plugins;
+
+This method returns the package names of the plugins that implement the
+Dancer2::Bundled::App::Cmd object's commands.
+
+=head2 plugin_for
+
+  my $plugin = $cmd->plugin_for($command);
+
+This method returns the plugin (module) for the given command.  If no plugin
+implements the command, it returns false.
+
+=head2 get_command
+
+  my ($command_name, $opt, @args) = $app->get_command(@args);
+
+Process arguments and into a command name and (optional) global options.
+
+=head2 usage
+
+  print $self->app->usage->text;
+
+Returns the usage object for the global options.
+
+=head2 usage_desc
+
+The top level usage line. Looks something like
+
+  "yourapp <command> [options]"
+
+=head2 global_opt_spec
+
+Returns a list with help command unless C<no_help_plugin> has been specified or
+an empty list. Can be overridden for pre-dispatch option processing.  This is
+useful for flags like --verbose.
+
+=head2 usage_error
+
+  $self->usage_error("Something's wrong!");
+
+Used to die with nice usage output, during C<validate_args>.
+
+=head1 TODO
+
+=over 4
+
+=item *
+
+publish and bring in Log::Speak (simple quiet/verbose output)
+
+=item *
+
+publish and use our internal enhanced describe_options
+
+=item *
+
+publish and use our improved simple input routines
+
+=back
+
+=head1 AUTHOR
+
+Ricardo Signes <rjbs@cpan.org>
+
+=head1 CONTRIBUTORS
+
+=for stopwords Adam Prime ambs Andreas Hernitscheck A. Sinan Unur Chris 'BinGOs' Williams David Golden Steinbrunner Davor Cubranic Denis Ibaev Diab Jerius Glenn Fowler Ingy dot Net Jakob Voss Jérôme Quelin John SJ Anderson Karen Etheridge Kent Fredric Matthew Astley mokko Olivier Mengué Ricardo SIGNES Ryan C. Thompson Salvatore Bonaccorso Sergey Romanov Stephen Caldwell Yuval Kogman
+
+=over 4
+
+=item *
+
+Adam Prime <aprime@oanda.com>
+
+=item *
+
+ambs <ambs@cpan.org>
+
+=item *
+
+Andreas Hernitscheck <andreash@lxhe.(none)>
+
+=item *
+
+A. Sinan Unur <nanis@cpan.org>
+
+=item *
+
+Chris 'BinGOs' Williams <chris@bingosnet.co.uk>
+
+=item *
+
+David Golden <dagolden@cpan.org>
+
+=item *
+
+David Steinbrunner <dsteinbrunner@pobox.com>
+
+=item *
+
+Davor Cubranic <cubranic@stat.ubc.ca>
+
+=item *
+
+Denis Ibaev <dionys@gmail.com>
+
+=item *
+
+Diab Jerius <djerius@cfa.harvard.edu>
+
+=item *
+
+Glenn Fowler <cebjyre@cpan.org>
+
+=item *
+
+Ingy dot Net <ingy@ingy.net>
+
+=item *
+
+Jakob Voss <jakob@nichtich.de>
+
+=item *
+
+Jakob Voss <voss@gbv.de>
+
+=item *
+
+Jérôme Quelin <jquelin@gmail.com>
+
+=item *
+
+John SJ Anderson <genehack@genehack.org>
+
+=item *
+
+Karen Etheridge <ether@cpan.org>
+
+=item *
+
+Kent Fredric <kentfredric@gmail.com>
+
+=item *
+
+Matthew Astley <mca@sanger.ac.uk>
+
+=item *
+
+mokko <mauricemengel@gmail.com>
+
+=item *
+
+Olivier Mengué <dolmen@cpan.org>
+
+=item *
+
+Ricardo SIGNES <rjbs@codesimply.com>
+
+=item *
+
+Ryan C. Thompson <rct@thompsonclan.org>
+
+=item *
+
+Salvatore Bonaccorso <carnil@debian.org>
+
+=item *
+
+Sergey Romanov <sromanov-dev@yandex.ru>
+
+=item *
+
+Stephen Caldwell <steve@campusexplorer.com>
+
+=item *
+
+Yuval Kogman <nuffin@cpan.org>
+
+=back
+
+=head1 COPYRIGHT AND LICENSE
+
+This software is copyright (c) 2016 by Ricardo Signes.
+
+This is free software; you can redistribute it and/or modify it under
+the same terms as the Perl 5 programming language system itself.
+
+=cut

--- a/lib/Dancer2/Bundled/App/Cmd/ArgProcessor.pm
+++ b/lib/Dancer2/Bundled/App/Cmd/ArgProcessor.pm
@@ -1,0 +1,51 @@
+use strict;
+use warnings;
+
+package Dancer2::Bundled::App::Cmd::ArgProcessor;
+$Dancer2::Bundled::App::Cmd::ArgProcessor::VERSION = '0.331';
+# ABSTRACT: Dancer2::Bundled::App::Cmd-specific wrapper for Getopt::Long::Descriptive
+
+sub _process_args {
+  my ($class, $args, @params) = @_;
+  local @ARGV = @$args;
+
+  require Getopt::Long::Descriptive;
+  Getopt::Long::Descriptive->VERSION(0.084);
+
+  my ($opt, $usage) = Getopt::Long::Descriptive::describe_options(@params);
+
+  return (
+    $opt,
+    [ @ARGV ], # whatever remained
+    usage => $usage,
+  );
+}
+
+1;
+
+__END__
+
+=pod
+
+=encoding UTF-8
+
+=head1 NAME
+
+Dancer2::Bundled::App::Cmd::ArgProcessor - Dancer2::Bundled::App::Cmd-specific wrapper for Getopt::Long::Descriptive
+
+=head1 VERSION
+
+version 0.331
+
+=head1 AUTHOR
+
+Ricardo Signes <rjbs@cpan.org>
+
+=head1 COPYRIGHT AND LICENSE
+
+This software is copyright (c) 2016 by Ricardo Signes.
+
+This is free software; you can redistribute it and/or modify it under
+the same terms as the Perl 5 programming language system itself.
+
+=cut

--- a/lib/Dancer2/Bundled/App/Cmd/Command.pm
+++ b/lib/Dancer2/Bundled/App/Cmd/Command.pm
@@ -1,0 +1,402 @@
+use strict;
+use warnings;
+
+package Dancer2::Bundled::App::Cmd::Command;
+$Dancer2::Bundled::App::Cmd::Command::VERSION = '0.331';
+use Dancer2::Bundled::App::Cmd::ArgProcessor;
+BEGIN { our @ISA = 'Dancer2::Bundled::App::Cmd::ArgProcessor' };
+
+# ABSTRACT: a base class for Dancer2::Bundled::App::Cmd commands
+
+use Carp ();
+
+#pod =method prepare
+#pod
+#pod   my ($cmd, $opt, $args) = $class->prepare($app, @args);
+#pod
+#pod This method is the primary way in which Dancer2::Bundled::App::Cmd::Command objects are built.
+#pod Given the remaining command line arguments meant for the command, it returns
+#pod the Command object, parsed options (as a hashref), and remaining arguments (as
+#pod an arrayref).
+#pod
+#pod In the usage above, C<$app> is the Dancer2::Bundled::App::Cmd object that is invoking the
+#pod command.
+#pod
+#pod =cut
+
+sub prepare {
+  my ($class, $app, @args) = @_;
+
+  my ($opt, $args, %fields)
+    = $class->_process_args(\@args, $class->_option_processing_params($app));
+
+  return (
+    $class->new({ app => $app, %fields }),
+    $opt,
+    @$args,
+  );
+}
+
+sub _option_processing_params {
+  my ($class, @args) = @_;
+
+  return (
+    $class->usage_desc(@args),
+    $class->opt_spec(@args),
+  );
+}
+
+#pod =method new
+#pod
+#pod This returns a new instance of the command plugin.  Probably only C<prepare>
+#pod should use this.
+#pod
+#pod =cut
+
+sub new {
+  my ($class, $arg) = @_;
+  bless $arg => $class;
+}
+
+#pod =method execute
+#pod
+#pod   $command_plugin->execute(\%opt, \@args);
+#pod
+#pod This method does whatever it is the command should do!  It is passed a hash
+#pod reference of the parsed command-line options and an array reference of left
+#pod over arguments.
+#pod
+#pod If no C<execute> method is defined, it will try to call C<run> -- but it will
+#pod warn about this behavior during testing, to remind you to fix the method name!
+#pod
+#pod =cut
+
+sub execute {
+  my $class = shift;
+
+  if (my $run = $class->can('run')) {
+    warn "Dancer2::Bundled::App::Cmd::Command subclasses should implement ->execute not ->run"
+      if $ENV{HARNESS_ACTIVE};
+
+    return $class->$run(@_);
+  }
+
+  Carp::croak ref($class) . " does not implement mandatory method 'execute'\n";
+}
+
+#pod =method app
+#pod
+#pod This method returns the Dancer2::Bundled::App::Cmd object into which this command is plugged.
+#pod
+#pod =cut
+
+sub app { $_[0]->{app}; }
+
+#pod =method usage
+#pod
+#pod This method returns the usage object for this command.  (See
+#pod L<Getopt::Long::Descriptive>).
+#pod
+#pod =cut
+
+sub usage { $_[0]->{usage}; }
+
+#pod =method command_names
+#pod
+#pod This method returns a list of command names handled by this plugin. The
+#pod first item returned is the 'canonical' name of the command.
+#pod
+#pod If this method is not overridden by an Dancer2::Bundled::App::Cmd::Command subclass, it will
+#pod return the last part of the plugin's package name, converted to lowercase.
+#pod For example, YourDancer2::Bundled::App::Cmd::Command::Init will, by default, handle the command
+#pod "init".
+#pod
+#pod Subclasses should generally get the superclass value of C<command_names>
+#pod and then append aliases.
+#pod
+#pod =cut
+
+sub command_names {
+  # from UNIVERSAL::moniker
+  (ref( $_[0] ) || $_[0]) =~ /([^:]+)$/;
+  return lc $1;
+}
+
+#pod =method usage_desc
+#pod
+#pod This method should be overridden to provide a usage string.  (This is the first
+#pod argument passed to C<describe_options> from Getopt::Long::Descriptive.)
+#pod
+#pod If not overridden, it returns "%c COMMAND %o";  COMMAND is the first item in
+#pod the result of the C<command_names> method.
+#pod
+#pod =cut
+
+sub usage_desc {
+  my ($self) = @_;
+
+  my ($command) = $self->command_names;
+  return "%c $command %o"
+}
+
+#pod =method opt_spec
+#pod
+#pod This method should be overridden to provide option specifications.  (This is
+#pod list of arguments passed to C<describe_options> from Getopt::Long::Descriptive,
+#pod after the first.)
+#pod
+#pod If not overridden, it returns an empty list.
+#pod
+#pod =cut
+
+sub opt_spec {
+  return;
+}
+
+#pod =method validate_args
+#pod
+#pod   $command_plugin->validate_args(\%opt, \@args);
+#pod
+#pod This method is passed a hashref of command line options (as processed by
+#pod Getopt::Long::Descriptive) and an arrayref of leftover arguments.  It may throw
+#pod an exception (preferably by calling C<usage_error>, below) if they are invalid,
+#pod or it may do nothing to allow processing to continue.
+#pod
+#pod =cut
+
+sub validate_args { }
+
+#pod =method usage_error
+#pod
+#pod   $self->usage_error("This command must not be run by root!");
+#pod
+#pod This method should be called to die with human-friendly usage output, during
+#pod C<validate_args>.
+#pod
+#pod =cut
+
+sub usage_error {
+  my ( $self, $error ) = @_;
+  die "Error: $error\nUsage: " . $self->_usage_text;
+}
+
+sub _usage_text {
+  my ($self) = @_;
+  local $@;
+  join "\n", eval { $self->app->_usage_text }, eval { $self->usage->text };
+}
+
+#pod =method abstract
+#pod
+#pod This method returns a short description of the command's purpose.  If this
+#pod method is not overridden, it will return the abstract from the module's Pod.
+#pod If it can't find the abstract, it will look for a comment starting with
+#pod "ABSTRACT:" like the ones used by L<Pod::Weaver::Section::Name>.
+#pod
+#pod =cut
+
+# stolen from ExtUtils::MakeMaker
+sub abstract {
+  my ($class) = @_;
+  $class = ref $class if ref $class;
+
+  my $result;
+  my $weaver_abstract;
+
+  # classname to filename
+  (my $pm_file = $class) =~ s!::!/!g;
+  $pm_file .= '.pm';
+  $pm_file = $INC{$pm_file} or return "(unknown)";
+
+  # if the pm file exists, open it and parse it
+  open my $fh, "<", $pm_file or return "(unknown)";
+
+  local $/ = "\n";
+  my $inpod;
+
+  while (local $_ = <$fh>) {
+    # =cut toggles, it doesn't end :-/
+    $inpod = /^=cut/ ? !$inpod : $inpod || /^=(?!cut)/;
+
+    if (/#+\s*ABSTRACT: (.*)/){
+      # takes ABSTRACT: ... if no POD defined yet
+      $weaver_abstract = $1;
+    }
+
+    next unless $inpod;
+    chomp;
+
+    next unless /^(?:$class\s-\s)(.*)/;
+
+    $result = $1;
+    last;
+  }
+
+  return $result || $weaver_abstract || "(unknown)";
+}
+
+#pod =method description
+#pod
+#pod This method can be overridden to provide full option description. It
+#pod is used by the built-in L<help|Dancer2::Bundled::App::Cmd::Command::help> command.
+#pod
+#pod If not overridden, it uses L<Pod::Usage> to extract the description
+#pod from the module's Pod DESCRIPTION section or the empty string.
+#pod
+#pod =cut
+
+sub description {
+    my ($class) = @_;
+    $class = ref $class if ref $class;
+
+    # classname to filename
+    (my $pm_file = $class) =~ s!::!/!g;
+    $pm_file .= '.pm';
+    $pm_file = $INC{$pm_file} or return '';
+
+    open my $input, "<", $pm_file or return '';
+
+    my $descr = "";
+    open my $output, ">", \$descr;
+
+    require Pod::Usage;
+    Pod::Usage::pod2usage( -input => $input,
+               -output => $output,
+               -exit => "NOEXIT", 
+               -verbose => 99,
+               -sections => "DESCRIPTION",
+               indent => 0
+    );
+    $descr =~ s/Description:\n//m;
+    chomp $descr;
+
+    return $descr;
+}
+
+1;
+
+__END__
+
+=pod
+
+=encoding UTF-8
+
+=head1 NAME
+
+Dancer2::Bundled::App::Cmd::Command - a base class for Dancer2::Bundled::App::Cmd commands
+
+=head1 VERSION
+
+version 0.331
+
+=head1 METHODS
+
+=head2 prepare
+
+  my ($cmd, $opt, $args) = $class->prepare($app, @args);
+
+This method is the primary way in which Dancer2::Bundled::App::Cmd::Command objects are built.
+Given the remaining command line arguments meant for the command, it returns
+the Command object, parsed options (as a hashref), and remaining arguments (as
+an arrayref).
+
+In the usage above, C<$app> is the Dancer2::Bundled::App::Cmd object that is invoking the
+command.
+
+=head2 new
+
+This returns a new instance of the command plugin.  Probably only C<prepare>
+should use this.
+
+=head2 execute
+
+  $command_plugin->execute(\%opt, \@args);
+
+This method does whatever it is the command should do!  It is passed a hash
+reference of the parsed command-line options and an array reference of left
+over arguments.
+
+If no C<execute> method is defined, it will try to call C<run> -- but it will
+warn about this behavior during testing, to remind you to fix the method name!
+
+=head2 app
+
+This method returns the Dancer2::Bundled::App::Cmd object into which this command is plugged.
+
+=head2 usage
+
+This method returns the usage object for this command.  (See
+L<Getopt::Long::Descriptive>).
+
+=head2 command_names
+
+This method returns a list of command names handled by this plugin. The
+first item returned is the 'canonical' name of the command.
+
+If this method is not overridden by an Dancer2::Bundled::App::Cmd::Command subclass, it will
+return the last part of the plugin's package name, converted to lowercase.
+For example, YourDancer2::Bundled::App::Cmd::Command::Init will, by default, handle the command
+"init".
+
+Subclasses should generally get the superclass value of C<command_names>
+and then append aliases.
+
+=head2 usage_desc
+
+This method should be overridden to provide a usage string.  (This is the first
+argument passed to C<describe_options> from Getopt::Long::Descriptive.)
+
+If not overridden, it returns "%c COMMAND %o";  COMMAND is the first item in
+the result of the C<command_names> method.
+
+=head2 opt_spec
+
+This method should be overridden to provide option specifications.  (This is
+list of arguments passed to C<describe_options> from Getopt::Long::Descriptive,
+after the first.)
+
+If not overridden, it returns an empty list.
+
+=head2 validate_args
+
+  $command_plugin->validate_args(\%opt, \@args);
+
+This method is passed a hashref of command line options (as processed by
+Getopt::Long::Descriptive) and an arrayref of leftover arguments.  It may throw
+an exception (preferably by calling C<usage_error>, below) if they are invalid,
+or it may do nothing to allow processing to continue.
+
+=head2 usage_error
+
+  $self->usage_error("This command must not be run by root!");
+
+This method should be called to die with human-friendly usage output, during
+C<validate_args>.
+
+=head2 abstract
+
+This method returns a short description of the command's purpose.  If this
+method is not overridden, it will return the abstract from the module's Pod.
+If it can't find the abstract, it will look for a comment starting with
+"ABSTRACT:" like the ones used by L<Pod::Weaver::Section::Name>.
+
+=head2 description
+
+This method can be overridden to provide full option description. It
+is used by the built-in L<help|Dancer2::Bundled::App::Cmd::Command::help> command.
+
+If not overridden, it uses L<Pod::Usage> to extract the description
+from the module's Pod DESCRIPTION section or the empty string.
+
+=head1 AUTHOR
+
+Ricardo Signes <rjbs@cpan.org>
+
+=head1 COPYRIGHT AND LICENSE
+
+This software is copyright (c) 2016 by Ricardo Signes.
+
+This is free software; you can redistribute it and/or modify it under
+the same terms as the Perl 5 programming language system itself.
+
+=cut

--- a/lib/Dancer2/Bundled/App/Cmd/Command/commands.pm
+++ b/lib/Dancer2/Bundled/App/Cmd/Command/commands.pm
@@ -1,0 +1,149 @@
+use strict;
+use warnings;
+
+package Dancer2::Bundled::App::Cmd::Command::commands;
+$Dancer2::Bundled::App::Cmd::Command::commands::VERSION = '0.331';
+use Dancer2::Bundled::App::Cmd::Command;
+BEGIN { our @ISA = 'Dancer2::Bundled::App::Cmd::Command' };
+
+# ABSTRACT: list the application's commands
+
+#pod =head1 DESCRIPTION
+#pod
+#pod This command will list all of the application commands available and their
+#pod abstracts.
+#pod
+#pod =method execute
+#pod
+#pod This is the command's primary method and raison d'etre.  It prints the
+#pod application's usage text (if any) followed by a sorted listing of the
+#pod application's commands and their abstracts.
+#pod
+#pod The commands are printed in sorted groups (created by C<sort_commands>); each
+#pod group is set off by blank lines.
+#pod
+#pod =cut
+
+sub execute {
+  my ($self, $opt, $args) = @_;
+
+  my $target = $opt->stderr ? *STDERR : *STDOUT;
+ 
+  my @cmd_groups = $self->app->command_groups;
+  my @primary_commands = map { @$_ if ref $_ } @cmd_groups;
+
+  if (!@cmd_groups) {
+    @primary_commands =
+      grep { $_ ne 'version' or $self->app->{show_version} }
+      map { ($_->command_names)[0] }
+      $self->app->command_plugins;
+
+    @cmd_groups = $self->sort_commands(@primary_commands);
+  }
+
+  my $fmt_width = 0;
+  for (@primary_commands) { $fmt_width = length if length > $fmt_width }
+  $fmt_width += 2; # pretty
+
+  foreach my $cmd_set (@cmd_groups) {
+    if (!ref $cmd_set) {
+      print { $target } "$cmd_set:\n";
+      next;
+    }
+    for my $command (@$cmd_set) {
+      my $abstract = $self->app->plugin_for($command)->abstract;
+      printf { $target } "%${fmt_width}s: %s\n", $command, $abstract;
+    }
+    print { $target } "\n";
+  }
+}
+
+#pod =method C<sort_commands>
+#pod
+#pod   my @sorted = $cmd->sort_commands(@unsorted);
+#pod
+#pod This method orders the list of commands into groups which it returns as a list of
+#pod arrayrefs, and optional group header strings.
+#pod
+#pod By default, the first group is for the "help" and "commands" commands, and all
+#pod other commands are in the second group.
+#pod
+#pod This method can be overridden by implementing the C<commands_groups> method in
+#pod your application base clase.
+#pod
+#pod =cut
+
+sub sort_commands {
+  my ($self, @commands) = @_;
+
+  my $float = qr/^(?:help|commands)$/;
+
+  my @head = sort grep { $_ =~ $float } @commands;
+  my @tail = sort grep { $_ !~ $float } @commands;
+
+  return (\@head, \@tail);
+}
+
+sub opt_spec {
+  return (
+    [ 'stderr' => 'hidden' ],
+  );
+}
+
+1;
+
+__END__
+
+=pod
+
+=encoding UTF-8
+
+=head1 NAME
+
+Dancer2::Bundled::App::Cmd::Command::commands - list the application's commands
+
+=head1 VERSION
+
+version 0.331
+
+=head1 DESCRIPTION
+
+This command will list all of the application commands available and their
+abstracts.
+
+=head1 METHODS
+
+=head2 execute
+
+This is the command's primary method and raison d'etre.  It prints the
+application's usage text (if any) followed by a sorted listing of the
+application's commands and their abstracts.
+
+The commands are printed in sorted groups (created by C<sort_commands>); each
+group is set off by blank lines.
+
+=head2 C<sort_commands>
+
+  my @sorted = $cmd->sort_commands(@unsorted);
+
+This method orders the list of commands into groups which it returns as a list of
+arrayrefs, and optional group header strings.
+
+By default, the first group is for the "help" and "commands" commands, and all
+other commands are in the second group.
+
+This method can be overridden by implementing the C<commands_groups> method in
+your application base clase.
+
+=head1 AUTHOR
+
+Ricardo Signes <rjbs@cpan.org>
+
+=head1 COPYRIGHT AND LICENSE
+
+This software is copyright (c) 2016 by Ricardo Signes.
+
+This is free software; you can redistribute it and/or modify it under
+the same terms as the Perl 5 programming language system itself.
+
+=cut

--- a/lib/Dancer2/Bundled/App/Cmd/Command/help.pm
+++ b/lib/Dancer2/Bundled/App/Cmd/Command/help.pm
@@ -1,0 +1,204 @@
+use strict;
+use warnings;
+
+package Dancer2::Bundled::App::Cmd::Command::help;
+$Dancer2::Bundled::App::Cmd::Command::help::VERSION = '0.331';
+use Dancer2::Bundled::App::Cmd::Command;
+BEGIN { our @ISA = 'Dancer2::Bundled::App::Cmd::Command'; }
+
+# ABSTRACT: display a command's help screen
+
+#pod =head1 DESCRIPTION
+#pod
+#pod This command will either list all of the application commands and their
+#pod abstracts, or display the usage screen for a subcommand with its
+#pod description.
+#pod
+#pod =head1 USAGE
+#pod
+#pod The help text is generated from three sources:
+#pod
+#pod =for :list
+#pod * The C<usage_desc> method
+#pod * The C<description> method
+#pod * The C<opt_spec> data structure
+#pod
+#pod The C<usage_desc> method provides the opening usage line, following the
+#pod specification described in L<Getopt::Long::Descriptive>.  In some cases,
+#pod the default C<usage_desc> in L<Dancer2::Bundled::App::Cmd::Command> may be sufficient and
+#pod you will only need to override it to provide additional command line
+#pod usage information.
+#pod
+#pod The C<opt_spec> data structure is used with L<Getopt::Long::Descriptive>
+#pod to generate the description of the options.
+#pod
+#pod Subcommand classes should override the C<discription> method to provide
+#pod additional information that is prepended before the option descriptions.
+#pod
+#pod For example, consider the following subcommand module:
+#pod
+#pod   package YourApp::Command::initialize;
+#pod
+#pod   # This is the default from Dancer2::Bundled::App::Cmd::Command
+#pod   sub usage_desc {
+#pod     my ($self) = @_;
+#pod     my $desc = $self->SUPER::usage_desc; # "%c COMMAND %o"
+#pod     return "$desc [DIRECTORY]";
+#pod   }
+#pod
+#pod   sub description {
+#pod     return "The initialize command prepares the application...";
+#pod   }
+#pod
+#pod   sub opt_spec {
+#pod     return (
+#pod       [ "skip-refs|R",  "skip reference checks during init", ],
+#pod       [ "values|v=s@",  "starting values", { default => [ 0, 1, 3 ] } ],
+#pod     );
+#pod   }
+#pod
+#pod   ...
+#pod
+#pod That module would generate help output like this:
+#pod
+#pod   $ yourapp help initialize
+#pod   yourapp initialize [-Rv] [long options...] [DIRECTORY]
+#pod
+#pod   The initialize command prepares the application...
+#pod
+#pod         --help            This usage screen
+#pod         -R --skip-refs    skip reference checks during init
+#pod         -v --values       starting values
+#pod
+#pod =cut
+
+sub usage_desc { '%c help [subcommand]' }
+
+sub command_names { qw/help --help -h -?/ }
+
+sub execute {
+  my ($self, $opts, $args) = @_;
+
+  if (!@$args) {
+    print $self->app->usage->text . "\n";
+
+    print "Available commands:\n\n";
+
+    $self->app->execute_command( $self->app->_prepare_command("commands") );
+  } else {
+    my ($cmd, $opt, $args) = $self->app->prepare_command(@$args);
+
+    local $@;
+    my $desc = $cmd->description;
+    $desc = "\n$desc" if length $desc;
+
+    my $ut = join "\n",
+      eval { $cmd->usage->leader_text },
+      $desc,
+      eval { $cmd->usage->option_text };
+
+    print "$ut\n";
+  }
+}
+
+1;
+
+__END__
+
+=pod
+
+=encoding UTF-8
+
+=head1 NAME
+
+Dancer2::Bundled::App::Cmd::Command::help - display a command's help screen
+
+=head1 VERSION
+
+version 0.331
+
+=head1 DESCRIPTION
+
+This command will either list all of the application commands and their
+abstracts, or display the usage screen for a subcommand with its
+description.
+
+=head1 USAGE
+
+The help text is generated from three sources:
+
+=over 4
+
+=item *
+
+The C<usage_desc> method
+
+=item *
+
+The C<description> method
+
+=item *
+
+The C<opt_spec> data structure
+
+=back
+
+The C<usage_desc> method provides the opening usage line, following the
+specification described in L<Getopt::Long::Descriptive>.  In some cases,
+the default C<usage_desc> in L<Dancer2::Bundled::App::Cmd::Command> may be sufficient and
+you will only need to override it to provide additional command line
+usage information.
+
+The C<opt_spec> data structure is used with L<Getopt::Long::Descriptive>
+to generate the description of the options.
+
+Subcommand classes should override the C<discription> method to provide
+additional information that is prepended before the option descriptions.
+
+For example, consider the following subcommand module:
+
+  package YourApp::Command::initialize;
+
+  # This is the default from Dancer2::Bundled::App::Cmd::Command
+  sub usage_desc {
+    my ($self) = @_;
+    my $desc = $self->SUPER::usage_desc; # "%c COMMAND %o"
+    return "$desc [DIRECTORY]";
+  }
+
+  sub description {
+    return "The initialize command prepares the application...";
+  }
+
+  sub opt_spec {
+    return (
+      [ "skip-refs|R",  "skip reference checks during init", ],
+      [ "values|v=s@",  "starting values", { default => [ 0, 1, 3 ] } ],
+    );
+  }
+
+  ...
+
+That module would generate help output like this:
+
+  $ yourapp help initialize
+  yourapp initialize [-Rv] [long options...] [DIRECTORY]
+
+  The initialize command prepares the application...
+
+        --help            This usage screen
+        -R --skip-refs    skip reference checks during init
+        -v --values       starting values
+
+=head1 AUTHOR
+
+Ricardo Signes <rjbs@cpan.org>
+
+=head1 COPYRIGHT AND LICENSE
+
+This software is copyright (c) 2016 by Ricardo Signes.
+
+This is free software; you can redistribute it and/or modify it under
+the same terms as the Perl 5 programming language system itself.
+
+=cut

--- a/lib/Dancer2/Bundled/App/Cmd/Command/version.pm
+++ b/lib/Dancer2/Bundled/App/Cmd/Command/version.pm
@@ -1,0 +1,68 @@
+use strict;
+use warnings;
+
+package Dancer2::Bundled::App::Cmd::Command::version;
+$Dancer2::Bundled::App::Cmd::Command::version::VERSION = '0.331';
+use Dancer2::Bundled::App::Cmd::Command;
+BEGIN { our @ISA = 'Dancer2::Bundled::App::Cmd::Command'; }
+
+# ABSTRACT: display an app's version
+
+#pod =head1 DESCRIPTION
+#pod
+#pod This command will display the program name, its base class
+#pod with version number, and the full program name.
+#pod
+#pod =cut
+
+sub command_names { qw/version --version/ }
+
+sub version_for_display {
+  $_[0]->version_package->VERSION
+}
+
+sub version_package {
+  ref($_[0]->app)
+}
+
+sub execute {
+  my ($self, $opts, $args) = @_;
+
+  printf "%s (%s) version %s (%s)\n",
+    $self->app->arg0, $self->version_package,
+    $self->version_for_display, $self->app->full_arg0;
+}
+
+1;
+
+__END__
+
+=pod
+
+=encoding UTF-8
+
+=head1 NAME
+
+Dancer2::Bundled::App::Cmd::Command::version - display an app's version
+
+=head1 VERSION
+
+version 0.331
+
+=head1 DESCRIPTION
+
+This command will display the program name, its base class
+with version number, and the full program name.
+
+=head1 AUTHOR
+
+Ricardo Signes <rjbs@cpan.org>
+
+=head1 COPYRIGHT AND LICENSE
+
+This software is copyright (c) 2016 by Ricardo Signes.
+
+This is free software; you can redistribute it and/or modify it under
+the same terms as the Perl 5 programming language system itself.
+
+=cut

--- a/lib/Dancer2/Bundled/App/Cmd/Plugin.pm
+++ b/lib/Dancer2/Bundled/App/Cmd/Plugin.pm
@@ -1,0 +1,43 @@
+use strict;
+use warnings;
+package Dancer2::Bundled::App::Cmd::Plugin;
+$Dancer2::Bundled::App::Cmd::Plugin::VERSION = '0.331';
+# ABSTRACT: a plugin for Dancer2::Bundled::App::Cmd commands
+
+sub _faux_curried_method {
+  my ($class, $name, $arg) = @_;
+
+  return sub {
+    my $cmd = $Dancer2::Bundled::App::Cmd::active_cmd;
+    $class->$name($cmd, @_);
+  }
+}
+
+1;
+
+__END__
+
+=pod
+
+=encoding UTF-8
+
+=head1 NAME
+
+Dancer2::Bundled::App::Cmd::Plugin - a plugin for Dancer2::Bundled::App::Cmd commands
+
+=head1 VERSION
+
+version 0.331
+
+=head1 AUTHOR
+
+Ricardo Signes <rjbs@cpan.org>
+
+=head1 COPYRIGHT AND LICENSE
+
+This software is copyright (c) 2016 by Ricardo Signes.
+
+This is free software; you can redistribute it and/or modify it under
+the same terms as the Perl 5 programming language system itself.
+
+=cut

--- a/lib/Dancer2/Bundled/App/Cmd/Setup.pm
+++ b/lib/Dancer2/Bundled/App/Cmd/Setup.pm
@@ -1,0 +1,293 @@
+use strict;
+use warnings;
+package Dancer2::Bundled::App::Cmd::Setup;
+$Dancer2::Bundled::App::Cmd::Setup::VERSION = '0.331';
+# ABSTRACT: helper for setting up Dancer2::Bundled::App::Cmd classes
+
+#pod =head1 OVERVIEW
+#pod
+#pod Dancer2::Bundled::App::Cmd::Setup is a helper library, used to set up base classes that will be
+#pod used as part of an Dancer2::Bundled::App::Cmd program.  For the most part you should refer to
+#pod L<the tutorial|Dancer2::Bundled::App::Cmd::Tutorial> for how you should use this library.
+#pod
+#pod This class is useful in three scenarios:
+#pod
+#pod =begin :list
+#pod
+#pod = when writing your Dancer2::Bundled::App::Cmd subclass
+#pod
+#pod Instead of writing:
+#pod
+#pod   package MyApp;
+#pod   use base 'Dancer2::Bundled::App::Cmd';
+#pod
+#pod ...you can write:
+#pod
+#pod   package MyApp;
+#pod   use Dancer2::Bundled::App::Cmd::Setup -app;
+#pod
+#pod The benefits of doing this are mostly minor, and relate to sanity-checking your
+#pod class.  The significant benefit is that this form allows you to specify
+#pod plugins, as in:
+#pod
+#pod   package MyApp;
+#pod   use Dancer2::Bundled::App::Cmd::Setup -app => { plugins => [ 'Prompt' ] };
+#pod
+#pod Plugins are described in L<Dancer2::Bundled::App::Cmd::Tutorial> and L<Dancer2::Bundled::App::Cmd::Plugin>.
+#pod
+#pod = when writing abstract base classes for commands
+#pod
+#pod That is: when you write a subclass of L<Dancer2::Bundled::App::Cmd::Command> that is intended for
+#pod other commands to use as their base class, you should use Dancer2::Bundled::App::Cmd::Setup.  For
+#pod example, if you want all the commands in MyApp to inherit from MyApp::Command,
+#pod you may want to write that package like this:
+#pod
+#pod   package MyApp::Command;
+#pod   use Dancer2::Bundled::App::Cmd::Setup -command;
+#pod
+#pod Do not confuse this with the way you will write specific commands:
+#pod
+#pod   package MyApp::Command::mycmd;
+#pod   use MyApp -command;
+#pod
+#pod Again, this form mostly performs some validation and setup behind the scenes
+#pod for you.  You can use C<L<base>> if you prefer.
+#pod
+#pod = when writing Dancer2::Bundled::App::Cmd plugins
+#pod
+#pod L<Dancer2::Bundled::App::Cmd::Plugin> is a mechanism that allows an Dancer2::Bundled::App::Cmd class to inject code
+#pod into all its command classes, providing them with utility routines.
+#pod
+#pod To write a plugin, you must use Dancer2::Bundled::App::Cmd::Setup.  As seen above, you must also
+#pod use Dancer2::Bundled::App::Cmd::Setup to set up your Dancer2::Bundled::App::Cmd subclass if you wish to consume
+#pod plugins.
+#pod
+#pod For more information on writing plugins, see L<Dancer2::Bundled::App::Cmd::Manual> and
+#pod L<Dancer2::Bundled::App::Cmd::Plugin>.
+#pod
+#pod =end :list
+#pod
+#pod =cut
+
+use Dancer2::Bundled::App::Cmd ();
+use Dancer2::Bundled::App::Cmd::Command ();
+use Dancer2::Bundled::App::Cmd::Plugin ();
+use Carp ();
+use Data::OptList ();
+use String::RewritePrefix ();
+
+# 0.06 is needed for load_optional_class
+use Class::Load 0.06 qw();
+
+use Sub::Exporter -setup => {
+  -as     => '_import',
+  exports => [ qw(foo) ],
+  collectors => [
+    -app     => \'_make_app_class',
+    -command => \'_make_command_class',
+    -plugin  => \'_make_plugin_class',
+  ],
+};
+
+sub import {
+  goto &_import;
+}
+
+sub _app_base_class { 'Dancer2::Bundled::App::Cmd' }
+
+sub _make_app_class {
+  my ($self, $val, $data) = @_;
+  my $into = $data->{into};
+
+  $val ||= {};
+  Carp::confess "invalid argument to -app setup"
+    if grep { $_ ne 'plugins' } keys %$val;
+
+  Carp::confess "app setup requested on Dancer2::Bundled::App::Cmd subclass $into"
+    if $into->isa('Dancer2::Bundled::App::Cmd');
+
+  $self->_make_x_isa_y($into, $self->_app_base_class);
+
+  if ( ! Class::Load::load_optional_class( $into->_default_command_base ) ) {
+    my $base = $self->_command_base_class;
+    Sub::Install::install_sub({
+      code => sub { $base },
+      into => $into,
+      as   => '_default_command_base',
+    });
+  }
+
+  # TODO Check this is right. -- kentnl, 2010-12
+  #
+  #  my $want_plugin_base = $self->_plugin_base_class;
+  my $want_plugin_base = 'Dancer2::Bundled::App::Cmd::Plugin';
+
+  my @plugins;
+  for my $plugin (@{ $val->{plugins} || [] }) {
+    $plugin = String::RewritePrefix->rewrite(
+      {
+        ''  => 'Dancer2::Bundled::App::Cmd::Plugin::',
+        '=' => ''
+      },
+      $plugin,
+    );
+    Class::Load::load_class( $plugin );
+    unless( $plugin->isa( $want_plugin_base ) ){
+        die "$plugin is not a " . $want_plugin_base;
+    }
+    push @plugins, $plugin;
+  }
+
+  Sub::Install::install_sub({
+    code => sub { @plugins },
+    into => $into,
+    as   => '_plugin_plugins',
+  });
+
+  return 1;
+}
+
+sub _command_base_class { 'Dancer2::Bundled::App::Cmd::Command' }
+
+sub _make_command_class {
+  my ($self, $val, $data) = @_;
+  my $into = $data->{into};
+
+  Carp::confess "command setup requested on Dancer2::Bundled::App::Cmd::Command subclass $into"
+    if $into->isa('Dancer2::Bundled::App::Cmd::Command');
+
+  $self->_make_x_isa_y($into, $self->_command_base_class);
+
+  return 1;
+}
+
+sub _make_x_isa_y {
+  my ($self, $x, $y) = @_;
+
+  no strict 'refs';
+  push @{"$x\::ISA"}, $y;
+}
+
+sub _plugin_base_class { 'Dancer2::Bundled::App::Cmd::Plugin' }
+sub _make_plugin_class {
+  my ($self, $val, $data) = @_;
+  my $into = $data->{into};
+
+  Carp::confess "plugin setup requested on Dancer2::Bundled::App::Cmd::Plugin subclass $into"
+    if $into->isa('Dancer2::Bundled::App::Cmd::Plugin');
+
+  Carp::confess "plugin setup requires plugin configuration" unless $val;
+
+  $self->_make_x_isa_y($into, $self->_plugin_base_class);
+
+  # In this special case, exporting everything by default is the sensible thing
+  # to do. -- rjbs, 2008-03-31
+  $val->{groups} = [ default => [ -all ] ] unless $val->{groups};
+
+  my @exports;
+  for my $pair (@{ Data::OptList::mkopt($val->{exports}) }) {
+    push @exports, $pair->[0], ($pair->[1] || \'_faux_curried_method');
+  }
+
+  $val->{exports} = \@exports;
+
+  Sub::Exporter::setup_exporter({
+    %$val,
+    into => $into,
+    as   => 'import_from_plugin',
+  });
+
+  return 1;
+}
+
+1;
+
+__END__
+
+=pod
+
+=encoding UTF-8
+
+=head1 NAME
+
+Dancer2::Bundled::App::Cmd::Setup - helper for setting up Dancer2::Bundled::App::Cmd classes
+
+=head1 VERSION
+
+version 0.331
+
+=head1 OVERVIEW
+
+Dancer2::Bundled::App::Cmd::Setup is a helper library, used to set up base classes that will be
+used as part of an Dancer2::Bundled::App::Cmd program.  For the most part you should refer to
+L<the tutorial|Dancer2::Bundled::App::Cmd::Tutorial> for how you should use this library.
+
+This class is useful in three scenarios:
+
+=over 4
+
+=item when writing your Dancer2::Bundled::App::Cmd subclass
+
+Instead of writing:
+
+  package MyApp;
+  use base 'Dancer2::Bundled::App::Cmd';
+
+...you can write:
+
+  package MyApp;
+  use Dancer2::Bundled::App::Cmd::Setup -app;
+
+The benefits of doing this are mostly minor, and relate to sanity-checking your
+class.  The significant benefit is that this form allows you to specify
+plugins, as in:
+
+  package MyApp;
+  use Dancer2::Bundled::App::Cmd::Setup -app => { plugins => [ 'Prompt' ] };
+
+Plugins are described in L<Dancer2::Bundled::App::Cmd::Tutorial> and L<Dancer2::Bundled::App::Cmd::Plugin>.
+
+=item when writing abstract base classes for commands
+
+That is: when you write a subclass of L<Dancer2::Bundled::App::Cmd::Command> that is intended for
+other commands to use as their base class, you should use Dancer2::Bundled::App::Cmd::Setup.  For
+example, if you want all the commands in MyApp to inherit from MyApp::Command,
+you may want to write that package like this:
+
+  package MyApp::Command;
+  use Dancer2::Bundled::App::Cmd::Setup -command;
+
+Do not confuse this with the way you will write specific commands:
+
+  package MyApp::Command::mycmd;
+  use MyApp -command;
+
+Again, this form mostly performs some validation and setup behind the scenes
+for you.  You can use C<L<base>> if you prefer.
+
+=item when writing Dancer2::Bundled::App::Cmd plugins
+
+L<Dancer2::Bundled::App::Cmd::Plugin> is a mechanism that allows an Dancer2::Bundled::App::Cmd class to inject code
+into all its command classes, providing them with utility routines.
+
+To write a plugin, you must use Dancer2::Bundled::App::Cmd::Setup.  As seen above, you must also
+use Dancer2::Bundled::App::Cmd::Setup to set up your Dancer2::Bundled::App::Cmd subclass if you wish to consume
+plugins.
+
+For more information on writing plugins, see L<Dancer2::Bundled::App::Cmd::Manual> and
+L<Dancer2::Bundled::App::Cmd::Plugin>.
+
+=back
+
+=head1 AUTHOR
+
+Ricardo Signes <rjbs@cpan.org>
+
+=head1 COPYRIGHT AND LICENSE
+
+This software is copyright (c) 2016 by Ricardo Signes.
+
+This is free software; you can redistribute it and/or modify it under
+the same terms as the Perl 5 programming language system itself.
+
+=cut

--- a/lib/Dancer2/Bundled/App/Cmd/Simple.pm
+++ b/lib/Dancer2/Bundled/App/Cmd/Simple.pm
@@ -1,0 +1,343 @@
+use strict;
+use warnings;
+
+package Dancer2::Bundled::App::Cmd::Simple;
+$Dancer2::Bundled::App::Cmd::Simple::VERSION = '0.331';
+use Dancer2::Bundled::App::Cmd::Command;
+BEGIN { our @ISA = 'Dancer2::Bundled::App::Cmd::Command' }
+
+# ABSTRACT: a helper for building one-command Dancer2::Bundled::App::Cmd applications
+
+use Dancer2::Bundled::App::Cmd;
+use Sub::Install;
+
+#pod =head1 SYNOPSIS
+#pod
+#pod in F<simplecmd>:
+#pod
+#pod   use YourDancer2::Bundled::App::Cmd;
+#pod   Your::Cmd->run;
+#pod
+#pod in F<YourApp/Cmd.pm>:
+#pod
+#pod   package YourDancer2::Bundled::App::Cmd;
+#pod   use base qw(Dancer2::Bundled::App::Cmd::Simple);
+#pod
+#pod   sub opt_spec {
+#pod     return (
+#pod       [ "blortex|X",  "use the blortex algorithm" ],
+#pod       [ "recheck|r",  "recheck all results"       ],
+#pod     );
+#pod   }
+#pod
+#pod   sub validate_args {
+#pod     my ($self, $opt, $args) = @_;
+#pod
+#pod     # no args allowed but options!
+#pod     $self->usage_error("No args allowed") if @$args;
+#pod   }
+#pod
+#pod   sub execute {
+#pod     my ($self, $opt, $args) = @_;
+#pod
+#pod     my $result = $opt->{blortex} ? blortex() : blort();
+#pod
+#pod     recheck($result) if $opt->{recheck};
+#pod
+#pod     print $result;
+#pod   }
+#pod
+#pod and, finally, at the command line:
+#pod
+#pod   knight!rjbs$ simplecmd --recheck
+#pod
+#pod   All blorts successful.
+#pod
+#pod =head1 SUBCLASSING
+#pod
+#pod When writing a subclass of Dancer2::Bundled::App::Cmd:Simple, there are only a few methods that
+#pod you might want to implement.  They behave just like the same-named methods in
+#pod Dancer2::Bundled::App::Cmd.
+#pod
+#pod =head2 opt_spec
+#pod
+#pod This method should be overridden to provide option specifications.  (This is
+#pod list of arguments passed to C<describe_options> from Getopt::Long::Descriptive,
+#pod after the first.)
+#pod
+#pod If not overridden, it returns an empty list.
+#pod
+#pod =head2 usage_desc
+#pod
+#pod This method should be overridden to provide the top level usage line.
+#pod It's a one-line summary of how the command is to be invoked, and
+#pod should be given in the format used for the C<$usage_desc> parameter to
+#pod C<describe_options> in Getopt::Long::Descriptive.
+#pod
+#pod If not overriden, it returns something that prints out like:
+#pod
+#pod   yourapp [-?h] [long options...]
+#pod
+#pod =head2 validate_args
+#pod
+#pod   $cmd->validate_args(\%opt, \@args);
+#pod
+#pod This method is passed a hashref of command line options (as processed by
+#pod Getopt::Long::Descriptive) and an arrayref of leftover arguments.  It may throw
+#pod an exception (preferably by calling C<usage_error>) if they are invalid, or it
+#pod may do nothing to allow processing to continue.
+#pod
+#pod =head2 execute
+#pod
+#pod   Your::Dancer2::Bundled::App::Cmd::Simple->execute(\%opt, \@args);
+#pod
+#pod This method does whatever it is the command should do!  It is passed a hash
+#pod reference of the parsed command-line options and an array reference of left
+#pod over arguments.
+#pod
+#pod =cut
+
+# The idea here is that the user will someday replace "Simple" in his ISA with
+# "Command" and then write a standard Dancer2::Bundled::App::Cmd package.  To make that possible,
+# we produce a behind-the-scenes Dancer2::Bundled::App::Cmd object when the user says 'use
+# MyApp::Simple' and redirect MyApp::Simple->run to that.
+my $i;
+BEGIN { $i = 0 }
+
+sub import {
+  my ($class) = @_;
+  return if $class eq __PACKAGE__;
+
+  # This signals that something has already set the target up.
+  return $class if $class->_cmd_pkg;
+
+  my $core_execute = Dancer2::Bundled::App::Cmd::Command->can('execute');
+  my $our_execute  = $class->can('execute');
+  Carp::confess(
+    "Dancer2::Bundled::App::Cmd::Simple subclasses must implement ->execute, not ->run"
+  ) unless $our_execute and $our_execute != $core_execute;
+
+  # I doubt the $i will ever be needed, but let's start paranoid.
+  my $generated_name = join('::', $class, '_App_Cmd', $i++);
+
+  {
+    no strict 'refs';
+    *{$generated_name . '::ISA'} = [ 'Dancer2::Bundled::App::Cmd' ];
+  }
+
+  Sub::Install::install_sub({
+    into => $class,
+    as   => '_cmd_pkg',
+    code => sub { $generated_name },
+  });
+
+  Sub::Install::install_sub({
+      into => $class,
+      as => 'command_names',
+      code => sub { 'only' },
+  });
+
+  Sub::Install::install_sub({
+    into => $generated_name,
+    as   => '_plugins',
+    code => sub { $class },
+  });
+
+  Sub::Install::install_sub({
+    into => $generated_name,
+    as   => 'default_command',
+    code => sub { 'only' },
+  });
+
+  Sub::Install::install_sub({
+    into => $generated_name,
+    as   => '_cmd_from_args',
+    code => sub {
+      my ($self, $args) = @_;
+      if (defined(my $command = $args->[0])) {
+        my $plugin = $self->plugin_for($command);
+        # If help was requested, show the help for the command, not the
+        # main help. Because the main help would talk about subcommands,
+        # and a "Simple" app has no subcommands.
+        if ($plugin and $plugin eq $self->plugin_for("help")) {
+          return ($command, [ $self->default_command ]);
+        }
+        # Any other value for "command" isn't really a command at all --
+        # it's the first argument. So call the default command instead.
+      }
+      return ($self->default_command, $args);
+    },
+  });
+
+  Sub::Install::install_sub({
+    into => $class,
+    as   => 'run',
+    code => sub {
+      $generated_name->new({
+        no_help_plugin     => 0,
+        no_commands_plugin => 1,
+      })->run(@_);
+    }
+  });
+
+  return $class;
+}
+
+sub usage_desc {
+  return "%c %o"
+}
+
+sub _cmd_pkg { }
+
+#pod =head1 WARNINGS
+#pod
+#pod B<This should be considered experimental!>  Although it is probably not going
+#pod to change much, don't build your business model around it yet, okay?
+#pod
+#pod Dancer2::Bundled::App::Cmd::Simple is not rich in black magic, but it does do some somewhat
+#pod gnarly things to make an Dancer2::Bundled::App::Cmd::Simple look as much like an
+#pod Dancer2::Bundled::App::Cmd::Command as possible.  This means that you can't deviate too much from
+#pod the sort of thing shown in the synopsis as you might like.  If you're doing
+#pod something other than writing a fairly simple command, and you want to screw
+#pod around with the Dancer2::Bundled::App::Cmd-iness of your program, Simple might not be the best
+#pod choice.
+#pod
+#pod B<One specific warning...>  if you are writing a program with the
+#pod Dancer2::Bundled::App::Cmd::Simple class embedded in it, you B<must> call import on the class.
+#pod That's how things work.  You can just do this:
+#pod
+#pod   YourDancer2::Bundled::App::Cmd->import->run;
+#pod
+#pod =cut
+
+1;
+
+__END__
+
+=pod
+
+=encoding UTF-8
+
+=head1 NAME
+
+Dancer2::Bundled::App::Cmd::Simple - a helper for building one-command Dancer2::Bundled::App::Cmd applications
+
+=head1 VERSION
+
+version 0.331
+
+=head1 SYNOPSIS
+
+in F<simplecmd>:
+
+  use YourDancer2::Bundled::App::Cmd;
+  Your::Cmd->run;
+
+in F<YourApp/Cmd.pm>:
+
+  package YourDancer2::Bundled::App::Cmd;
+  use base qw(Dancer2::Bundled::App::Cmd::Simple);
+
+  sub opt_spec {
+    return (
+      [ "blortex|X",  "use the blortex algorithm" ],
+      [ "recheck|r",  "recheck all results"       ],
+    );
+  }
+
+  sub validate_args {
+    my ($self, $opt, $args) = @_;
+
+    # no args allowed but options!
+    $self->usage_error("No args allowed") if @$args;
+  }
+
+  sub execute {
+    my ($self, $opt, $args) = @_;
+
+    my $result = $opt->{blortex} ? blortex() : blort();
+
+    recheck($result) if $opt->{recheck};
+
+    print $result;
+  }
+
+and, finally, at the command line:
+
+  knight!rjbs$ simplecmd --recheck
+
+  All blorts successful.
+
+=head1 SUBCLASSING
+
+When writing a subclass of Dancer2::Bundled::App::Cmd:Simple, there are only a few methods that
+you might want to implement.  They behave just like the same-named methods in
+Dancer2::Bundled::App::Cmd.
+
+=head2 opt_spec
+
+This method should be overridden to provide option specifications.  (This is
+list of arguments passed to C<describe_options> from Getopt::Long::Descriptive,
+after the first.)
+
+If not overridden, it returns an empty list.
+
+=head2 usage_desc
+
+This method should be overridden to provide the top level usage line.
+It's a one-line summary of how the command is to be invoked, and
+should be given in the format used for the C<$usage_desc> parameter to
+C<describe_options> in Getopt::Long::Descriptive.
+
+If not overriden, it returns something that prints out like:
+
+  yourapp [-?h] [long options...]
+
+=head2 validate_args
+
+  $cmd->validate_args(\%opt, \@args);
+
+This method is passed a hashref of command line options (as processed by
+Getopt::Long::Descriptive) and an arrayref of leftover arguments.  It may throw
+an exception (preferably by calling C<usage_error>) if they are invalid, or it
+may do nothing to allow processing to continue.
+
+=head2 execute
+
+  Your::Dancer2::Bundled::App::Cmd::Simple->execute(\%opt, \@args);
+
+This method does whatever it is the command should do!  It is passed a hash
+reference of the parsed command-line options and an array reference of left
+over arguments.
+
+=head1 WARNINGS
+
+B<This should be considered experimental!>  Although it is probably not going
+to change much, don't build your business model around it yet, okay?
+
+Dancer2::Bundled::App::Cmd::Simple is not rich in black magic, but it does do some somewhat
+gnarly things to make an Dancer2::Bundled::App::Cmd::Simple look as much like an
+Dancer2::Bundled::App::Cmd::Command as possible.  This means that you can't deviate too much from
+the sort of thing shown in the synopsis as you might like.  If you're doing
+something other than writing a fairly simple command, and you want to screw
+around with the Dancer2::Bundled::App::Cmd-iness of your program, Simple might not be the best
+choice.
+
+B<One specific warning...>  if you are writing a program with the
+Dancer2::Bundled::App::Cmd::Simple class embedded in it, you B<must> call import on the class.
+That's how things work.  You can just do this:
+
+  YourDancer2::Bundled::App::Cmd->import->run;
+
+=head1 AUTHOR
+
+Ricardo Signes <rjbs@cpan.org>
+
+=head1 COPYRIGHT AND LICENSE
+
+This software is copyright (c) 2016 by Ricardo Signes.
+
+This is free software; you can redistribute it and/or modify it under
+the same terms as the Perl 5 programming language system itself.
+
+=cut

--- a/lib/Dancer2/Bundled/App/Cmd/Subdispatch.pm
+++ b/lib/Dancer2/Bundled/App/Cmd/Subdispatch.pm
@@ -1,0 +1,156 @@
+use strict;
+use warnings;
+
+package Dancer2::Bundled::App::Cmd::Subdispatch;
+$Dancer2::Bundled::App::Cmd::Subdispatch::VERSION = '0.331';
+use Dancer2::Bundled::App::Cmd;
+use Dancer2::Bundled::App::Cmd::Command;
+BEGIN { our @ISA = qw(Dancer2::Bundled::App::Cmd::Command Dancer2::Bundled::App::Cmd) } 
+
+# ABSTRACT: an Dancer2::Bundled::App::Cmd::Command that is also an Dancer2::Bundled::App::Cmd
+
+#pod =method new
+#pod
+#pod A hackish new that allows us to have an Command instance before they normally
+#pod exist.
+#pod
+#pod =cut
+
+sub new {
+	my ($inv, $fields, @args) = @_;
+	if (ref $inv) {
+		@{ $inv }{ keys %$fields } = values %$fields;
+		return $inv;
+	} else {
+		$inv->SUPER::new($fields, @args);
+	}
+}
+
+#pod =method prepare
+#pod
+#pod   my $subcmd = $subdispatch->prepare($app, @args);
+#pod
+#pod An overridden version of L<Dancer2::Bundled::App::Cmd::Command/prepare> that performs a new
+#pod dispatch cycle.
+#pod
+#pod =cut
+
+sub prepare {
+	my ($class, $app, @args) = @_;
+
+	my $self = $class->new({ app => $app });
+
+	my ($subcommand, $opt, @sub_args) = $self->get_command(@args);
+
+  $self->set_global_options($opt);
+
+	if (defined $subcommand) {
+    return $self->_prepare_command($subcommand, $opt, @sub_args);
+  } else {
+    if (@args) {
+      return $self->_bad_command(undef, $opt, @sub_args);
+    } else {
+      return $self->_prepare_default_command($opt, @sub_args);
+    }
+  }
+}
+
+sub _plugin_prepare {
+  my ($self, $plugin, @args) = @_;
+  return $plugin->prepare($self->choose_parent_app($self->app, $plugin), @args);
+}
+
+#pod =method app
+#pod
+#pod   $subdispatch->app;
+#pod
+#pod This method returns the application that this subdispatch is a command of.
+#pod
+#pod =cut
+
+sub app { $_[0]{app} }
+
+#pod =method choose_parent_app
+#pod
+#pod   $subcmd->prepare(
+#pod     $subdispatch->choose_parent_app($app, $opt, $plugin),
+#pod     @$args
+#pod   );
+#pod
+#pod A method that chooses whether the parent app or the subdispatch is going to be
+#pod C<< $cmd->app >>.
+#pod
+#pod =cut
+
+sub choose_parent_app {
+	my ( $self, $app, $plugin ) = @_;
+
+	if (
+    $plugin->isa("Dancer2::Bundled::App::Cmd::Command::commands")
+    or $plugin->isa("Dancer2::Bundled::App::Cmd::Command::help")
+    or scalar keys %{ $self->global_options }
+  ) {
+		return $self;
+	} else {
+		return $app;
+	}
+}
+
+1;
+
+__END__
+
+=pod
+
+=encoding UTF-8
+
+=head1 NAME
+
+Dancer2::Bundled::App::Cmd::Subdispatch - an Dancer2::Bundled::App::Cmd::Command that is also an Dancer2::Bundled::App::Cmd
+
+=head1 VERSION
+
+version 0.331
+
+=head1 METHODS
+
+=head2 new
+
+A hackish new that allows us to have an Command instance before they normally
+exist.
+
+=head2 prepare
+
+  my $subcmd = $subdispatch->prepare($app, @args);
+
+An overridden version of L<Dancer2::Bundled::App::Cmd::Command/prepare> that performs a new
+dispatch cycle.
+
+=head2 app
+
+  $subdispatch->app;
+
+This method returns the application that this subdispatch is a command of.
+
+=head2 choose_parent_app
+
+  $subcmd->prepare(
+    $subdispatch->choose_parent_app($app, $opt, $plugin),
+    @$args
+  );
+
+A method that chooses whether the parent app or the subdispatch is going to be
+C<< $cmd->app >>.
+
+=head1 AUTHOR
+
+Ricardo Signes <rjbs@cpan.org>
+
+=head1 COPYRIGHT AND LICENSE
+
+This software is copyright (c) 2016 by Ricardo Signes.
+
+This is free software; you can redistribute it and/or modify it under
+the same terms as the Perl 5 programming language system itself.
+
+=cut

--- a/lib/Dancer2/Bundled/App/Cmd/Subdispatch/DashedStyle.pm
+++ b/lib/Dancer2/Bundled/App/Cmd/Subdispatch/DashedStyle.pm
@@ -1,0 +1,107 @@
+use strict;
+use warnings;
+
+package Dancer2::Bundled::App::Cmd::Subdispatch::DashedStyle;
+$Dancer2::Bundled::App::Cmd::Subdispatch::DashedStyle::VERSION = '0.331';
+use Dancer2::Bundled::App::Cmd::Subdispatch;
+BEGIN { our @ISA = 'Dancer2::Bundled::App::Cmd::Subdispatch' };
+
+# ABSTRACT: "app cmd --subcmd" style subdispatching
+
+#pod =method get_command
+#pod
+#pod   my ($subcommand, $opt, $args) = $subdispatch->get_command(@args)
+#pod
+#pod A version of get_command that chooses commands as options in the following
+#pod style:
+#pod
+#pod   mytool mycommand --mysubcommand
+#pod
+#pod =cut
+
+sub get_command {
+	my ($self, @args) = @_;
+
+	my (undef, $opt, @sub_args)
+    = $self->Dancer2::Bundled::App::Cmd::Command::prepare($self->app, @args);
+
+	if (my $cmd = delete $opt->{subcommand}) {
+		delete $opt->{$cmd}; # useless boolean
+		return ($cmd, $opt, @sub_args);
+	} else {
+    return (undef, $opt, @sub_args);
+  }
+}
+
+#pod =method opt_spec
+#pod
+#pod A version of C<opt_spec> that calculates the getopt specification from the
+#pod subcommands.
+#pod
+#pod =cut
+
+sub opt_spec {
+	my ($self, $app) = @_;
+
+	my $subcommands = $self->_command;
+	my %plugins = map {
+		$_ => [ $_->command_names ],
+	} values %$subcommands;
+
+	foreach my $opt_spec (values %plugins) {
+		$opt_spec = join("|", grep { /^\w/ } @$opt_spec);
+	}
+
+	my @subcommands = map { [ $plugins{$_} =>  $_->abstract ] } keys %plugins;
+
+	return (
+		[ subcommand => hidden => { one_of => \@subcommands } ],
+		$self->global_opt_spec($app),
+		{ getopt_conf => [ 'pass_through' ] },
+	);
+}
+
+1;
+
+__END__
+
+=pod
+
+=encoding UTF-8
+
+=head1 NAME
+
+Dancer2::Bundled::App::Cmd::Subdispatch::DashedStyle - "app cmd --subcmd" style subdispatching
+
+=head1 VERSION
+
+version 0.331
+
+=head1 METHODS
+
+=head2 get_command
+
+  my ($subcommand, $opt, $args) = $subdispatch->get_command(@args)
+
+A version of get_command that chooses commands as options in the following
+style:
+
+  mytool mycommand --mysubcommand
+
+=head2 opt_spec
+
+A version of C<opt_spec> that calculates the getopt specification from the
+subcommands.
+
+=head1 AUTHOR
+
+Ricardo Signes <rjbs@cpan.org>
+
+=head1 COPYRIGHT AND LICENSE
+
+This software is copyright (c) 2016 by Ricardo Signes.
+
+This is free software; you can redistribute it and/or modify it under
+the same terms as the Perl 5 programming language system itself.
+
+=cut

--- a/lib/Dancer2/Bundled/App/Cmd/Tester.pm
+++ b/lib/Dancer2/Bundled/App/Cmd/Tester.pm
@@ -1,0 +1,253 @@
+use strict;
+use warnings;
+package Dancer2::Bundled::App::Cmd::Tester;
+$Dancer2::Bundled::App::Cmd::Tester::VERSION = '0.331';
+# ABSTRACT: for capturing the result of running an app
+
+#pod =head1 SYNOPSIS
+#pod
+#pod   use Test::More tests => 4;
+#pod   use Dancer2::Bundled::App::Cmd::Tester;
+#pod
+#pod   use YourApp;
+#pod
+#pod   my $result = test_app(YourApp => [ qw(command --opt value) ]);
+#pod
+#pod   like($result->stdout, qr/expected output/, 'printed what we expected');
+#pod
+#pod   is($result->stderr, '', 'nothing sent to sderr');
+#pod
+#pod   is($result->error, undef, 'threw no exceptions');
+#pod
+#pod   my $result = test_app(YourApp => [ qw(command --opt value --quiet) ]);
+#pod
+#pod   is($result->output, '', 'absolutely no output with --quiet');
+#pod
+#pod =head1 DESCRIPTION
+#pod
+#pod One of the reasons that user-executed programs are so often poorly tested is
+#pod that they are hard to test.  Dancer2::Bundled::App::Cmd::Tester is one of the tools App-Cmd
+#pod provides to help make it easy to test Dancer2::Bundled::App::Cmd-based programs.
+#pod
+#pod It provides one routine: test_app.
+#pod
+#pod =method test_app
+#pod
+#pod B<Note>: while C<test_app> is a method, it is by default exported as a
+#pod subroutine into the namespace that uses Dancer2::Bundled::App::Cmd::Tester.  In other words: you
+#pod probably don't need to think about this as a method unless you want to subclass
+#pod Dancer2::Bundled::App::Cmd::Tester.
+#pod
+#pod   my $result = test_app($app_class => \@argv_contents);
+#pod
+#pod This will locally set C<@ARGV> to simulate command line arguments, and will
+#pod then call the C<run> method on the given application class (or application).
+#pod Output to the standard output and standard error filehandles  will be captured.
+#pod
+#pod C<$result> is an Dancer2::Bundled::App::Cmd::Tester::Result object, which has methods to access
+#pod the following data:
+#pod
+#pod   stdout - the output sent to stdout
+#pod   stderr - the output sent to stderr
+#pod   output - the combined output of stdout and stderr
+#pod   error  - the exception thrown by running the application, or undef
+#pod   run_rv - the return value of the run method (generally irrelevant)
+#pod   exit_code - the numeric exit code that would've been issued (0 is 'okay')
+#pod
+#pod The output is captured using L<IO::TieCombine>, which I<can> ensure that the
+#pod ordering is preserved in the combined output, but I<can't> capture the output
+#pod of external programs.  You can reverse these tradeoffs by using
+#pod L<Dancer2::Bundled::App::Cmd::Tester::CaptureExternal> instead.
+#pod
+#pod =cut
+
+use Sub::Exporter::Util qw(curry_method);
+use Sub::Exporter -setup => {
+  exports => { test_app => curry_method },
+  groups  => { default  => [ qw(test_app) ] },
+};
+
+our $TEST_IN_PROGRESS;
+BEGIN {
+  *CORE::GLOBAL::exit = sub {
+    my ($rc) = @_;
+    return CORE::exit($rc) unless $TEST_IN_PROGRESS;
+    Dancer2::Bundled::App::Cmd::Tester::Exited->throw($rc);
+  };
+}
+
+#pod =for Pod::Coverage result_class
+#pod
+#pod =cut
+
+sub result_class { 'Dancer2::Bundled::App::Cmd::Tester::Result' }
+
+sub test_app {
+  my ($class, $app, $argv) = @_;
+
+  local $Dancer2::Bundled::App::Cmd::_bad = 0;
+
+  $app = $app->new unless ref($app) or $app->isa('Dancer2::Bundled::App::Cmd::Simple');
+
+  my $result = $class->_run_with_capture($app, $argv);
+
+  my $error = $result->{error};
+
+  my $exit_code = defined $error ? ((0+$!)||-1) : 0;
+
+  if ($error and eval { $error->isa('Dancer2::Bundled::App::Cmd::Tester::Exited') }) {
+    $exit_code = $$error;
+  }
+
+  $exit_code =1 if $Dancer2::Bundled::App::Cmd::_bad && ! $exit_code;
+
+  $class->result_class->new({
+    app    => $app,
+    exit_code => $exit_code,
+    %$result,
+  });
+}
+
+sub _run_with_capture {
+  my ($class, $app, $argv) = @_;
+
+  require IO::TieCombine;
+  my $hub = IO::TieCombine->new;
+
+  my $stdout = tie local *STDOUT, $hub, 'stdout';
+  my $stderr = tie local *STDERR, $hub, 'stderr';
+
+  my $run_rv;
+
+  my $ok = eval {
+    local $TEST_IN_PROGRESS = 1;
+    local @ARGV = @$argv;
+    $run_rv = $app->run;
+    1;
+  };
+
+  my $error = $ok ? undef : $@;
+
+  return {
+    stdout => $hub->slot_contents('stdout'),
+    stderr => $hub->slot_contents('stderr'),
+    output => $hub->combined_contents,
+    error  => $error,
+    run_rv => $run_rv,
+  };
+}
+
+{
+  package Dancer2::Bundled::App::Cmd::Tester::Result;
+$Dancer2::Bundled::App::Cmd::Tester::Result::VERSION = '0.331';
+sub new {
+    my ($class, $arg) = @_;
+    bless $arg => $class;
+  }
+
+  for my $attr (qw(app stdout stderr output error run_rv exit_code)) {
+    Sub::Install::install_sub({
+      code => sub { $_[0]->{$attr} },
+      as   => $attr,
+    });
+  }
+}
+
+{
+  package Dancer2::Bundled::App::Cmd::Tester::Exited;
+$Dancer2::Bundled::App::Cmd::Tester::Exited::VERSION = '0.331';
+sub throw {
+    my ($class, $code) = @_;
+    $code = 0 unless defined $code;
+    my $self = (bless \$code => $class);
+    die $self;
+  }
+}
+
+1;
+
+__END__
+
+=pod
+
+=encoding UTF-8
+
+=head1 NAME
+
+Dancer2::Bundled::App::Cmd::Tester - for capturing the result of running an app
+
+=head1 VERSION
+
+version 0.331
+
+=head1 SYNOPSIS
+
+  use Test::More tests => 4;
+  use Dancer2::Bundled::App::Cmd::Tester;
+
+  use YourApp;
+
+  my $result = test_app(YourApp => [ qw(command --opt value) ]);
+
+  like($result->stdout, qr/expected output/, 'printed what we expected');
+
+  is($result->stderr, '', 'nothing sent to sderr');
+
+  is($result->error, undef, 'threw no exceptions');
+
+  my $result = test_app(YourApp => [ qw(command --opt value --quiet) ]);
+
+  is($result->output, '', 'absolutely no output with --quiet');
+
+=head1 DESCRIPTION
+
+One of the reasons that user-executed programs are so often poorly tested is
+that they are hard to test.  Dancer2::Bundled::App::Cmd::Tester is one of the tools App-Cmd
+provides to help make it easy to test Dancer2::Bundled::App::Cmd-based programs.
+
+It provides one routine: test_app.
+
+=head1 METHODS
+
+=head2 test_app
+
+B<Note>: while C<test_app> is a method, it is by default exported as a
+subroutine into the namespace that uses Dancer2::Bundled::App::Cmd::Tester.  In other words: you
+probably don't need to think about this as a method unless you want to subclass
+Dancer2::Bundled::App::Cmd::Tester.
+
+  my $result = test_app($app_class => \@argv_contents);
+
+This will locally set C<@ARGV> to simulate command line arguments, and will
+then call the C<run> method on the given application class (or application).
+Output to the standard output and standard error filehandles  will be captured.
+
+C<$result> is an Dancer2::Bundled::App::Cmd::Tester::Result object, which has methods to access
+the following data:
+
+  stdout - the output sent to stdout
+  stderr - the output sent to stderr
+  output - the combined output of stdout and stderr
+  error  - the exception thrown by running the application, or undef
+  run_rv - the return value of the run method (generally irrelevant)
+  exit_code - the numeric exit code that would've been issued (0 is 'okay')
+
+The output is captured using L<IO::TieCombine>, which I<can> ensure that the
+ordering is preserved in the combined output, but I<can't> capture the output
+of external programs.  You can reverse these tradeoffs by using
+L<Dancer2::Bundled::App::Cmd::Tester::CaptureExternal> instead.
+
+=for Pod::Coverage result_class
+
+=head1 AUTHOR
+
+Ricardo Signes <rjbs@cpan.org>
+
+=head1 COPYRIGHT AND LICENSE
+
+This software is copyright (c) 2016 by Ricardo Signes.
+
+This is free software; you can redistribute it and/or modify it under
+the same terms as the Perl 5 programming language system itself.
+
+=cut

--- a/lib/Dancer2/Bundled/App/Cmd/Tester/CaptureExternal.pm
+++ b/lib/Dancer2/Bundled/App/Cmd/Tester/CaptureExternal.pm
@@ -1,0 +1,130 @@
+use strict;
+use warnings;
+package Dancer2::Bundled::App::Cmd::Tester::CaptureExternal;
+$Dancer2::Bundled::App::Cmd::Tester::CaptureExternal::VERSION = '0.331';
+use parent 'Dancer2::Bundled::App::Cmd::Tester';
+use Capture::Tiny 0.13 qw/capture/;
+
+# ABSTRACT: Extends Dancer2::Bundled::App::Cmd::Tester to capture from external subprograms
+
+#pod =head1 SYNOPSIS
+#pod
+#pod   use Test::More tests => 4;
+#pod   use Dancer2::Bundled::App::Cmd::Tester::CaptureExternal;
+#pod
+#pod   use YourApp;
+#pod
+#pod   my $result = test_app(YourApp => [ qw(command --opt value) ]);
+#pod
+#pod   like($result->stdout, qr/expected output/, 'printed what we expected');
+#pod
+#pod   is($result->stderr, '', 'nothing sent to sderr');
+#pod
+#pod   ok($result->output, "STDOUT concatenated with STDERR");
+#pod
+#pod =head1 DESCRIPTION
+#pod
+#pod L<Dancer2::Bundled::App::Cmd::Tester> provides a useful scaffold for testing applications, but it
+#pod is unable to capture output generated from any external subprograms that are
+#pod invoked from the application.
+#pod
+#pod This subclass uses an alternate mechanism for capturing output
+#pod (L<Capture::Tiny>) that does capture from external programs, with one
+#pod major limitation.
+#pod
+#pod It is not possible to capture externally from both STDOUT and STDERR while
+#pod also having appropriately interleaved combined output.  Therefore, the
+#pod C<output> from this subclass simply concatenates the two.
+#pod
+#pod You can still use C<output> for testing if there is any output at all or for
+#pod testing if something appeared in either output stream, but you can't rely on
+#pod the ordering being correct between lines to STDOUT and lines to STDERR.
+#pod
+#pod =cut
+
+sub _run_with_capture {
+  my ($class, $app, $argv) = @_;
+
+  my $run_rv;
+
+  my ($stdout, $stderr, $ok) = capture {
+    eval {
+      local $Dancer2::Bundled::App::Cmd::Tester::TEST_IN_PROGRESS = 1;
+      local @ARGV = @$argv;
+      $run_rv = $app->run;
+      1;
+    };
+  };
+
+  my $error = $ok ? undef : $@;
+
+  return {
+    stdout => $stdout,
+    stderr => $stderr,
+    output => $stdout . $stderr,
+    error  => $error,
+    run_rv => $run_rv,
+  };
+}
+
+1;
+
+__END__
+
+=pod
+
+=encoding UTF-8
+
+=head1 NAME
+
+Dancer2::Bundled::App::Cmd::Tester::CaptureExternal - Extends Dancer2::Bundled::App::Cmd::Tester to capture from external subprograms
+
+=head1 VERSION
+
+version 0.331
+
+=head1 SYNOPSIS
+
+  use Test::More tests => 4;
+  use Dancer2::Bundled::App::Cmd::Tester::CaptureExternal;
+
+  use YourApp;
+
+  my $result = test_app(YourApp => [ qw(command --opt value) ]);
+
+  like($result->stdout, qr/expected output/, 'printed what we expected');
+
+  is($result->stderr, '', 'nothing sent to sderr');
+
+  ok($result->output, "STDOUT concatenated with STDERR");
+
+=head1 DESCRIPTION
+
+L<Dancer2::Bundled::App::Cmd::Tester> provides a useful scaffold for testing applications, but it
+is unable to capture output generated from any external subprograms that are
+invoked from the application.
+
+This subclass uses an alternate mechanism for capturing output
+(L<Capture::Tiny>) that does capture from external programs, with one
+major limitation.
+
+It is not possible to capture externally from both STDOUT and STDERR while
+also having appropriately interleaved combined output.  Therefore, the
+C<output> from this subclass simply concatenates the two.
+
+You can still use C<output> for testing if there is any output at all or for
+testing if something appeared in either output stream, but you can't rely on
+the ordering being correct between lines to STDOUT and lines to STDERR.
+
+=head1 AUTHOR
+
+Ricardo Signes <rjbs@cpan.org>
+
+=head1 COPYRIGHT AND LICENSE
+
+This software is copyright (c) 2016 by Ricardo Signes.
+
+This is free software; you can redistribute it and/or modify it under
+the same terms as the Perl 5 programming language system itself.
+
+=cut

--- a/lib/Dancer2/CLI.pm
+++ b/lib/Dancer2/CLI.pm
@@ -3,6 +3,6 @@ package Dancer2::CLI;
 
 use strict;
 use warnings;
-use App::Cmd::Setup -app;
+use Dancer2::Bundled::App::Cmd::Setup -app;
 
 1;

--- a/lib/Dancer2/CLI/Command/gen.pm
+++ b/lib/Dancer2/CLI/Command/gen.pm
@@ -4,7 +4,7 @@ package Dancer2::CLI::Command::gen;
 use strict;
 use warnings;
 
-use App::Cmd::Setup -command;
+use Dancer2::Bundled::App::Cmd::Setup -command;
 
 use HTTP::Tiny;
 use File::Find;

--- a/lib/Dancer2/CLI/Command/version.pm
+++ b/lib/Dancer2/CLI/Command/version.pm
@@ -3,7 +3,7 @@ package Dancer2::CLI::Command::version;
 
 use strict;
 use warnings;
-use App::Cmd::Setup -command;
+use Dancer2::Bundled::App::Cmd::Setup -command;
 use Module::Runtime 'require_module';
 
 sub description { 'Display version of Dancer2' }


### PR DESCRIPTION
See #1602 - App::Cmd > 0.331 depends on much newer perl versions, we've always supported older perls where practical, and we shouldn't suddenly pull the rug out from under our users on older perls trying to install Dancer2.