### PR TITLE
Remove App::Cmd dep and have script/dancer2 bail if it's not installed

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -1,4 +1,3 @@
-requires 'App::Cmd::Setup';
 requires 'Attribute::Handlers';
 requires 'Carp';
 requires 'Clone';

--- a/lib/Dancer2/CLI.pm
+++ b/lib/Dancer2/CLI.pm
@@ -3,6 +3,17 @@ package Dancer2::CLI;
 
 use strict;
 use warnings;
+
+BEGIN {
+    eval {
+        require App::Cmd::Setup;
+        1; 
+    } or do {
+        warn "ERROR: You need to install App::Cmd first to use this tool";
+        exit;
+    }
+}
+
 use App::Cmd::Setup -app;
 
 1;

--- a/lib/Dancer2/CLI.pm
+++ b/lib/Dancer2/CLI.pm
@@ -9,7 +9,21 @@ BEGIN {
         require App::Cmd::Setup;
         1; 
     } or do {
-        warn "ERROR: You need to install App::Cmd first to use this tool";
+        warn <<INSTALLAPPCMD;
+ERROR: You need to install App::Cmd first to use this tool.
+
+You can do so using your preferred module installation method, for instance;
+
+  # using cpanminus
+  cpanm App::Cmd
+  # or using CPAN.pm
+  cpan App::Cmd
+  
+For more detailed instructions, see http://www.cpan.org/modules/INSTALL.html
+
+Without App::Cmd, the `dancer2` app minting tool cannot be used, but Dancer2
+can still be used for existing apps.
+INSTALLAPPCMD
         exit;
     }
 }


### PR DESCRIPTION
The other approach discussed on #1602 - just removing the dependency on App::Cmd, so people using older perls can still install Dancer2, and have the `dancer2` minting tool exit with an explanatory message if the user doesn't have App::Cmd installed.

Leaves D2 installable for everyone, but with the minting tool not working until they install App::Cmd (until such time as we've replaced our use of that with e.g. MooX::Options).

This is an alternative approach to #1602 and #1603 - I'd expect only one of the PRs to be merged, depending on which we pick.