### PR TITLE
Fix broken tests following App::Cmd removal

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -28,6 +28,8 @@ add_files_in = README.mkdn
 -remove = AutoPrereqs
 -remove = GithubMeta
 -remove = ModuleBuild
+; Don't add CLI files to the auto-generated test
+test_compile_skip = ^Dancer2::CLI
 
 [DynamicPrereqs]
 ; GH#1332 if old HTTP::XSCookies is installed we need to upgrade

--- a/dist.ini
+++ b/dist.ini
@@ -28,7 +28,8 @@ add_files_in = README.mkdn
 -remove = AutoPrereqs
 -remove = GithubMeta
 -remove = ModuleBuild
-; Don't add CLI files to the auto-generated test
+; Don't add CLI files to the auto-generated test.
+; TODO: Remove this when GH #1319 is finished.
 test_compile_skip = ^Dancer2::CLI
 
 [DynamicPrereqs]

--- a/t/cli.t
+++ b/t/cli.t
@@ -2,6 +2,8 @@ use strict;
 use warnings;
 use Test::More;
 
+# TODO: Remove this test when GH #1319 is done.
+# This test is intended to be temporary until then.
 eval { require App::Cmd::Setup; 1; }
     or plan skip_all => 'App::Cmd::Setup required for this test';
 

--- a/t/cli.t
+++ b/t/cli.t
@@ -1,0 +1,11 @@
+use strict;
+use warnings;
+use Test::More;
+
+eval { require App::Cmd::Setup; 1; }
+    or plan skip_all => 'App::Cmd::Setup required for this test';
+
+plan tests => 3;
+use_ok 'Dancer2::CLI';
+use_ok 'Dancer2::CLI::Command::gen';
+use_ok 'Dancer2::CLI::Command::version';


### PR DESCRIPTION
The `Test::Compile` plugin to `Dist::Zilla` tries to build a compile test with all of our modules, except now that we have removed the requirement for `App::Cmd::Setup`, `App::Cmd::Setup` might not be installed, and our test suite fails. This PR addresses the problem in two ways:

* Excludes the `Dancer2::CLI` namespace from the automatic compile test generation

* Builds a compiles test specifically for the CLI that skips all if `App::Cmd::Setup` is not installed