### PR TITLE
Bugfix/1611 redirect forwardslash

### DIFF
--- a/lib/Dancer2/Core/App.pm
+++ b/lib/Dancer2/Core/App.pm
@@ -1275,7 +1275,7 @@ sub redirect {
     my $destination = shift;
     my $status      = shift;
 
-    if ($destination =~ m{^/[^/]}) {
+    if ($destination =~ m{^/(?!/)}) {
         # If the app is mounted to something other than "/", we must
         # preserve its path.
         my $script_name = $self->request->script_name;

--- a/t/issues/gh-1564.t
+++ b/t/issues/gh-1564.t
@@ -12,6 +12,7 @@ use HTTP::Request::Common;
     package App;
     use Dancer2;
 
+    get '/root' => sub { redirect '/'; };
     get '/leading_slash' => sub { redirect '/expected'; };
     get '/relative' => sub { redirect 'expected'; };
     get '/relative/one-dot' => sub { redirect './expected'; };
@@ -25,6 +26,12 @@ my $app = builder {
     mount '/other-mount-point' => App->to_app();
 };
 
+my @leading_slash_tests = (
+    # the expected result (last element) needs the mount prepended in the actual tests
+    [ 'Relative with leading slash', '/leading_slash', '/expected' ],
+    [ 'Relative root', '/root', '/' ],  # Test for issue #1611
+);
+
 my @common_tests = (
     [ 'Relative redirect', '/relative', 'expected' ],
     [ 'Relative redirect with ./', '/relative/one-dot', './expected' ],
@@ -34,18 +41,24 @@ my @common_tests = (
 );
 
 subtest 'Testing app mounted to /' => sub {
+    my $mount = '';
+
     test_psgi $app, sub {
         my $cb = shift;
 
-        subtest 'Redirecting with a leading slash' => sub {
-            my $res = $cb->( GET '/leading_slash' );
-            is($res->code, 302, 'Correct code');
-            is(
-                $res->headers->header('Location'),
-                '/expected',
-                'Correct location header'
-            );
-        };
+        for my $test (@leading_slash_tests) {
+            my ($name, $url, $expected) = @$test;
+            subtest $name => sub {
+                my $res = $cb->( GET $url );
+                is($res->code, 302, 'Correct code');
+                is(
+                    $res->headers->header('Location'),
+                    $mount . $expected,
+                    'Correct location header'
+                );
+            }
+        }
+
         foreach my $test (@common_tests) {
             my ($name, $url, $expected) = @$test;
             subtest $name => sub {
@@ -62,21 +75,28 @@ subtest 'Testing app mounted to /' => sub {
 };
 
 subtest 'Testing app mounted to /other-mount-point' => sub {
+    my $mount = '/other-mount-point';
+
     test_psgi $app, sub {
         my $cb = shift;
 
-        subtest 'Redirecting with a leading slash' => sub {
-            my $res = $cb->( GET '/other-mount-point/leading_slash' );
-            is($res->code, 302, 'Correct code');
-            is(
-                $res->headers->header('Location'),
-                '/other-mount-point/expected',
-                'Correct location header'
-            );
-        };
+        for my $test (@leading_slash_tests) {
+            my ($name, $url, $expected) = @$test;
+            $url = "$mount$url";
+            subtest $name => sub {
+                my $res = $cb->( GET $url );
+                is($res->code, 302, 'Correct code');
+                is(
+                    $res->headers->header('Location'),
+                    "$mount$expected",  # scriptname prepended to redirect path
+                    'Correct location header'
+                );
+            }
+        }
+
         foreach my $test (@common_tests) {
             my ($name, $url, $expected) = @$test;
-            $url = "other-mount-point$url";
+            $url = "$mount$url";
             subtest $name => sub {
                 my $res = $cb->( GET $url );
                 is($res->code, 302, 'Correct code');


### PR DESCRIPTION
Consistent behaviour for `redirect '/'` and `redirect '/any/path/beginning/with/single/slash` when mounted on a non-root path. Both will get the scriptname prepended to the Location header path.

This uses @gurnec's fix from #1611, with added tests.

Resolves #1611.