### PR TITLE
Provide a consistent list of community resources

### DIFF
--- a/lib/Dancer2/CLI/Gen.pm
+++ b/lib/Dancer2/CLI/Gen.pm
@@ -194,6 +194,8 @@ To access your application, point your browser to http://localhost:5000
 
 If you need community assistance, the following resources are available:
 - Dancer website: http://perldancer.org
+- Twitter: https://twitter.com/PerlDancer/
+- GitHub: https://github.com/PerlDancer/Dancer2/
 - Mailing list: http://lists.perldancer.org/mailman/listinfo/dancer-users
 - IRC: irc.perl.org#dancer
 

--- a/share/skel/views/index.tt
+++ b/share/skel/views/index.tt
@@ -17,9 +17,11 @@
             <h3>Join the community</h3>
             <ul class="links">
 
-              <li><a href="http://perldancer.org/">PerlDancer</a></li>
-              <li><a href="http://twitter.com/PerlDancer/">Official Twitter</a></li>
+              <li><a href="https://perldancer.org/">PerlDancer Website</a></li>
+              <li><a href="https://twitter.com/PerlDancer/">Official Twitter</a></li>
               <li><a href="https://github.com/PerlDancer/Dancer2/">GitHub Community</a></li>
+              <li><a href="http://lists.perldancer.org/mailman/listinfo/dancer-users">Mailing List</a></li>
+              <li><a href="irc://irc.perl.org/dancer">IRC</a></li>
             </ul>
           </li>
 
@@ -33,6 +35,7 @@
               <li><a
               href="https://metacpan.org/pod/Dancer2::Tutorial"
               title="a tutorial to build a small blog engine with Dancer">Tutorial</a></li>
+              <li><a href="https://metacpan.org/pod/Dancer2::Manual::Deployment">Deployment</a></li>
             </ul>
           </li>
 


### PR DESCRIPTION
When generating a new app, the command line output and the links to community resources in the generated app should match. This makes the list of community resources consistent between the two.

Also added the deployment manual to the list of documentation in the generated app.