### PR TITLE
Clarify D2::Template::Simple's role in life

### DIFF
--- a/lib/Dancer2/Template/Simple.pm
+++ b/lib/Dancer2/Template/Simple.pm
@@ -153,15 +153,14 @@ To use this engine, you may configure L<Dancer2> via C<config.yaml>:
 
 =head1 DESCRIPTION
 
-This template engine is provided as a default one for the Dancer2 micro
-framework.
+This template engine is primarily to serve as a migration path for users of 
+L<Dancer>. This should be fine for development purposes, but you would be 
+better served by using L<Dancer2::Template::TemplateToolkit> or one of the
+many alternatives available on CPAN to power an application with Dancer2 
+in production environment. 
 
-This template engine should be fine for development purposes but is not a
-powerful one, it's written in pure Perl and has no C bindings to accelerate the
-template processing.
-
-If you want to power an application with Dancer2 in production environment, it's
-strongly advised to switch to L<Dancer2::Template::TemplateToolkit>.
+C<Dancer2::Template::Simple> is written in pure Perl and has no C bindings 
+to accelerate the template processing.
 
 =head1 SYNTAX
 

--- a/lib/Dancer2/Template/Simple.pm
+++ b/lib/Dancer2/Template/Simple.pm
@@ -154,7 +154,7 @@ To use this engine, you may configure L<Dancer2> via C<config.yaml>:
 =head1 DESCRIPTION
 
 This template engine is primarily to serve as a migration path for users of 
-L<Dancer>. This should be fine for development purposes, but you would be 
+L<Dancer>. It should be fine for development purposes, but you would be 
 better served by using L<Dancer2::Template::TemplateToolkit> or one of the
 many alternatives available on CPAN to power an application with Dancer2 
 in production environment. 


### PR DESCRIPTION
This is one thing to come out of #1615. Got me to thinking about why we have two template systems in core when we really want to steer devs to other template engines.

After talking with @SysPete and @veryrusty, it was decided we should update the pod here to clarify what role `Dancer2::Template::Simple` fills, and to consider splitting `Dancer2::Template::Tiny` to another distribution.