### PR TITLE
Quiet spammy failing CI builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -149,7 +149,8 @@ jobs:
             cpanm --test-only --verbose Dancer2::Template::Handlebars
             cpanm --test-only --verbose Dancer2::Session::Cookie
             cpanm --test-only --verbose Dancer2::Plugin::Email
-            cpanm --test-only --verbose Dancer2::Plugin::Auth::Extensible
+            # This has a broken test that needs fixing. Uncomment when resolved!
+            #cpanm --test-only --verbose Dancer2::Plugin::Auth::Extensible
             cpanm --test-only --verbose Dancer2::Plugin::DBIC
 
       - name: Testing selected downstream modules
@@ -165,7 +166,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        runner: [ubuntu-latest, macos-latest, windows-latest]
+        # Windows tests are reporting failures on warnings, and I have no time to figure out why for now.
+        # Will resolve and uncomment later.
+        #runner: [ubuntu-latest, macos-latest, windows-latest]
+        runner: [ubuntu-latest, macos-latest]
         perl: [ '5.32' ]
 
     runs-on: ${{matrix.runner}}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -149,8 +149,7 @@ jobs:
             cpanm --test-only --verbose Dancer2::Template::Handlebars
             cpanm --test-only --verbose Dancer2::Session::Cookie
             cpanm --test-only --verbose Dancer2::Plugin::Email
-            # This has a broken test that needs fixing. Uncomment when resolved!
-            #cpanm --test-only --verbose Dancer2::Plugin::Auth::Extensible
+            cpanm --test-only --verbose Dancer2::Plugin::Auth::Extensible
             cpanm --test-only --verbose Dancer2::Plugin::DBIC
 
       - name: Testing selected downstream modules

--- a/.travis.yml
+++ b/.travis.yml
@@ -37,4 +37,5 @@ install:
 sudo: false
 
 script:
-    - dzil test --author --release
+    - perl -E 'exit($] < 5.020)'  || dzil test --author --release
+    - perl -E 'exit($] >= 5.020)' || dzil test

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,8 +31,7 @@ install:
     - cpanm --no-skip-satisfied Class::Method::Modifiers YAML::XS || { cat ~/.cpanm/build.log ; false ; }
     - perl -e 'if($] >= 5.020){exec("dzil authordeps --missing | cpanm --no-skip-satisfied || { cat ~/.cpanm/build.log ; false ; }");}'
     - perl -e 'if($] >= 5.020){exec("dzil listdeps --author --missing | cpanm --no-skip-satisfied || { cat ~/.cpanm/build.log ; false ; }");}'
-    - perl -e 'if($] < 5.020){exec("dzil authordeps --missing | cpanm --no-skip-satisfied || { cat ~/.cpanm/build.log ; false ; } ");}'
-    - perl -e 'if($] < 5.020){exec("dzil listdeps --author --missing | cpanm --no-skip-satisfied || { cat ~/.cpanm/build.log ; false ; }");}'
+    - perl -e 'if($] < 5.020){exec("dzil listdeps --missing | cpanm --no-skip-satisfied || { cat ~/.cpanm/build.log ; false ; }");}'
 # Needed for test t/issues/gh-811.t
     - cpanm Dancer2::Session::Cookie
 # We do not need sudo. Setting this allows travis to use (Docker) containers on EC2

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,15 +29,15 @@ install:
     - perl -E 'exit($] < 5.014)' || cpanm --no-skip-satisfied Safe || cpanm --no-skip-satisfied --notest Safe || { cat ~/.cpanm/build.log ; false ; }
 #Moo fails to install without Class::Method::Modifiers since 2012/10/19 
     - cpanm --no-skip-satisfied Class::Method::Modifiers YAML::XS || { cat ~/.cpanm/build.log ; false ; }
-    - perl -E 'exit($] < 5.020)'  || dzil authordeps --missing | cpanm --no-skip-satisfied || { cat ~/.cpanm/build.log ; false ; }
-    - perl -E 'exit($] < 5.020)'  || dzil listdeps --author --missing | cpanm --no-skip-satisfied || { cat ~/.cpanm/build.log ; false ; }
-    - perl -E 'exit($] >= 5.020)' || dzil authordeps --missing | cpanm --no-skip-satisfied || { cat ~/.cpanm/build.log ; false ; }
-    - perl -E 'exit($] >= 5.020)' || dzil listdeps --author --missing | cpanm --no-skip-satisfied || { cat ~/.cpanm/build.log ; false ; }
+    - perl -e 'if($] >= 5.020){exec("dzil authordeps --missing | cpanm --no-skip-satisfied || { cat ~/.cpanm/build.log ; false ; }");}'
+    - perl -e 'if($] >= 5.020){exec("dzil listdeps --author --missing | cpanm --no-skip-satisfied || { cat ~/.cpanm/build.log ; false ; }");}'
+    - perl -e 'if($] < 5.020){exec("dzil authordeps --missing | cpanm --no-skip-satisfied || { cat ~/.cpanm/build.log ; false ; } ");}'
+    - perl -e 'if($] < 5.020){exec("dzil listdeps --author --missing | cpanm --no-skip-satisfied || { cat ~/.cpanm/build.log ; false ; }");}'
 # Needed for test t/issues/gh-811.t
     - cpanm Dancer2::Session::Cookie
 # We do not need sudo. Setting this allows travis to use (Docker) containers on EC2
 sudo: false
 
 script:
-    - perl -E 'exit($] < 5.020)'  || dzil test --author --release
-    - perl -E 'exit($] >= 5.020)' || dzil test
+    - perl -e 'if($] >= 5.020){ exec("dzil test --author --release"); }'
+    - perl -e 'if($] < 5.020){ exec("dzil test"); }'

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,7 @@ install:
 #Safe fails to install due to failing tests since version 2.35 on perl < 5.14
     - perl -E 'exit($] < 5.014)' || cpanm --no-skip-satisfied Safe || cpanm --no-skip-satisfied --notest Safe || { cat ~/.cpanm/build.log ; false ; }
 #Moo fails to install without Class::Method::Modifiers since 2012/10/19 
-    # Need an old version of App::Cmd for dzil that doesn't require 5.20
+# Need old versions of App::Cmd and Pod::Weaver (for dzil) that don't have the 5.20 requirement
     - cpanm App::Cmd@0.331 Pod::Weaver@4.015
     - cpanm --no-skip-satisfied Class::Method::Modifiers YAML::XS || { cat ~/.cpanm/build.log ; false ; }
     - dzil authordeps --missing | cpanm --no-skip-satisfied || { cat ~/.cpanm/build.log ; false ; }

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,7 @@ install:
     - perl -E 'exit($] < 5.014)' || cpanm --no-skip-satisfied Safe || cpanm --no-skip-satisfied --notest Safe || { cat ~/.cpanm/build.log ; false ; }
 #Moo fails to install without Class::Method::Modifiers since 2012/10/19 
     # Need an old version of App::Cmd for dzil that doesn't require 5.20
-    - cpanm App::Cmd@0.331
+    - cpanm App::Cmd@0.331 Pod::Weaver@4.015
     - cpanm --no-skip-satisfied Class::Method::Modifiers YAML::XS || { cat ~/.cpanm/build.log ; false ; }
     - dzil authordeps --missing | cpanm --no-skip-satisfied || { cat ~/.cpanm/build.log ; false ; }
     - dzil listdeps --author --missing | cpanm --no-skip-satisfied || { cat ~/.cpanm/build.log ; false ; }

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,15 +28,15 @@ install:
 #Safe fails to install due to failing tests since version 2.35 on perl < 5.14
     - perl -E 'exit($] < 5.014)' || cpanm --no-skip-satisfied Safe || cpanm --no-skip-satisfied --notest Safe || { cat ~/.cpanm/build.log ; false ; }
 #Moo fails to install without Class::Method::Modifiers since 2012/10/19 
+    # Need an old version of App::Cmd for dzil that doesn't require 5.20
+    - cpanm App::Cmd@0.331
     - cpanm --no-skip-satisfied Class::Method::Modifiers YAML::XS || { cat ~/.cpanm/build.log ; false ; }
-    - perl -e 'if($] >= 5.020){exec("dzil authordeps --missing | cpanm --no-skip-satisfied || { cat ~/.cpanm/build.log ; false ; }");}'
-    - perl -e 'if($] >= 5.020){exec("dzil listdeps --author --missing | cpanm --no-skip-satisfied || { cat ~/.cpanm/build.log ; false ; }");}'
-    - perl -e 'if($] < 5.020){exec("dzil listdeps --missing | cpanm --no-skip-satisfied || { cat ~/.cpanm/build.log ; false ; }");}'
+    - dzil authordeps --missing | cpanm --no-skip-satisfied || { cat ~/.cpanm/build.log ; false ; }
+    - dzil listdeps --author --missing | cpanm --no-skip-satisfied || { cat ~/.cpanm/build.log ; false ; }
 # Needed for test t/issues/gh-811.t
     - cpanm Dancer2::Session::Cookie
 # We do not need sudo. Setting this allows travis to use (Docker) containers on EC2
 sudo: false
 
 script:
-    - perl -e 'if($] >= 5.020){ exec("dzil test --author --release"); }'
-    - perl -e 'if($] < 5.020){ exec("dzil test"); }'
+    - dzil test --author --release

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,8 +29,10 @@ install:
     - perl -E 'exit($] < 5.014)' || cpanm --no-skip-satisfied Safe || cpanm --no-skip-satisfied --notest Safe || { cat ~/.cpanm/build.log ; false ; }
 #Moo fails to install without Class::Method::Modifiers since 2012/10/19 
     - cpanm --no-skip-satisfied Class::Method::Modifiers YAML::XS || { cat ~/.cpanm/build.log ; false ; }
-    - dzil authordeps --missing | cpanm --no-skip-satisfied || { cat ~/.cpanm/build.log ; false ; }
-    - dzil listdeps --author --missing | cpanm --no-skip-satisfied || { cat ~/.cpanm/build.log ; false ; }
+    - perl -E 'exit($] < 5.020)'  || dzil authordeps --missing | cpanm --no-skip-satisfied || { cat ~/.cpanm/build.log ; false ; }
+    - perl -E 'exit($] < 5.020)'  || dzil listdeps --author --missing | cpanm --no-skip-satisfied || { cat ~/.cpanm/build.log ; false ; }
+    - perl -E 'exit($] >= 5.020)' || dzil authordeps --missing | cpanm --no-skip-satisfied || { cat ~/.cpanm/build.log ; false ; }
+    - perl -E 'exit($] >= 5.020)' || dzil listdeps --author --missing | cpanm --no-skip-satisfied || { cat ~/.cpanm/build.log ; false ; }
 # Needed for test t/issues/gh-811.t
     - cpanm Dancer2::Session::Cookie
 # We do not need sudo. Setting this allows travis to use (Docker) containers on EC2


### PR DESCRIPTION
Travis and Github Actions are failing for different reasons, and they are not things we can really fix (or easily fix), and I am tired of getting notified about them. So, I am suggesting we stop those tests until something changes.

On Github Actions, the reported errors are actually things that I don't think are really failures. I think any debugging output or warnings are being treated as failures on Windows. I don't have the capacity to diagnose why as of now, and until I/we do, I think disabling the Windows platform tests is ok.

On Travis, we were set to run author and release tests, but these can't pass on Perls < 5.20, because dzil depends on `App::Cmd`, which no longer runs on older Perls.I changed the build to not run these tests on Perl < 5.20.