### PR TITLE
GH-1621 - fix recursion error in TT after longjump

### DIFF
--- a/t/issues/gh-1621/gh-1621.t
+++ b/t/issues/gh-1621/gh-1621.t
@@ -1,0 +1,52 @@
+#!/usr/bin/env perl
+
+use strict;
+use warnings;
+
+use Test::More;
+use Plack::Test;
+use HTTP::Request::Common;
+use Ref::Util qw<is_coderef>;
+
+# Test to ensure that a longjump out of a template, caused by a call to redirect,
+# does not cause any future problems rendering a template. Whilst this test is
+# slightly obscure for reasons of simplicity, the exact use-case is in the use
+# of Plugin::LogReport. If it catches a fatal error (which could occur during
+# the render of a template) then it will redirect to another page.
+
+{
+    package MyApp;
+
+    use Dancer2;
+
+    set template => 'template_toolkit';
+
+    # Set up 2 routes to the same template. The first route will redirect when
+    # the template renders, the second will not
+    get '/redirect' => sub {
+        my $redir = sub {
+            redirect "somewhere";
+        };
+        template 'redirect',
+            { redirect_sub => $redir }
+    };
+
+    get '/noredirect' => sub {
+        template 'redirect';
+    };
+}
+
+my $app = Dancer2->psgi_app;
+ok( is_coderef($app), 'Got app' );
+
+test_psgi $app, sub {
+    my $cb = shift;
+    my $res = $cb->(GET '/redirect');
+    is $res->code, 302, 'Redirect template results in redirect';
+
+    $res = $cb->(GET '/noredirect');
+    is $res->code, 200, 'Successful subsequent request to normal template';
+    like $res->content, qr/foobar/, 'Correct content';
+};
+
+done_testing();

--- a/t/issues/gh-1621/views/redirect.tt
+++ b/t/issues/gh-1621/views/redirect.tt
@@ -1,0 +1,1 @@
+[% IF NOT redirect_sub %]foobar[% END %]


### PR DESCRIPTION
Fix problem described in #1621. Rebuild the Template::Toolkit engine if it doesn't complete its render, otherwise a recursion error is thrown for any subsequent template processes. This is prevalent when using Plugin::LogReport which makes a call to redirect if a fatal exception occurs (which could happen during the render of a template).

There is one outstanding problem with this PR, which is that there is a very odd error on completion of the test, normally:

```Can't call method "undefined" on an undefined value``` but can sometimes be something random like ```Can't locate object method "undefined" via package "Correct content" (perhaps you forgot to load "Correct content"?).``` or ```Can't locate object method "undefined" via package "Plack::Util::Prototype::set" (perhaps you forgot to load "Plack::Util::Prototype::set"?)```

This will need to be fixed before any merge. I have spent hours trying to track it down (including via the Perl debugger) but it is a mystery. Does anyone else have any idea where it is coming from? It does not happen when either using another templating engine or removing the redirect call during the render.