### PR TITLE
Copy Dockerfile from the right spot

### DIFF
--- a/lib/Dancer2/CLI/Gen.pm
+++ b/lib/Dancer2/CLI/Gen.pm
@@ -149,7 +149,7 @@ sub run {
     }
 
     if( $self->docker ) {
-        push @$files_to_copy, [ path( $self->skel, 'docker/Dockerfile' ), "$app_name/Dockerfile" ];
+        push @$files_to_copy, [ path( $self->parent_command->_dist_dir, 'docker/Dockerfile' ), "$app_name/Dockerfile" ];
     }
 
     my $vars = {


### PR DESCRIPTION
I tested this on a different machine than I developed on prior to release, and had some cruft that masked a bug when adding a Dockerfile to a new application. The dockerfile is located off of the dist dir, not off of the skel dir. This minor fix changes that.

I consider this a blocker for the release. Please review ASAP.