### PR TITLE
Proposal: Set minimum Perl to 5.10.1

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -1,3 +1,4 @@
+requires 'perl', 5.010001;
 requires 'Attribute::Handlers';
 requires 'Carp';
 requires 'Clone';

--- a/lib/Dancer2.pm
+++ b/lib/Dancer2.pm
@@ -2,6 +2,7 @@ package Dancer2;
 
 # ABSTRACT: Lightweight yet powerful web application framework
 
+use 5.10.1;
 use strict;
 use warnings;
 use List::Util 'first';

--- a/lib/Dancer2/Core/Route.pm
+++ b/lib/Dancer2/Core/Route.pm
@@ -95,12 +95,8 @@ sub match {
     return unless @values;
 
     # if some named captures are found, return captures
-    # no warnings is for perl < 5.10
     # - Note no @values implies no named captures
-    if (my %captures =
-        do { no warnings; %+ }
-      )
-    {
+    if (my %captures = %+ ) {
         return $self->_match_data( { captures => \%captures } );
     }
 

--- a/lib/Dancer2/Manual.pod
+++ b/lib/Dancer2/Manual.pod
@@ -337,7 +337,7 @@ must be defined explicitly with C<qr{}>, like the following:
         return "Hello $name";
     };
 
-For Perl 5.10+, a route regex may use named capture groups. The C<captures>
+A route regex may use named capture groups. The C<captures>
 keyword will return a reference to a copy of C<%+>.
 
 =head3 Conditional Matching

--- a/lib/Dancer2/Manual/Keywords.pod
+++ b/lib/Dancer2/Manual/Keywords.pod
@@ -58,9 +58,6 @@ Returns a L<Hash::MultiValue> object from the body parameters.
 Returns a reference to a copy of C<%+>, if there are named captures in the
 route's regular expression.
 
-Named captures are a feature of Perl 5.10, and are not supported in earlier
-versions:
-
     get qr{
         / (?<object> user   | ticket | comment )
         / (?<action> delete | find )

--- a/t/classes/Dancer2-Core-Route/deprecated_param_keys.t
+++ b/t/classes/Dancer2-Core-Route/deprecated_param_keys.t
@@ -16,9 +16,7 @@ like(
     'Find deprecation of :splat',
 );
 
-SKIP: {
-    skip 'Need perl >= 5.10', 1 unless $] >= 5.010;
-    like(
+like(
         capture_stderr {
             Dancer2::Core::Route->new(
                 regexp => '/:captures',
@@ -28,7 +26,6 @@ SKIP: {
         },
         qr{^Named placeholder 'captures' is deprecated},
         'Find deprecation of :captures',
-    );
-}
+);
 
 done_testing;

--- a/t/classes/Dancer2-Core-Route/match.t
+++ b/t/classes/Dancer2-Core-Route/match.t
@@ -180,9 +180,7 @@ for my $t (@tests) {
     }
 }
 
-# captures test
-SKIP: {
-    skip "Need perl >= 5.10", 1 unless $] >= 5.010;
+subtest "named captures" => sub {
 
     ## Regexp is parsed in compile time. So, eval with QUOTES to force to parse later.
     my $route_regex;
@@ -220,7 +218,7 @@ SKIP: {
         }
       },
       "named captures work";
-}
+};
 
 note "routes with options"; {
     my $route_w_options = Dancer2::Core::Route->new(

--- a/t/disp_named_capture.t
+++ b/t/disp_named_capture.t
@@ -22,12 +22,8 @@ my $response = $test->request( $request );
 is( $response->content, 1 );
 
 # "Dummy" regex to populate global $+
-# eval'd as named captures are not available until 5.10
-my $c;
-eval <<'NAMED';
 "12345" =~ m#(?<capture>23)#;
-$c = $+{capture};
-NAMED
+my $c = $+{capture};
 
 $request  = HTTP::Request->new( GET => 'http://localhost/2' );
 $response = $test->request( $request );

--- a/t/dsl/parameters.t
+++ b/t/dsl/parameters.t
@@ -347,11 +347,7 @@ subtest 'Captured route parameters' => sub {
     }
 };
 
-SKIP: {
-    Test::More::skip "named captures not available until 5.10", 1
-      if !$^V or $^V lt v5.10;
-
-    subtest 'Named captured route parameters' => sub {
+subtest 'Named captured route parameters' => sub {
         {
             package App::Route::NamedCapture; ## no critic
             use Dancer2;
@@ -391,6 +387,6 @@ SKIP: {
             my $res = $app->request( GET '/bar/quux' );
             ok( $res->is_success, 'Successful request' );
         };
-    };
 };
+
 done_testing();


### PR DESCRIPTION
We can no longer install on 5.8 due to upstream dependencies, so I think it is time to admit defeat and bump our min dep. This also allows us to use defined-or and state variables.

Changes:
- use 5.10.1 in Dancer.pm
- add 5.10.1 dep to cpanfile
- remove all mentions of 5.10 from docs when describing named captures
- remove special-casing in code and tests for < 5.10