### PR TITLE
Replace strings in Dancer2 config with environment variables

### DIFF
--- a/lib/Dancer2/Core/Role/ConfigReader.pm
+++ b/lib/Dancer2/Core/Role/ConfigReader.pm
@@ -232,6 +232,9 @@ sub load_config_file {
     }
 
     # TODO handle mergeable entries
+
+    $self->_replace_env_vars($config);
+
     return $config;
 }
 
@@ -273,6 +276,48 @@ sub _compile_config_entry {
     defined $trigger or return $value;
 
     return $trigger->( $self, $value, $config );
+}
+
+# Attn. We are traversing along the original data structure all the time,
+# using references, and changing values on the spot, not returning anything.
+sub _replace_env_vars {
+    my ( $self, $entry ) = @_;
+    if( ref $entry ne 'HASH' && ref $entry ne 'ARRAY' ) {
+        croak 'Param entry is not HASH or ARRAY';
+    }
+    if( ref $entry eq 'HASH' ) {
+        foreach my $value (values %{ $entry }) {
+            if( (ref $value) =~ m/(HASH|ARRAY)/msx ) {
+                $self->_replace_env_vars( $value );
+            } elsif( (ref $value) =~ m/(CODE|REF|GLOB)/msx ) {
+                # Pretty much anything else except SCALAR. Do nothing
+                1;
+            } else {
+                if( $value ) {
+                    while( my ($k, $v) = each %ENV) {
+                        $value =~ s/ \$ [{] ENV:$k [}] /$v/gmsx;
+                    }
+                }
+            }
+        }
+    } else {
+        # ref $entry is 'ARRAY'
+        foreach my $value (@{ $entry }) {
+            if( (ref $value) =~ m/(HASH|ARRAY)/msx ) {
+                $self->_replace_env_vars( $value );
+            } elsif( (ref $value) =~ m/(CODE|REF|GLOB)/msx ) {
+                # Pretty much anything else except SCALAR. Do nothing
+                1;
+            } else {
+                if( $value ) {
+                    while( my ($k, $v) = each %ENV) {
+                        $value =~ s/ \$ [{] ENV:$k [}] /$v/gmsx;
+                    }
+                }
+            }
+        }
+    }
+    return;
 }
 
 1;

--- a/lib/Dancer2/Core/Role/ConfigReader.pm
+++ b/lib/Dancer2/Core/Role/ConfigReader.pm
@@ -233,7 +233,10 @@ sub load_config_file {
 
     # TODO handle mergeable entries
 
-    $self->_replace_env_vars($config);
+    if( defined $config->{'env_var_replace'} && $config->{'env_var_replace'} ) {
+        warn "Apply environment variables to config\n" if $ENV{DANCER_CONFIG_VERBOSE};
+        $self->_replace_env_vars($config);
+    }
 
     return $config;
 }


### PR DESCRIPTION
Ref #1628 

What this PR changes?

1) After reading the whole config from different files, it traverses the whole tree and if it sees a string with a substring like "${ENV:SOME_ENV}", it changes it to the corresponding environment variable, if that environment variable is defined.
2) Before doing 1), it checks if the config item "env_var_replace" is defined and is boolean true. If so, then it executes 1). Otherwise it skips. This is to maintain backwards compatibility.
3) Unit tests included.

I am using this solution in my build and web application.
