### PR TITLE
Fix CI push setting to run on branches with / in the name

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: CI
 
 on:
   push:
-    branches: '*'
+    branches: '**'
   pull_request:
-    branches: '*'
+    branches: '**'
   schedule:
     - cron: '42 5 * * *'
 


### PR DESCRIPTION
Copied the setting from Dancer2 to an another repository and wondered why the CI action would only trigger on master branch :zany_face: 