### PR TITLE
Bugfix/route matches

### DIFF
--- a/lib/Dancer2/Core/Route.pm
+++ b/lib/Dancer2/Core/Route.pm
@@ -114,28 +114,30 @@ sub match {
         my @splat;
         for ( my $i = 0; $i < @values; $i++ ) {
             # Is this value from a token?
-            if ( $token_or_splat[$i] eq 'typed_token' ) {
-                my ( $token, $type ) = @{ shift @typed_tokens };
+            if ( defined $token_or_splat[$i] ) {
+                if ( $token_or_splat[$i] eq 'typed_token' ) {
+                    my ( $token, $type ) = @{ shift @typed_tokens };
 
-                if (defined $values[$i]) {
-                    # undef value mean that token was marked as optional so
-                    # we only do type check on defined value
-                    return
-                      unless $type->check($values[$i]);
+                    if (defined $values[$i]) {
+                        # undef value mean that token was marked as optional so
+                        # we only do type check on defined value
+                        return
+                          unless $type->check($values[$i]);
+                    }
+                    $params{$token} = $values[$i];
+                    next;
                 }
-                $params{$token} = $values[$i];
-                next;
-            }
-            if ( $token_or_splat[$i] eq 'token' ) {
-                $params{ shift @tokens } = $values[$i];
-                 next;
-            }
+                if ( $token_or_splat[$i] eq 'token' ) {
+                    $params{ shift @tokens } = $values[$i];
+                     next;
+                }
 
-            # megasplat values are split on '/'
-            if ($token_or_splat[$i] eq 'megasplat') {
-                $values[$i] = [
-                    defined $values[$i] ? split( m{/} , $values[$i], -1 ) : ()
-                ];
+                # megasplat values are split on '/'
+                if ($token_or_splat[$i] eq 'megasplat') {
+                    $values[$i] = [
+                        defined $values[$i] ? split( m{/} , $values[$i], -1 ) : ()
+                    ];
+                }
             }
             push @splat, $values[$i];
         }

--- a/t/classes/Dancer2-Core-Route/match.t
+++ b/t/classes/Dancer2-Core-Route/match.t
@@ -112,10 +112,17 @@ my @tests = (
         [ { splat => [48] }, 44 ],
     ],
 
+    # regex and tokens/splat
+    [
+        [ 'get', '/(any|some)/thing/*', sub {60} ],
+        # was causing 'Use of uninitialized value within @token_or_splat' warnings
+        '/any/thing/else',
+        [ { splat => ['any', 'else'] }, 60 ]
+    ],
 );
 
 
-plan tests => 111;
+plan tests => 116;
 
 for my $t (@tests) {
     my ( $route, $path, $expected ) = @$t;


### PR DESCRIPTION
Mixed regex and splats in paths such as `get '/(any|some)/thing/*' => sub {...}` result in more values from the match than there are regex comments and the generation of `use of unitialized value` warnings.

Add a simple test and check the token/spat comment is defined before testing equality to Shh those warnings.