### PR TITLE
Fix the Dancer2::DeprecationPolicy abstract

### DIFF
--- a/lib/Dancer2/DeprecationPolicy.pod
+++ b/lib/Dancer2/DeprecationPolicy.pod
@@ -1,5 +1,6 @@
-package Dancer2::DeprecationPolicy; # ABSTRACT: Define the process by which
-outdated, broken, or unused code from Dancer2
+package Dancer2::DeprecationPolicy; 
+
+# ABSTRACT: Define the process by which outdated, broken, or unused code is removed from Dancer2
 
 =encoding UTF-8
 


### PR DESCRIPTION
When I reformatted the document, I failed to notice how vim butchered the module abstract. This restores it, and also fixes the wording.

Resolves #1657