### PR TITLE
Add 'gen' command to 'dancer2' runs

### DIFF
--- a/lib/Dancer2/Manual.pod
+++ b/lib/Dancer2/Manual.pod
@@ -46,7 +46,7 @@ the most recent version on CPAN.
 
 Create a web application using the dancer script:
 
-    $ dancer2 -a MyApp && cd MyApp
+    $ dancer2 gen -a MyApp && cd MyApp
     + MyApp
     + MyApp/config.yml
     + MyApp/Makefile.PL
@@ -90,7 +90,7 @@ a script to start it. A default skeleton is used to bootstrap the new
 application, but you can use the C<-s> option to provide another skeleton.
 For example:
 
-    $ dancer2 -a MyApp -s ~/mydancerskel
+    $ dancer2 gen -a MyApp -s ~/mydancerskel
 
 For an example of a skeleton directory check the default one available in
 the C<share/> directory of your Dancer2 distribution.
@@ -1868,7 +1868,7 @@ Carton builds them for you when you need it.
 
 First set up a new app:
 
-     $ dancer2 -a MyApp
+     $ dancer2 gen -a MyApp
      ...
 
 Delete the files that are not needed:


### PR DESCRIPTION
Per [this thread on Perlmonks](https://www.perlmonks.org/?node_id=11142558), the tutorial and manual were lacking the `gen` command in the `dancer2` application examples:

```
Successfully installed Dancer2-0.400000 (upgraded from 0.301004)
1 distribution installed

steve@maezi ~/scratch >dancer2 -a

Unknown option: a
Usage: dancer2 [-h] -h --help --man [subcommand] at /Users/steve/perl5/perlbrew/perls/perl-5.32.1/lib/site_perl/5.32.1/CLI/Osprey/Descriptive/Usage.pm line 329.
```