### PR TITLE
(Rebased) rename show_errors as show_stacktrace

### DIFF
--- a/Changes
+++ b/Changes
@@ -4,7 +4,8 @@
     * PR #1247: Fix edge case in plugin compat (Sawyer X)
 
     [ ENHANCEMENTS ]
-    * None
+    * GH #769, PR #829, #1662: Rename show_errors as show_stacktrace
+      (Nuno Ramos Carvalho, Sawyer X)
 
     [ DOCUMENTATION ]
     * GH #1657: Fix the Dancer2::DeprecationPolicy abstract (Jason A. Crome)

--- a/lib/Dancer2/Config.pod
+++ b/lib/Dancer2/Config.pod
@@ -403,7 +403,7 @@ to use them.
 Sessions are configured with a corresponding L</Session engine> section, as
 shown below.
 
-=head3 show_errors (boolean)
+=head3 show_stacktrace (boolean)
 
 If set to true, Dancer2 will render a detailed debug screen whenever an
 error is caught. If set to false, Dancer2 will render the default error
@@ -412,7 +412,7 @@ by the C<error_template> setting.
 
 The error screen attempts to sanitise sensitive looking information
 (passwords / card numbers in the request, etc) but you still should not have
-show_errors enabled whilst in production, as there is still a risk of
+show_stacktrace enabled whilst in production, as there is still a risk of
 divulging details.
 
 =head3 error_template (template path)

--- a/lib/Dancer2/Config.pod
+++ b/lib/Dancer2/Config.pod
@@ -403,6 +403,12 @@ to use them.
 Sessions are configured with a corresponding L</Session engine> section, as
 shown below.
 
+=head3 show_errors (boolean)
+
+Deprecated configuration.
+
+Use C<show_stacktrace> described below instead.
+
 =head3 show_stacktrace (boolean)
 
 If set to true, Dancer2 will render a detailed debug screen whenever an

--- a/lib/Dancer2/Cookbook.pod
+++ b/lib/Dancer2/Cookbook.pod
@@ -104,7 +104,7 @@ In your C<config.yaml>:
         Baz : 0
 
 In your main route controller:
-    
+
     use Dancer2;
     use Module::Runtime 'require_module';
 

--- a/lib/Dancer2/Core/Error.pm
+++ b/lib/Dancer2/Core/Error.pm
@@ -18,14 +18,14 @@ has app => (
     predicate => 'has_app',
 );
 
-has show_errors => (
+has show_stacktrace => (
     is      => 'ro',
     isa     => Bool,
     default => sub {
         my $self = shift;
 
         $self->has_app
-            and return $self->app->setting('show_errors');
+            and return $self->app->setting('show_stacktrace');
     },
 );
 
@@ -106,8 +106,8 @@ sub default_error_page {
     my $uri_base = $self->has_app && $self->app->has_request ?
         $self->app->request->uri_base : '';
 
-    # GH#1001 stack trace if show_errors is true and this is a 'server' error (5xx)
-    my $show_fullmsg = $self->show_errors && $self->status =~ /^5/;
+    # GH#1001 stack trace if show_stacktrace is true and this is a 'server' error (5xx)
+    my $show_fullmsg = $self->show_stacktrace && $self->status =~ /^5/;
     my $opts = {
         title    => $self->title,
         charset  => $self->charset,
@@ -273,8 +273,8 @@ sub _build_content {
         return $content if defined $content;
     }
 
-    # It doesn't make sense to return a static page for a 500 if show_errors is on
-    if ( !($self->show_errors && $self->status eq '500') ) {
+    # It doesn't make sense to return a static page for a 500 if show_stacktrace is on
+    if ( !($self->show_stacktrace && $self->status eq '500') ) {
          if ( my $content = $self->static_page ) {
              return $content;
          }
@@ -500,7 +500,7 @@ Create a new Dancer2::Core::Error object. For available arguments see ATTRIBUTES
 
 =method supported_hooks ();
 
-=attr show_errors
+=attr show_stacktrace
 
 =attr charset
 

--- a/lib/Dancer2/Manual.pod
+++ b/lib/Dancer2/Manual.pod
@@ -823,6 +823,9 @@ is set to true, in the case of a 500 error the static HTML page will not be
 shown, but will be replaced with a default error page containing more
 informative diagnostics. For more information see L<Dancer2::Config>.)
 
+(In older versions, B<show_errors> was used instead of B<show_stacktrace>.
+Both are supported, but B<show_errors> is deprecated.)
+
 =item * As default, render a generic error page on the fly.
 
 =back

--- a/lib/Dancer2/Manual.pod
+++ b/lib/Dancer2/Manual.pod
@@ -818,7 +818,7 @@ it's used to report the error.
 
 =item * Next, looks in the C<public/> directory for a corresponding HTML file
 matching the error code (e.g. C<500.html> or C<404.html>). If such a file
-exists, it's used to report the error. (Note, however, that if B<show_errors>
+exists, it's used to report the error. (Note, however, that if B<show_stacktrace>
 is set to true, in the case of a 500 error the static HTML page will not be
 shown, but will be replaced with a default error page containing more
 informative diagnostics. For more information see L<Dancer2::Config>.)
@@ -834,7 +834,7 @@ error page with the HTTP status code 500.
 
 It's possible either to display the content of the error message or to hide
 it with a generic error page. This is a choice left to the end-user and can
-be controlled with the B<show_errors> setting (see above).
+be controlled with the B<show_stacktrace> setting (see above).
 
 =head2 Error Hooks
 
@@ -1446,14 +1446,14 @@ file:
     # appdir/environments/development.yml
     log: 'debug'
     startup_info: 1
-    show_errors:  1
+    show_stacktrace:  1
 
 And in a production one:
 
     # appdir/environments/production.yml
     log: 'warning'
     startup_info: 0
-    show_errors:  0
+    show_stacktrace:  0
 
 Please note that you are not limited to writing configuration files in YAML.
 Dancer2 supports any file format that is supported by L<Config::Any>, such

--- a/lib/Dancer2/Tutorial.pod
+++ b/lib/Dancer2/Tutorial.pod
@@ -431,13 +431,13 @@ session handler and initialize a session manager. To do that, we add some
 configuration directives toward the top of our 'dancr.pl' file.  But there are
 more options than just the session engine we want to set.
 
-    set 'database'     => File::Spec->catfile(File::Spec->tmpdir(), 'dancr.db');
-    set 'session'      => 'Simple';
-    set 'template'     => 'template_toolkit';
-    set 'logger'       => 'console';
-    set 'log'          => 'debug';
-    set 'show_errors'  => 1;
-    set 'startup_info' => 1;
+    set 'database'        => File::Spec->catfile(File::Spec->tmpdir(), 'dancr.db');
+    set 'session'         => 'Simple';
+    set 'template'        => 'template_toolkit';
+    set 'logger'          => 'console';
+    set 'log'             => 'debug';
+    set 'show_stacktrace' => 1;
+    set 'startup_info'    => 1;
 
 Hopefully these are fairly self-explanatory. We want the Simple session
 engine, the Template Toolkit template engine, logging enabled (at the
@@ -680,16 +680,16 @@ Here's the complete 'dancr.pl' script from start to finish.
     use File::Slurper qw/ read_text /;
     use Template;
 
-    set 'database'     => File::Spec->catfile(File::Spec->tmpdir(), 'dancr.db');
-    set 'session'      => 'Simple';
-    set 'template'     => 'template_toolkit';
-    set 'logger'       => 'console';
-    set 'log'          => 'debug';
-    set 'show_errors'  => 1;
-    set 'startup_info' => 1;
-    set 'username'     => 'admin';
-    set 'password'     => 'password';
-    set 'layout'       => 'main';
+    set 'database'        => File::Spec->catfile(File::Spec->tmpdir(), 'dancr.db');
+    set 'session'         => 'Simple';
+    set 'template'        => 'template_toolkit';
+    set 'logger'          => 'console';
+    set 'log'             => 'debug';
+    set 'show_stacktrace' => 1;
+    set 'startup_info'    => 1;
+    set 'username'        => 'admin';
+    set 'password'        => 'password';
+    set 'layout'          => 'main';
 
     sub set_flash {
         my $message = shift;
@@ -1064,7 +1064,7 @@ the following five settings sprinkled throughout:
 
     logger: "console"
     log: "core"
-    show_errors: 1
+    show_stacktrace: 1
     startup_info: 1
 
 The first four settings duplicate many of the settings in our new Dancr2 app. So

--- a/share/skel/environments/development.yml
+++ b/share/skel/environments/development.yml
@@ -14,7 +14,7 @@ log: "core"
 # should Dancer2 show a stacktrace when an 5xx error is caught?
 # if set to yes, public/500.html will be ignored and either
 # views/500.tt, 'error_template' template, or a default error template will be used.
-show_errors: 1
+show_stacktrace: 1
 
 # print the banner
 startup_info: 1

--- a/share/skel/environments/production.yml
+++ b/share/skel/environments/production.yml
@@ -7,7 +7,7 @@ log: "warning"
 logger: "file"
 
 # hide errors
-show_errors: 0
+show_stacktrace: 0
 
 # disable server tokens in production environments
 no_server_tokens: 1

--- a/t/app.t
+++ b/t/app.t
@@ -11,7 +11,7 @@ use File::Spec;
 
 # our app/dispatcher object
 my $app = Dancer2::Core::App->new( name => 'main', );
-$app->setting( show_errors => 1 ); # enable show errors
+$app->setting( show_stacktrace => 1 ); # enable show stacktrace
 my $dispatcher = Dancer2::Core::Dispatcher->new( apps => [$app] );
 
 # first basic tests

--- a/t/config/config.yml
+++ b/t/config/config.yml
@@ -1,6 +1,6 @@
 main: 1
 charset: 'UTF-8'
-show_errors: 1
+show_stacktrace: 1
 
 application:
    some_feature: foo

--- a/t/config/environments/production.yml
+++ b/t/config/environments/production.yml
@@ -1,2 +1,2 @@
-show_errors: 0
+show_stacktrace: 0
 logger: "console"

--- a/t/config/environments/staging.json
+++ b/t/config/environments/staging.json
@@ -1,5 +1,5 @@
 {
     "main": "1",
     "charset": 'UTF-8',
-    "show_errors": "1"
+    "show_stacktrace": "1"
 }

--- a/t/config2/config.yml
+++ b/t/config2/config.yml
@@ -1,6 +1,6 @@
 main: 1
 charset: 'UTF-8'
-show_errors: 1
+show_stacktrace: 1
 
 application:
    feature_1: foo

--- a/t/config_reader.t
+++ b/t/config_reader.t
@@ -150,7 +150,7 @@ is_deeply $m->config->{application},
 
 note "config parsing";
 
-is $f->config->{show_errors}, 0;
+is $f->config->{show_stacktrace}, 0;
 is $f->config->{main},        1;
 is $f->config->{charset},     'utf-8', "normalized UTF-8 to utf-8";
 

--- a/t/dispatcher.t
+++ b/t/dispatcher.t
@@ -18,7 +18,7 @@ my $buffer = {};
 my $app = Dancer2::Core::App->new( name => 'main' );
 
 $app->setting( logger      => engine('logger') );
-$app->setting( show_errors => 1 );
+$app->setting( show_stacktrace => 1 );
 
 # a simple / route
 my $simple_route = $app->add_route(

--- a/t/dsl/content.t
+++ b/t/dsl/content.t
@@ -8,7 +8,7 @@ my $logger;
 {
     package App::ContentFail; ## no critic
     use Dancer2;
-    set show_errors => 1;
+    set show_stacktrace => 1;
     set logger      => 'Capture';
 
     $logger = app->engine('logger');

--- a/t/dsl/error_template.t
+++ b/t/dsl/error_template.t
@@ -27,7 +27,7 @@ use Ref::Util qw<is_coderef>;
     package StandardError;
 
     use Dancer2;
-    set show_errors => 1;
+    set show_stacktrace => 1;
 
     get '/no_template' => sub {
         send_error "oopsie", 404;

--- a/t/error.t
+++ b/t/error.t
@@ -123,24 +123,24 @@ subtest 'Throwing an error with a response' => sub {
 
     my $err = eval { Dancer2::Core::Error->new(
         exception   => 'our exception',
-        show_errors => 1
+        show_stacktrace => 1
     )->throw($resp) };
       
     isa_ok($err, 'Dancer2::Core::Response', "Error->throw() accepts a response");
 };
 
-subtest 'Error with show_errors: 0' => sub {
+subtest 'Error with show_stacktrace: 0' => sub {
     my $err = Dancer2::Core::Error->new(
-        exception   => 'our exception',
-        show_errors => 0
+        exception       => 'our exception',
+        show_stacktrace => 0
     )->throw;
     unlike $err->content => qr/our exception/;
 };
 
-subtest 'Error with show_errors: 1' => sub {
+subtest 'Error with show_stacktrace: 1' => sub {
     my $err = Dancer2::Core::Error->new(
-        exception   => 'our exception',
-        show_errors => 1
+        exception       => 'our exception',
+        show_stacktrace => 1
     )->throw;
     like $err->content => qr/our exception/;
 };
@@ -176,8 +176,8 @@ subtest 'Error with exception object' => sub {
     local $@;
     eval { MyTestException->throw('a test exception object') };
     my $err = Dancer2::Core::Error->new(
-        exception   => $@,
-        show_errors => 1,
+        exception       => $@,
+        show_stacktrace => 1,
     )->throw;
 
     like $err->content, qr/a test exception object/, 'Error content contains exception message';
@@ -201,11 +201,11 @@ subtest 'Errors without server tokens' => sub {
     is( $r->header('server'), undef, "No server header when no_server_tokens => 1" );
 };
 
-subtest 'Errors with show_errors and circular references' => sub {
+subtest 'Errors with show_stacktrace and circular references' => sub {
     {
         package App::ShowErrorsCircRef;
         use Dancer2;
-        set show_errors           => 1;
+        set show_stacktrace           => 1;
         set something_with_config => {something => config};
         set password              => '===VERY-UNIQUE-STRING===';
         set innocent_thing        => '===VERY-INNOCENT-STRING===';

--- a/t/issues/gh-1070.t
+++ b/t/issues/gh-1070.t
@@ -7,7 +7,7 @@ use HTTP::Request::Common;
 {
     package App;
     use Dancer2;
-    set show_errors => 1;
+    set show_stacktrace => 1;
 }
 
 my $test = Plack::Test->create( App->to_app );

--- a/t/issues/gh-1098.t
+++ b/t/issues/gh-1098.t
@@ -13,9 +13,9 @@ subtest 'Core::Error serializer isa tests' => sub {
 
     is exception { Dancer2::Core::Error->new }, undef, "Error->new lived";
 
-    like exception { Dancer2::Core::Error->new(show_errors => []) },
+    like exception { Dancer2::Core::Error->new(show_stacktrace => []) },
     qr/Reference \Q[]\E did not pass type constraint "Bool"/i,
-      "Error->new(show_errors => []) died";
+      "Error->new(show_stacktrace => []) died";
 
     is exception {
         Dancer2::Core::Error->new(serializer => undef)

--- a/t/session_bad_client_cookie.t
+++ b/t/session_bad_client_cookie.t
@@ -41,7 +41,7 @@ use HTTP::Cookies;
     };
 
     set session     => 'Simple';
-    set show_errors => 1;
+    set show_stacktrace => 1;
 
     get '/set_session/*' => sub {
         my ($name) = splat;

--- a/t/session_engines.t
+++ b/t/session_engines.t
@@ -49,8 +49,8 @@ BEGIN {
     setting session => 'Simple';
 
     set(
-        show_errors  => 1,
-        environment  => 'production',
+        show_stacktrace  => 1,
+        environment      => 'production',
     );
 }
 

--- a/t/session_hooks.t
+++ b/t/session_hooks.t
@@ -30,8 +30,8 @@ my $test_flags = {};
     use Dancer2;
 
     set(
-        show_errors => 1,
-        envoriment  => 'production'
+        show_stacktrace => 1,
+        envoriment      => 'production'
     );
 
     setting( session => 'Simple' );

--- a/t/session_hooks_no_change_id.t
+++ b/t/session_hooks_no_change_id.t
@@ -31,7 +31,7 @@ my $test_flags = {};
     use Dancer2;
 
     set(
-        show_errors => 1,
+        show_stacktrace => 1,
         envoriment  => 'production'
     );
 

--- a/t/session_lifecycle.t
+++ b/t/session_lifecycle.t
@@ -10,8 +10,8 @@ use lib 't/lib';
     package App;
     use Dancer2;
 
-    set session     => 'Simple';
-    set show_errors => 1;
+    set session         => 'Simple';
+    set show_stacktrace => 1;
 
     get '/no_session_data' => sub {
         return "session not modified";


### PR DESCRIPTION
This is a rebase of @nunorc's work in #829.

I added another commit to make sure `show_errors` still works, but documented it's deprecated.