### PR TITLE
Remove failing module from GitHub actions config

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -144,7 +144,6 @@ jobs:
       - name: Testing selected Plugins
         run: |
             cpanm --test-only --verbose Dancer2::Plugin::Auth::HTTP::Basic::DWIW
-            cpanm --test-only --verbose Dancer2::Plugin::Minion
             cpanm --test-only --verbose Dancer2::Template::Handlebars
             cpanm --test-only --verbose Dancer2::Session::Cookie
             cpanm --test-only --verbose Dancer2::Plugin::Email


### PR DESCRIPTION
Minion is having some issues with the SQLite backend in GitHub actions presently. I don't have the time to diagnose a non-core issue right now, and the build failure emails are annoying, so away it goes.