### PR TITLE
Stringify VERSION_FROM correctly in Makefile.PL

### DIFF
--- a/lib/Dancer2/CLI/Gen.pm
+++ b/lib/Dancer2/CLI/Gen.pm
@@ -154,7 +154,7 @@ sub run {
 
     my $vars = {
         appname          => $app_name,
-        appfile          => $app_file,
+        appfile          => $app_file->stringify,
         apppath          => $app_path,
         appdir           => File::Spec->rel2abs( $app_path ),
         apppath          => $app_path,


### PR DESCRIPTION
I'm not sure if the problem is in Path::Tiny, or how a Path::Tiny object is stringified by Dancer2::Template::Simple, but when generating a skeleton app, the combination caused the new app's `Makefile.PL` to be written with two files in `VERSION_FROM`, which produces an error when Perl tries to produce a Makefile. Explicitly stringifying the appfile path before generating the new app's Makefile prevents the problem from happening.

Fixes #1675.