### PR TITLE
Add documentation resources to the doc map

### DIFF
--- a/lib/Dancer2.pm
+++ b/lib/Dancer2.pm
@@ -196,7 +196,7 @@ how to convert a Dancer (1) based application to Dancer2.
 
 =over
 
-=item * Core and community policy, and standards of conduct
+=item * Core and Community Policy, and Standards of Conduct
 
 The L<Dancer core and community policy, and standards of conduct> clearly explains
 what constitutes acceptable behavior in our community, what behavior is considered

--- a/lib/Dancer2.pm
+++ b/lib/Dancer2.pm
@@ -196,6 +196,14 @@ how to convert a Dancer (1) based application to Dancer2.
 
 =over
 
+=item * Core and community policy, and standards of conduct
+
+The L<Dancer core and community policy, and standards of conduct> clearly explains
+what constitutes acceptable behavior in our community, what behavior is considered
+abusive and unacceptable, and what steps will be taken to remediate inappropriate
+and abusive behavior. By participating in any public forum for Dancer or its
+community, you are agreeing to the terms of this policy.
+
 =item * Git Guide
 
 The L<Git guide|GitGuide> describes how to set up your development environment to contribute

--- a/lib/Dancer2.pm
+++ b/lib/Dancer2.pm
@@ -204,6 +204,12 @@ abusive and unacceptable, and what steps will be taken to remediate inappropriat
 and abusive behavior. By participating in any public forum for Dancer or its
 community, you are agreeing to the terms of this policy.
 
+=item * GitHub Wiki
+
+Our L<GitHub wiki|https://github.com/PerlDancer/Dancer2/wiki> has community-contributed
+documentation, as well as other information that doesn't fit comfortably within
+this manual.
+
 =item * Git Guide
 
 The L<Git guide|GitGuide> describes how to set up your development environment to contribute

--- a/lib/Dancer2.pm
+++ b/lib/Dancer2.pm
@@ -198,7 +198,7 @@ how to convert a Dancer (1) based application to Dancer2.
 
 =item * Core and Community Policy, and Standards of Conduct
 
-The L<Dancer core and community policy, and standards of conduct> clearly explains
+The L<Dancer core and community policy, and standards of conduct> defines
 what constitutes acceptable behavior in our community, what behavior is considered
 abusive and unacceptable, and what steps will be taken to remediate inappropriate
 and abusive behavior. By participating in any public forum for Dancer or its

--- a/lib/Dancer2.pm
+++ b/lib/Dancer2.pm
@@ -207,7 +207,7 @@ community, you are agreeing to the terms of this policy.
 =item * GitHub Wiki
 
 Our L<GitHub wiki|https://github.com/PerlDancer/Dancer2/wiki> has community-contributed
-documentation, as well as other information that doesn't fit comfortably within
+documentation, as well as other information that doesn't quite fit within
 this manual.
 
 =item * Git Guide

--- a/lib/Dancer2.pm
+++ b/lib/Dancer2.pm
@@ -212,9 +212,9 @@ this manual.
 
 =item * Git Guide
 
-The L<Git guide|GitGuide> describes how to set up your development environment to contribute
-to the development of Dancer2, Dancer2's Git workflow, submission guidelines, and
-various coding standards.
+The L<Git guide|https://github.com/PerlDancer/Dancer2/blob/master/GitGuide.md> describes
+how to set up your development environment to contribute to the development of Dancer2,
+Dancer2's Git workflow, submission guidelines, and various coding standards.
 
 =item * Deprecation Policy
 


### PR DESCRIPTION
We've had the community standards and wiki in place for some time, but did not make them easily accessible to our community. By adding them to the documentation map, they should be more visible to developers and community members.

The link to the Git Guide was pointing to a non-existent CPAN module. This has been corrected.

This addresses #1414 and a lot more.