### PR TITLE
Bump minimum version of Perl to 5.14

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,6 +88,7 @@ jobs:
         perl-version:
           - '5.32'
           - "5.30"
+          - "5.14"
 #          - "5.28"
 #          - "5.26"
 #          - "5.24"
@@ -95,8 +96,6 @@ jobs:
 #          - "5.20"
 #          - "5.18"
 #          - "5.16"
-#          - "5.14"
-          - "5.12"  # Not available?
 
     container:
       image: perl:${{ matrix.perl-version }}

--- a/cpanfile
+++ b/cpanfile
@@ -1,4 +1,4 @@
-requires 'perl', 5.012005;
+requires 'perl', 5.014000;
 requires 'Attribute::Handlers';
 requires 'Carp';
 requires 'Clone';


### PR DESCRIPTION
Moo now has a minimum version of Perl 5.14, and without Moo, we have nothing.