### PR TITLE
Change GitGuide to the more standard Contributing

### DIFF
--- a/Contributing.md
+++ b/Contributing.md
@@ -1,9 +1,4 @@
-# Git Guide
-
-This guide will help you to set up your environment to be able to work
-on the Dancer2's repository.
-
-## Contributing
+# Contributing
 
 This guide has been written to help anyone interested in contributing
 to the development of Dancer2.

--- a/README.mkdn
+++ b/README.mkdn
@@ -89,9 +89,9 @@ complete outline on where to go for help.
     documentation, as well as other information that doesn't quite fit within
     this manual.
 
-- Git Guide
+- Contributing
 
-    The [Git guide](https://github.com/PerlDancer/Dancer2/blob/master/GitGuide.md) describes
+    The [contribution guidelines](https://github.com/PerlDancer/Dancer2/blob/master/Contributing.md) describe
     how to set up your development environment to contribute to the development of Dancer2,
     Dancer2's Git workflow, submission guidelines, and various coding standards.
 
@@ -141,6 +141,7 @@ We are also on IRC: #dancer on irc.perl.org.
 ## CORE DEVELOPERS EMERITUS
 
     David Golden
+    Steven Humphrey
 
 ## CONTRIBUTORS
 

--- a/lib/Dancer2.pm
+++ b/lib/Dancer2.pm
@@ -210,9 +210,9 @@ Our L<GitHub wiki|https://github.com/PerlDancer/Dancer2/wiki> has community-cont
 documentation, as well as other information that doesn't quite fit within
 this manual.
 
-=item * Git Guide
+=item * Contributing
 
-The L<Git guide|https://github.com/PerlDancer/Dancer2/blob/master/GitGuide.md> describes
+The L<contribution guidelines|https://github.com/PerlDancer/Dancer2/blob/master/Contributing.md> describe
 how to set up your development environment to contribute to the development of Dancer2,
 Dancer2's Git workflow, submission guidelines, and various coding standards.
 


### PR DESCRIPTION
Many larger projects I see these days (and a lot of smaller ones too) have a file in the repo called Contributing. I think it makes it much clearer what the document is all about.