### PR TITLE
Fix broken link to community Standards of Conduct

### DIFF
--- a/README.mkdn
+++ b/README.mkdn
@@ -77,7 +77,7 @@ complete outline on where to go for help.
 
 - Core and Community Policy, and Standards of Conduct
 
-    The ["Dancer core and community policy, and standards of conduct"](#dancer-core-and-community-policy-and-standards-of-conduct) defines
+    The [Dancer core and community policy, and standards of conduct](https://metacpan.org/pod/Dancer2%3A%3APolicy) defines
     what constitutes acceptable behavior in our community, what behavior is considered
     abusive and unacceptable, and what steps will be taken to remediate inappropriate
     and abusive behavior. By participating in any public forum for Dancer or its
@@ -141,6 +141,7 @@ We are also on IRC: #dancer on irc.perl.org.
 ## CORE DEVELOPERS EMERITUS
 
     David Golden
+    Steven Humphrey
 
 ## CONTRIBUTORS
 

--- a/lib/Dancer2.pm
+++ b/lib/Dancer2.pm
@@ -198,7 +198,7 @@ how to convert a Dancer (1) based application to Dancer2.
 
 =item * Core and Community Policy, and Standards of Conduct
 
-The L<Dancer core and community policy, and standards of conduct> defines
+The L<Dancer core and community policy, and standards of conduct|Dancer2::Policy> defines
 what constitutes acceptable behavior in our community, what behavior is considered
 abusive and unacceptable, and what steps will be taken to remediate inappropriate
 and abusive behavior. By participating in any public forum for Dancer or its


### PR DESCRIPTION
The link from the documentation index pointed to nowhere in particular. All better now.