### PR TITLE
Rename Dancer2::Policy to Dancer2::StandardsOfConduct

### DIFF
--- a/lib/Dancer2.pm
+++ b/lib/Dancer2.pm
@@ -198,7 +198,7 @@ how to convert a Dancer (1) based application to Dancer2.
 
 =item * Core and Community Policy, and Standards of Conduct
 
-The L<Dancer core and community policy, and standards of conduct> defines
+The L<Dancer core and community policy, and standards of conduct|Dancer2::StandardsOfConduct> defines
 what constitutes acceptable behavior in our community, what behavior is considered
 abusive and unacceptable, and what steps will be taken to remediate inappropriate
 and abusive behavior. By participating in any public forum for Dancer or its

--- a/lib/Dancer2/StandardsOfConduct.pod
+++ b/lib/Dancer2/StandardsOfConduct.pod
@@ -1,4 +1,4 @@
-package Dancer2::Policy;
+package Dancer2::StandardsOfConduct;
 # ABSTRACT: Dancer core and community policy and standards of conduct
 
 use strict;


### PR DESCRIPTION
Being extremely clear and explicit about what this is. By keeping it as Pod it will always be a perldoc invocation away.