### PR TITLE
Document missing logging hooks and format option; fix typo

### DIFF
--- a/lib/Dancer2/Core/Role/Logger.pm
+++ b/lib/Dancer2/Core/Role/Logger.pm
@@ -242,6 +242,10 @@ The possible values are:
 
 =over 4
 
+=item %a
+
+app name
+
 =item %h
 
 host emitting the request

--- a/lib/Dancer2/Manual.pod
+++ b/lib/Dancer2/Manual.pod
@@ -682,6 +682,35 @@ for details on the following hooks:
 
 =back
 
+=head2 Logging
+
+Logging hooks do not allow you to alter log message content, but they do
+give you a place to perform extra actions. For example, if you want to send
+an email for error messages, but you don't want to use a heavier logger
+such as L<Log::Any> or L<Log::Log4perl>:
+
+    hook 'engine.logger.after' => sub {
+        my ( $logger, $level, $message ) = @_;
+
+        if( $level eq 'error' ) {
+            # Send an email with the message content
+        }
+    };
+
+There are two hooks available for logging:
+
+=over 4
+
+=item * engine.logger.before
+
+This hook is called before a log message is produced.
+
+=item * engine.logger.after
+
+This hook is called after a log message is produced.
+
+=back
+
 =head2 Serializers
 
 =over 4

--- a/t/logger.t
+++ b/t/logger.t
@@ -63,7 +63,7 @@ subtest 'log level and capture' => sub {
     is_deeply $trap->read, [];
 };
 
-subtest 'logger enging hooks' => sub {
+subtest 'logger engine hooks' => sub {
     # before hook can change log level or message.
     hook 'engine.logger.before' => sub {
         my $logger = shift; # @_ = ( $level, @message_args )


### PR DESCRIPTION
Here are a couple of very small fixes: correcting a subtest name typo, and documenting a missing formatting option in the logger docs.