### PR TITLE
Update tests for minimum, current Perl version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,9 +30,9 @@ jobs:
       fail-fast: false
       matrix:
         perl-version:
-          - '5.38'
-          - '5.32'
-          - '5.20'
+          - 'latest'
+          - '5.36-bookworm'
+          - '5.20-buster'
 
     container:
       image: perldocker/perl-tester:${{ matrix.perl-version }}     # https://hub.docker.com/r/perldocker/perl-tester
@@ -63,14 +63,14 @@ jobs:
             dzil test --author --release
 
       - name: Create release
-        if: ${{ matrix.perl-version == '5.38' }}
+        if: ${{ matrix.perl-version == 'latest' }}
         run: |
             # Increase the version number by 0.000001 so in the reports we can be sure we are using the code to be released.
             perl -i -p -e 's/^version\s*=\s*(\d+\.\d+)/"version = " . ($1 + 0.000001)/e' dist.ini
             dzil build
 
       - name: Archive artifacts
-        if: ${{ matrix.perl-version == '5.38' }}
+        if: ${{ matrix.perl-version == 'latest' }}
         uses: actions/upload-artifact@v2
         with:
           name: the-dancer
@@ -86,16 +86,17 @@ jobs:
       fail-fast: false
       matrix:
         perl-version:
-          - '5.38'
-          - "5.32"
-          - "5.14"
+          - 'latest'
+          - "5.36-bookworm"
+          - "5.20-buster"
 #          - "5.28"
 #          - "5.26"
 #          - "5.24"
 #          - "5.22"
-#          - "5.20"
+#- "5.20"
 #          - "5.18"
 #          - "5.16"
+#          - "5.14"
 
     container:
       image: perl:${{ matrix.perl-version }}
@@ -122,7 +123,7 @@ jobs:
       fail-fast: false
       matrix:
         perl-version:
-          - '5.38'
+          - 'latest'
 
     container:
       image: perldocker/perl-tester:${{ matrix.perl-version }}     # https://hub.docker.com/r/perldocker/perl-tester
@@ -166,7 +167,7 @@ jobs:
         # Will resolve and uncomment later.
         #runner: [ubuntu-latest, macos-latest, windows-latest]
         runner: [ubuntu-latest, macos-latest]
-        perl: [ '5.38' ]
+        perl: [ 'latest' ]
 
     runs-on: ${{matrix.runner}}
     name: Native on OS ${{matrix.runner}} Perl ${{matrix.perl}}

--- a/dist.ini
+++ b/dist.ini
@@ -28,6 +28,7 @@ add_files_in = README.md
 -remove = AutoPrereqs
 -remove = GithubMeta
 -remove = ModuleBuild
+-remove = License
 
 [DynamicPrereqs]
 ; GH#1332 if old HTTP::XSCookies is installed we need to upgrade


### PR DESCRIPTION
Minimum "supported" Perl version should be 5.20 now. Make sure we run tests against the most current production version too.