### PR TITLE
Fix unable to use send_as during template processing (#1712)

### DIFF
--- a/lib/Dancer2/Core/App.pm
+++ b/lib/Dancer2/Core/App.pm
@@ -898,14 +898,15 @@ sub template {
         });
         # Catch any exceptions that may happen during template processing
         my $content = eval { $template->process( @_ ) };
+        my $eval_result = $@;
         $self->set_with_return($old_with_return);
         # If there was a previous response set before the exception (or set as
         # part of the exception handling), then use that, otherwise throw the
         # exception as normal
         if ($local_response) {
             $self->with_return->($local_response);
-        } elsif ($@) {
-            die $@;
+        } elsif ($eval_result) {
+            die $eval_result;
         }
         return $content;
     }

--- a/t/issues/gh-1712/gh-1712.t
+++ b/t/issues/gh-1712/gh-1712.t
@@ -1,0 +1,70 @@
+#!/usr/bin/env perl
+
+use strict;
+use warnings;
+
+use Test::More;
+use Plack::Test;
+use HTTP::Request::Common;
+use Ref::Util qw<is_coderef>;
+
+# Tests for obscure rendering situations that may occur whilst undertaking
+# template processing
+
+{
+    package MyApp;
+
+    use Dancer2;
+
+    set template => 'template_toolkit';
+
+    hook on_route_exception => sub {
+        status 200;
+            send_as(plain => "Some plain text");
+    };
+
+    get '/bork' => sub {
+        my $bork = sub {
+            die "I've borked in the template";
+        };
+        template 'exec',
+            { exec_sub => $bork }
+    };
+
+    get '/plain' => sub {
+        my $plain = sub {
+            send_as(plain => "Some plain text");
+        };
+        template 'exec',
+            { exec_sub => $plain }
+    };
+
+    get '/html' => sub {
+        my $html = sub {
+            send_as(html => "<p>HTML text</p>");
+        };
+        template 'exec',
+            { exec_sub => $html }
+    };
+}
+
+my $app = Dancer2->psgi_app;
+ok( is_coderef($app), 'Got app' );
+
+test_psgi $app, sub {
+    my $cb = shift;
+
+    my $res = $cb->(GET '/bork');
+    is $res->code, 200, 'Correct status code when overriding exception handling';
+    like $res->content, qr/plain text/, 'Correct content when overriding exception handling';
+
+    $res = $cb->(GET '/plain');
+    is $res->code, 200, 'Correct status when sending as plain during template render';
+    like $res->content, qr/plain text/, 'Correct content when sending as plain';
+
+    $res = $cb->(GET '/html');
+    is $res->code, 200, 'Correct status when sending as HTML during template render';
+    like $res->content, qr/HTML text/, 'Correct content when sending as HTML';
+};
+
+done_testing();

--- a/t/issues/gh-1712/views/exec.tt
+++ b/t/issues/gh-1712/views/exec.tt
@@ -1,0 +1,1 @@
+[% IF NOT exec_sub %]foobar[% END %]


### PR DESCRIPTION
Fix the problems as described in #1712. Namely these are further issues subsequent to #1622 regarding unusual actions that take place during template rendering. This could be, for example, custom exception handling during failed template rendering, which result in plain text being sent back to the client instead of the template.