### PR TITLE
Remove Scope::Upper recommends

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -65,7 +65,6 @@ recommends 'Math::Random::ISAAC::XS';
 recommends 'MooX::TypeTiny';
 recommends 'Pod::Simple::Search';
 recommends 'Pod::Simple::SimpleTree';
-recommends 'Scope::Upper';
 recommends 'Type::Tiny::XS';
 recommends 'URL::Encode::XS';
 recommends 'YAML::XS';


### PR DESCRIPTION
Ref #1716

Thanks to @waghanza for noting that Scope::Upper is failing to build on devel perl releases. 
Thanks to @SysPete for confirming we should have removed the recommends on Scope::Upper when Return::MultiLevel was removed.