### PR TITLE
Add Module::Pluggable as a requirement, excluding broken versions

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -22,7 +22,6 @@ requires 'Import::Into';
 requires 'JSON::MaybeXS';
 requires 'List::Util', '1.29';   # 1.29 has the pair* functions
 requires 'MIME::Base64', '3.13'; # 3.13 has the URL safe variants
-requires 'Module::Pluggable', '!= 6.1, != 6.2'; # 6.1 and 6.2 fail their test suite when run as root
 requires 'Module::Runtime';
 requires 'Moo', '2.000000';
 requires 'Moo::Role';
@@ -47,6 +46,12 @@ requires 'File::Which';
 
 requires 'Role::Tiny', '2.000000';
 conflicts 'Role::Tiny', '== 2.000007';
+
+# Module::Pluggable 6.1 and 6.2 fail their test suite when run as root,
+# such as under docker in a github action
+requires 'Module::Pluggable';
+conflicts 'Module::Pluggable', '== 6.1';
+conflicts 'Module::Pluggable', '== 6.2';
 
 # Minimum version of YAML is needed due to:
 # - https://github.com/PerlDancer/Dancer2/issues/899

--- a/cpanfile
+++ b/cpanfile
@@ -22,6 +22,7 @@ requires 'Import::Into';
 requires 'JSON::MaybeXS';
 requires 'List::Util', '1.29';   # 1.29 has the pair* functions
 requires 'MIME::Base64', '3.13'; # 3.13 has the URL safe variants
+requires 'Module::Pluggable', '!= 6.1, != 6.2'; # 6.1 and 6.2 fail their test suite when run as root
 requires 'Module::Runtime';
 requires 'Moo', '2.000000';
 requires 'Moo::Role';


### PR DESCRIPTION
Module::Pluggable added checks for unreadable files in v6.1 and v6.2. Those tests fail when installed as root, which may happen under docker, such as under github actions.

While we have no explicit dependency on Module::Pluggable, our dependencies do, such as Config::Any.

@cromedome this _should_ be sufficient for the github actions to "just work". They run in docker containers as the root user.  This is a bit of a crutch until Module::Plugable is patched. Upstream issue: https://github.com/simonwistow/Module-Pluggable/issues/27  

