### PR TITLE
Force install Module::Pluggable so CI can run

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,6 +44,7 @@ jobs:
       - name: Install dependencies
         run: |
             perl -v
+            cpanm --notest --force Module::Pluggable
             dzil authordeps --missing | cpanm --notest
             dzil listdeps --author --missing | cpanm --notest
 
@@ -111,6 +112,7 @@ jobs:
       - name: Install Dancer
         run: |
             perl -v
+            cpanm --notest --force Module::Pluggable
             cpanm Dancer2-*.tar.gz
             perl -MDancer2 -e 'print "$Dancer2::VERSION\n"'
 
@@ -138,6 +140,7 @@ jobs:
       - name: Install Dancer
         run: |
             perl -v
+            cpanm --notest --force Module::Pluggable
             cpanm Dancer2-*.tar.gz
             perl -MDancer2 -e 'print "$Dancer2::VERSION\n"'
 
@@ -189,6 +192,8 @@ jobs:
         run: |
             perl -v
 
+            cpanm --notest --force Module::Pluggable
+
             # Unclear why Test::TCP fails on GitHub Actions on Windows, but this seems to be related:
             # https://github.com/tokuhirom/Test-TCP/pull/99
             cpanm --notest Test::TCP
@@ -204,6 +209,7 @@ jobs:
       - name: Install Dancer on Linux and OSX
         if: ${{ ! startsWith( matrix.runner, 'windows-' )  }}
         run: |
+            cpanm --notest --force Module::Pluggable
             cpanm Dancer2-*.tar.gz
             perl -MDancer2 -e 'print qq{$Dancer2::VERSION\n}'
 


### PR DESCRIPTION
GitHub Actions, regardless of what we tell it, still insists on installing the incorrect version of Module::Pluggable. Instead, we'll hit it with a really big hammer and force it to install.

This can be removed once the author fixes the issue installing Module::Pluggable as root.

I don't like doing this but I also don't like holding up a release because tests aren't passing. 