### PR TITLE
Enable use of a different Template::Toolkit base class (#1722)

### DIFF
--- a/lib/Dancer2/Template/TemplateToolkit.pm
+++ b/lib/Dancer2/Template/TemplateToolkit.pm
@@ -9,6 +9,9 @@ use Dancer2::FileUtils qw<path>;
 use Scalar::Util ();
 use Template;
 
+# Override to use a different Template::Toolkit base class
+has 'template_class' => ( is => 'ro', default => 'Template' );
+
 with 'Dancer2::Core::Role::Template';
 
 has '+engine' => ( isa => InstanceOf ['Template'], );
@@ -37,7 +40,7 @@ sub _build_engine {
         sub { [ $ttt->views ] },
     ];
 
-    my $tt = Template->new(%tt_config);
+    my $tt = $self->template_class->new(%tt_config);
     $Template::Stash::PRIVATE = undef if $self->config->{show_private_variables};
     return $tt;
 }

--- a/lib/Dancer2/Template/TemplateToolkit.pm
+++ b/lib/Dancer2/Template/TemplateToolkit.pm
@@ -193,6 +193,22 @@ PARSER (L<Template::Parser>) and GRAMMAR (L<Template::Grammar>). If you intend t
 several of these components in your app, it is suggested to create an app-specific subclass
 that handles all of them at the same time.
 
+=head2 Custom Template::Toolkit class
+
+When subclassing this module it is possible to use a different
+Template::Toolkit class (for example if you have also subclassed that). To do
+that simply define a different C<template_class> property:
+
+    package Dancer2::Template::TemplateToolkit::FooBar;
+    
+    use Moo;
+    
+    extends 'Dancer2::Template::TemplateToolkit';
+    
+    has '+template_class' => ( default => 'TemplateFooBar' );
+    
+    1;
+
 =head2 Template Caching
 
 L<Template>::Tookit templates can be cached by adding the C<COMPILE_EXT> property to your

--- a/t/lib/Dancer2/Template/TemplateToolkitFoo.pm
+++ b/t/lib/Dancer2/Template/TemplateToolkitFoo.pm
@@ -1,0 +1,15 @@
+package Dancer2::Template::TemplateToolkitFoo;
+
+# Custom Template::Toolkit template engine that uses a custom Template class
+
+use strict;
+use warnings;
+
+use Moo;
+use TemplateFoo;
+
+extends 'Dancer2::Template::TemplateToolkit';
+
+has '+template_class' => ( default => 'TemplateFoo' );
+
+1;

--- a/t/lib/TemplateFoo.pm
+++ b/t/lib/TemplateFoo.pm
@@ -1,0 +1,13 @@
+package TemplateFoo;
+
+# Custom Template::Toolkit class
+
+use base 'Template';
+
+sub process
+{   my ($self, $template, $vars, $outstream, @opts) = @_;
+    $$outstream = "Custom Render Template";
+    1;
+}
+
+1;


### PR DESCRIPTION
Enable use of different Template::Toolkit base class in `Dancer2::Template::TemplateToolkit` (see #1722)