### PR TITLE
split cookie values on `&` only

### DIFF
--- a/lib/Dancer2/Core/Request.pm
+++ b/lib/Dancer2/Core/Request.pm
@@ -579,7 +579,7 @@ sub _build_cookies {
         $cookies->{$name} = Dancer2::Core::Cookie->new(
             name  => $name,
             # HTTP::XSCookies v0.17+ will do the split and return an arrayref
-            value => (is_arrayref($value) ? $value : [split(/[&;]/, $value)])
+            value => is_arrayref($value) ? $value : [split '&', $value ]
         );
     }
     return $cookies;

--- a/t/cookie.t
+++ b/t/cookie.t
@@ -4,7 +4,6 @@ use Test::Fatal;
 use Test::More;
 
 BEGIN {
-
     # Freeze time at Tue, 15-Jun-2010 00:00:00 GMT
     *CORE::GLOBAL::time = sub { return 1276560000 }
 }
@@ -15,78 +14,77 @@ use Dancer2::Core::Request;
 diag "If you want extra speed, install HTTP::XSCookies"
   if !Dancer2::Core::Cookie::_USE_XS;
 
-sub run_test {
+subtest 'with HTTP::XSCookies' => \&all_tests
+    if Dancer2::Core::Cookie::_USE_XS;
 
-    note "Constructor";
+if ( Dancer2::Core::Cookie::_USE_XS ) {
+    no warnings 'redefine';
+    *Dancer2::Core::Cookie::to_header = \&Dancer2::Core::Cookie::pp_to_header;
+}
 
+subtest 'w/o HTTP::XSCookies' => \&all_tests
+    if Dancer2::Core::Cookie::_USE_XS;
+
+sub all_tests {
     my $cookie = Dancer2::Core::Cookie->new( name => "foo" );
 
-    isa_ok $cookie => 'Dancer2::Core::Cookie';
-    can_ok $cookie => 'to_header';
+    subtest "Constructor" => sub {
+        isa_ok $cookie => 'Dancer2::Core::Cookie';
+        can_ok $cookie => 'to_header';
+    };
+
+    subtest "Setting values" => sub {
+        is $cookie->value("foo") => "foo", "Can set value";
+        is $cookie->value        => "foo", "Set value stuck";
+
+        is $cookie . "bar", "foobar", "Stringifies to desired value";
+
+        ok $cookie->value( [qw(a b c)] ), "can set multiple values";
+        is $cookie->value => 'a', "get first value in scalar context";
+        is_deeply [ $cookie->value ] => [qw(a b c)],
+            "get all values in list context";;
+
+        ok $cookie->value( { x => 1, y => 2 } ), "can set values with a hashref";
+        like $cookie->value => qr/^[xy]$/;    # hashes doesn't store order...
+        is_deeply [ sort $cookie->value ] => [ sort ( 1, 2, 'x', 'y' ) ];
+    };
 
 
-    note "Setting values";
+    subtest "accessors and defaults" => sub {
+        is $cookie->name        => 'foo', "name is as expected";
+        is $cookie->name("bar") => "bar", "can change name";
+        is $cookie->name        => 'bar', "name change stuck";
 
-    is $cookie->value("foo") => "foo", "Can set value";
-    is $cookie->value        => "foo", "Set value stuck";
+        ok !$cookie->domain, "no domain set by default";
+        is $cookie->domain("dancer.org") => "dancer.org",
+            "setting domain returns new value";
+        is $cookie->domain               => "dancer.org",
+            "new domain valjue stuck";
+        is $cookie->domain("")           => "", "can clear domain";
+        ok !$cookie->domain, "no domain set now";
 
-    is $cookie . "bar", "foobar", "Stringifies to desired value";
+        is $cookie->path => '/', "by default, path is /";
+        ok $cookie->has_path, "has_path";
+        is $cookie->path("/foo") => "/foo", "setting path returns new value";
+        ok $cookie->has_path, "has_path";
+        is $cookie->path => "/foo", "new path stuck";
 
-    ok $cookie->value( [qw(a b c)] ), "can set multiple values";
-    is $cookie->value => 'a', "get first value in scalar context";
-    is_deeply [ $cookie->value ] => [qw(a b c)],
-        "get all values in list context";;
+        ok !$cookie->secure, "no cookie secure flag by default";
+        is $cookie->secure(1) => 1, "enabling \$cookie->secure returns new value";
+        is $cookie->secure    => 1, "\$cookie->secure flag is enabled";
+        is $cookie->secure(0) => 0, "disabling \$cookie->secure returns new value";
+        ok !$cookie->secure, "\$cookie->secure flag is disabled";
 
-    ok $cookie->value( { x => 1, y => 2 } ), "can set values with a hashref";
-    like $cookie->value => qr/^[xy]$/;    # hashes doesn't store order...
-    is_deeply [ sort $cookie->value ] => [ sort ( 1, 2, 'x', 'y' ) ];
+        ok $cookie->http_only, "http_only by default";
+        is $cookie->http_only(0) => 0,
+            "disabling \$cookie->http_only returns new value";
+        ok !$cookie->http_only,
+            "\$cookie->http_only is now disabled";
 
+        like exception { $cookie->same_site('foo') },
+            qr/Value "foo" did not pass type constraint "Enum\["Strict","Lax","None"\]/;
+    };
 
-    note "accessors and defaults";
-
-    is $cookie->name        => 'foo', "name is as expected";
-    is $cookie->name("bar") => "bar", "can change name";
-    is $cookie->name        => 'bar', "name change stuck";
-
-    ok !$cookie->domain, "no domain set by default";
-    is $cookie->domain("dancer.org") => "dancer.org",
-        "setting domain returns new value";
-    is $cookie->domain               => "dancer.org",
-        "new domain valjue stuck";
-    is $cookie->domain("")           => "", "can clear domain";
-    ok !$cookie->domain, "no domain set now";
-
-    is $cookie->path => '/', "by default, path is /";
-    ok $cookie->has_path, "has_path";
-    is $cookie->path("/foo") => "/foo", "setting path returns new value";
-    ok $cookie->has_path, "has_path";
-    is $cookie->path => "/foo", "new path stuck";
-
-    ok !$cookie->secure, "no cookie secure flag by default";
-    is $cookie->secure(1) => 1, "enabling \$cookie->secure returns new value";
-    is $cookie->secure    => 1, "\$cookie->secure flag is enabled";
-    is $cookie->secure(0) => 0, "disabling \$cookie->secure returns new value";
-    ok !$cookie->secure, "\$cookie->secure flag is disabled";
-
-    ok $cookie->http_only, "http_only by default";
-    is $cookie->http_only(0) => 0,
-        "disabling \$cookie->http_only returns new value";
-    ok !$cookie->http_only,
-        "\$cookie->http_only is now disabled";
-
-    like exception { $cookie->same_site('foo') },
-        qr/Value "foo" did not pass type constraint "Enum\["Strict","Lax","None"\]/;
-
-    note "expiration strings";
-
-    my $min  = 60;
-    my $hour = 60 * $min;
-    my $day  = 24 * $hour;
-    my $week = 7 * $day;
-    my $mon  = 30 * $day;
-    my $year = 365 * $day;
-
-    ok !$cookie->expires;
     my %times = (
         "+2"                                   => "Tue, 15-Jun-2010 00:00:02 GMT",
         "+2h"                                  => "Tue, 15-Jun-2010 02:00:00 GMT",
@@ -110,98 +108,100 @@ sub run_test {
         "+2 something"                => "+2 something",
     );
 
-    for my $exp ( keys %times ) {
-        my $want = $times{$exp};
+    subtest "expiration strings" => sub {
+        my $min  = 60;
+        my $hour = 60 * $min;
+        my $day  = 24 * $hour;
+        my $week = 7 * $day;
+        my $mon  = 30 * $day;
+        my $year = 365 * $day;
 
-        $cookie->expires($exp);
-        is $cookie->expires => $want, "expiry $exp => $want";;
-    }
+        ok !$cookie->expires;
 
+        for my $exp ( keys %times ) {
+            my $want = $times{$exp};
 
-    note "to header";
+            $cookie->expires($exp);
+            is $cookie->expires => $want, "expiry $exp => $want";;
+        }
+    };
 
-    my @cake = (
-        {   cookie => {
-                name    => 'bar',
-                value   => 'foo',
-                expires => '+2h',
-                secure  => 1
+    subtest "to header" => sub {
+
+        my @cake = (
+            {   cookie => {
+                    name    => 'bar',
+                    value   => 'foo',
+                    expires => '+2h',
+                    secure  => 1
+                },
+                expected => sprintf(
+                    "bar=foo; Expires=%s; HttpOnly; Path=/; Secure",
+                    $times{'+2h'},
+                ),
             },
-            expected => sprintf(
-                "bar=foo; Expires=%s; HttpOnly; Path=/; Secure",
-                $times{'+2h'},
-            ),
-        },
-        {   cookie => {
-                name      => 'bar',
-                value     => 'foo',
-                domain    => 'dancer.org',
-                path      => '/dance',
-                http_only => 1
+            {   cookie => {
+                    name      => 'bar',
+                    value     => 'foo',
+                    domain    => 'dancer.org',
+                    path      => '/dance',
+                    http_only => 1
+                },
+                expected => "bar=foo; Domain=dancer.org; HttpOnly; Path=/dance",
             },
-            expected => "bar=foo; Domain=dancer.org; HttpOnly; Path=/dance",
-        },
-        {   cookie => {
-                name  => 'bar',
-                value => 'foo',
+            {   cookie => {
+                    name  => 'bar',
+                    value => 'foo',
+                },
+                expected => "bar=foo; HttpOnly; Path=/",
             },
-            expected => "bar=foo; HttpOnly; Path=/",
-        },
-        {   cookie => {
-                name  => 'bar',
-                value => 'foo',
-                http_only => 0,
+            {   cookie => {
+                    name  => 'bar',
+                    value => 'foo',
+                    http_only => 0,
+                },
+                expected => "bar=foo; Path=/",
             },
-            expected => "bar=foo; Path=/",
-        },
-        {   cookie => {
-                name  => 'bar',
-                value => 'foo',
-                http_only => '0',
+            {   cookie => {
+                    name  => 'bar',
+                    value => 'foo',
+                    http_only => '0',
+                },
+                expected => "bar=foo; Path=/",
             },
-            expected => "bar=foo; Path=/",
-        },
-        {   cookie => {
-                name      => 'same-site',
-                value     => 'strict',
-                same_site => 'Strict',
+            {   cookie => {
+                    name      => 'same-site',
+                    value     => 'strict',
+                    same_site => 'Strict',
+                },
+                expected => 'same-site=strict; HttpOnly; Path=/; SameSite=Strict',
             },
-            expected => 'same-site=strict; HttpOnly; Path=/; SameSite=Strict',
-        },
-        {   cookie => {
-                name      => 'same-site',
-                value     => 'lax',
-                same_site => 'Lax',
+            {   cookie => {
+                    name      => 'same-site',
+                    value     => 'lax',
+                    same_site => 'Lax',
+                },
+                expected => 'same-site=lax; HttpOnly; Path=/; SameSite=Lax',
             },
-            expected => 'same-site=lax; HttpOnly; Path=/; SameSite=Lax',
-        },
-    );
+        );
 
-    for my $cook (@cake) {
-        my $c = Dancer2::Core::Cookie->new(%{$cook->{cookie}});
-        # name=value; sorted fields
-        my @a = split /; /, $c->to_header;
-        is join("; ", shift @a, sort @a), $cook->{expected};
-    }
+        for my $cook (@cake) {
+            my $c = Dancer2::Core::Cookie->new(%{$cook->{cookie}});
+            # name=value; sorted fields
+            my @a = split /; /, $c->to_header;
+            is join("; ", shift @a, sort @a), $cook->{expected};
+        }
+    };
 
-    note 'multi-value';
+    subtest 'multi-value' => sub {
+        my $c = Dancer2::Core::Cookie->new( name => 'foo', value => [qw/bar baz/] );
 
-    my $c = Dancer2::Core::Cookie->new( name => 'foo', value => [qw/bar baz/] );
+        is $c->to_header, 'foo=bar&baz; Path=/; HttpOnly';
 
-    is $c->to_header, 'foo=bar&baz; Path=/; HttpOnly';
+        my $r = Dancer2::Core::Request->new( env => { HTTP_COOKIE => 'foo=bar&baz' } );
 
-    my $r = Dancer2::Core::Request->new( env => { HTTP_COOKIE => 'foo=bar&baz' } );
-
-    is_deeply [ $r->cookies->{foo}->value ], [qw/bar baz/];
-}
-
-note "Run test with XS_HTTP_COOKIES" if Dancer2::Core::Cookie::_USE_XS;
-run_test();
-if ( Dancer2::Core::Cookie::_USE_XS ) {
-    note "Run test without XS_HTTP_COOKIES";
-    no warnings 'redefine';
-    *Dancer2::Core::Cookie::to_header = \&Dancer2::Core::Cookie::pp_to_header;
-    run_test();
+        is_deeply [ $r->cookies->{foo}->value ], [qw/bar baz/];
+    };
 }
 
 done_testing;

--- a/t/cookie.t
+++ b/t/cookie.t
@@ -11,19 +11,18 @@ BEGIN {
 use Dancer2::Core::Cookie;
 use Dancer2::Core::Request;
 
-diag "If you want extra speed, install HTTP::XSCookies"
-  if !Dancer2::Core::Cookie::_USE_XS;
-
-subtest 'with HTTP::XSCookies' => \&all_tests
-    if Dancer2::Core::Cookie::_USE_XS;
-
 if ( Dancer2::Core::Cookie::_USE_XS ) {
+
+    subtest 'with HTTP::XSCookies' => \&all_tests;
+
     no warnings 'redefine';
     *Dancer2::Core::Cookie::to_header = \&Dancer2::Core::Cookie::pp_to_header;
 }
+else {
+    diag "If you want extra speed, install HTTP::XSCookies";
+}
 
-subtest 'w/o HTTP::XSCookies' => \&all_tests
-    if Dancer2::Core::Cookie::_USE_XS;
+subtest 'w/o HTTP::XSCookies' => \&all_tests;
 
 sub all_tests {
     my $cookie = Dancer2::Core::Cookie->new( name => "foo" );


### PR DESCRIPTION
Seems that ::Request was being overly zealous and was splitting the cookie value on `;` as well. This is not the same behavior as HTTP::XSCookie, which only split on `&`.

Fix #1701