### PR TITLE
Source of on_hook_exception

### DIFF
--- a/lib/Dancer2/Core/App.pm
+++ b/lib/Dancer2/Core/App.pm
@@ -1241,7 +1241,7 @@ sub compile_hooks {
                     # Don't execute the hook_exception hook if the exception
                     # has been generated from a hook exception handler itself,
                     # thus preventing potentially recursive code.
-                    $app->execute_hook( 'core.app.hook_exception', $app, $err )
+                    $app->execute_hook( 'core.app.hook_exception', $app, $err, $position )
                         unless $is_hook_exception;
                     my $is_halted = $app->response->is_halted; # Capture before cleanup
                     # We can't cleanup if we're in the hook for a hook

--- a/lib/Dancer2/Manual.pod
+++ b/lib/Dancer2/Manual.pod
@@ -928,16 +928,19 @@ L<Dancer2::Core::App> and the error as arguments.
   };
 
 C<on_hook_exception> is called when an exception has been caught within a hook,
-just before logging and rethrowing it higher. This hook receives a
-L<Dancer2::Core::App> and the error as arguments. If the function provided to
-on_hook_exception causes an exception itself, then this will be ignored (thus
-preventing a potentially recursive situation). However, it is still possible
-for the function to set a custom response and halt it (and optionally die),
-thus providing a method to render custom content in the event of an exception
-in a hook. This is shown in the example below:
+just before logging and rethrowing it higher. This hook receives as arguments:
+L<Dancer2::Core::App>, the error string and the name of the hook where the
+exception occurred. The hook name is the full hook name (e.g.
+C<core.app.route_exception>).
+
+If the function provided to on_hook_exception causes an exception itself, then
+this will be ignored (thus preventing a potentially recursive situation).
+However, it is still possible for the function to set a custom response and
+halt it (and optionally die), thus providing a method to render custom content
+in the event of an exception in a hook. This is shown in the example below:
 
   hook on_hook_exception => sub {
-    my ($app, $error) = @_;
+    my ($app, $error, $hook_name) = @_;
     $app->response->content("Some custom content for the response");
     $app->response->halt;
   };

--- a/t/hooks.t
+++ b/t/hooks.t
@@ -169,9 +169,10 @@ my $tests_flags = {};
     };
 
     hook on_hook_exception => sub {
-        my ($app, $error) = @_;
+        my ($app, $error, $hook_name) = @_;
         ::is ref($app), 'Dancer2::Core::App';
         ::like $error, qr/this is an exception in the after hook/;
+        ::is $hook_name, 'core.app.after_request';
         $app->response->content("Setting response from exception hook");
         $app->response->halt;
     };


### PR DESCRIPTION
Sorry, I've just realized that in #1738 it would be very useful to have the name of the hook that has thrown an exception (so that the receiving sub knows whether it is before, during or after a request). Any chance of merging this before release please..? Thanks!