### PR TITLE
Fix "package" in Dancer2/Manual/Tutorial.pod

### DIFF
--- a/lib/Dancer2.pm
+++ b/lib/Dancer2.pm
@@ -156,10 +156,10 @@ You have questions. We have answers.
 
 =item * Dancer2 Tutorial
 
-Want to learn by example? The L<Dancer2::Manual::Tutorial> will take you from
+Want to learn by example? The L<tutorial|Dancer2::Manual::Tutorial> will take you from
 installation to a working application.
 
-item * Quick Start
+=item * Quick Start
 
 Want to get going faster? L<Quick Start|Dancer2::Manual::QuickStart> will help you install Dancer2
 and bootstrap a new application quickly.

--- a/lib/Dancer2/Manual/Tutorial.pod
+++ b/lib/Dancer2/Manual/Tutorial.pod
@@ -1,4 +1,4 @@
-package Dancer2::Tutorial;
+package Dancer2::Manual::Tutorial;
 # ABSTRACT: A step-by-step guide to get you dancing
 
 =encoding utf8


### PR DESCRIPTION
The "package" in Dancer2/Manual/Tutorial.pod was "Dancer2::Tutorial". That caused the link to the tutorial (on https://metacpan.org/pod/Dancer2) not to work

Just a small fix :)