### PR TITLE
Fix uri_for prefix behavior and ensure forward preserves app context;…

### DIFF
--- a/t/route_prefix_forward.t
+++ b/t/route_prefix_forward.t
@@ -1,0 +1,49 @@
+use strict;
+use warnings;
+use Test::More;
+use Plack::Test;
+use HTTP::Request::Common qw(GET);
+
+{
+    package TestApp;
+    use Dancer2;
+
+    prefix '/info';
+
+    get '/foo' => sub {
+        forward '/info/bar';
+    };
+
+    get '/bar' => sub {
+        return request->uri_for('/delete');
+    };
+
+    get '/delete' => sub {
+        return "DELETE OK";
+    };
+}
+
+my $app = TestApp->to_app;
+
+test_psgi
+    app    => $app,
+    client => sub {
+        my $cb = shift;
+
+        # Test forwarding + prefix handling
+        my $res = $cb->( GET '/info/foo' );
+        is( $res->code, 200, 'GET /info/foo returns 200' );
+
+        like(
+            $res->content,
+            qr{/info/delete$},
+            'uri_for returns prefixed delete path'
+        );
+
+        # Test the delete route
+        my $res2 = $cb->( GET '/info/delete' );
+        is( $res2->code, 200, 'GET /info/delete returns 200' );
+        is( $res2->content, 'DELETE OK', 'delete route works' );
+    };
+
+done_testing;


### PR DESCRIPTION
Related Issue #1747

This PR fixes a bug where `uri_for` (and `uri_for_route`) did not respect the application prefix when called inside a forwarded request.

What’s fixed
- Forwarded requests now retain the app reference and `uri_for_route` callback.
- `uri_for` correctly applies the app prefix in both normal and forwarded requests.

Added
- New regression test: `t/route_prefix_forward.t`

This ensures that calling `forward` inside a prefixed app still generates proper prefixed URLs like `/info/delete` instead of `/delete`.