### PR TITLE
Get multiple session cookie values at once with clear method

### DIFF
--- a/lib/Dancer2/Core/Cookie.pm
+++ b/lib/Dancer2/Core/Cookie.pm
@@ -86,6 +86,11 @@ around value => sub {
     return wantarray ? @$array : $array->[0];
 };
 
+sub values {
+    my $self  = shift;
+    return @{ $self->{'value'} || [] };
+}
+
 # this is only for overloading; need a real sub to refer to, as the Moose
 # attribute accessor won't be available at that point.
 sub _get_value { shift->value }
@@ -178,6 +183,11 @@ you say e.g. return "Hi, $cookie", you'll get the cookie's value there.)
 In list context, returns a list of potentially multiple values; in scalar
 context, returns just the first value.  (So, if you expect a cookie to have
 multiple values, use list context.)
+
+=method values
+
+Returns all values associated with this cookie, always a list. (So in scalar
+context, you will get the count.)
 
 =attr name
 

--- a/lib/Dancer2/Manual.pod
+++ b/lib/Dancer2/Manual.pod
@@ -1247,6 +1247,24 @@ To retrieve all cookies, use the C<cookies> keyword:
         }
     }
 
+=head2 Multiple Values Per Cookie
+
+Cookie values can be multi-valued. C<cookie('name')> returns the first value
+in scalar context and all values in list context.
+
+    my $visitor  = cookie('visitor'); # single value
+    my @visitors = cookie('visitor'); # multiple values (list context)
+
+However, you can also call the methods C<value> (for either scalar/list
+contexts), or C<values> for list only context:
+
+    my $cookie   = cookies->{'name'};
+    my $visitor  = $cookie->value();
+    my @visitors = $cookies->values();
+
+    # this also works, similar to the DSL keyword 'cookie'
+    my @visitors = $cookie->value();
+
 =head2 Deleting Cookies
 
 To delete a cookie, set it with an expiration time in the past:

--- a/t/cookie.t
+++ b/t/cookie.t
@@ -42,6 +42,10 @@ sub all_tests {
         is $cookie->value => 'a', "get first value in scalar context";
         is_deeply [ $cookie->value ] => [qw(a b c)],
             "get all values in list context";;
+        is_deeply [ $cookie->values ] => [qw(a b c)],
+            "values returns all values";
+        is scalar $cookie->values => 3,
+            "values returns arrayref in scalar context";
 
         ok $cookie->value( { x => 1, y => 2 } ), "can set values with a hashref";
         like $cookie->value => qr/^[xy]$/;    # hashes doesn't store order...


### PR DESCRIPTION
Closes #1073.

Added `values()` to `Dancer2::Core::Cookie`, so it's always list context in that method. Since it's not in a DSL, I'm not entirely sure it's useful.

I'm fine with this just being closed as in "not enough value in it" (because I'm doubting whether it has any unless we deprecate the context-aware part of `cookie()`, which we're probably not going to do) - perfectly fine by me. :)