### PR TITLE
Make Plugin dsl keyword App-specific

### DIFF
--- a/t/issues/gh-1449/TestPlugin.pm
+++ b/t/issues/gh-1449/TestPlugin.pm
@@ -1,0 +1,14 @@
+use strict;
+use warnings;
+package TestPlugin;
+use Dancer2::Plugin;
+
+sub test {
+    my ($self) = @_;
+    $self->app->cookie($self->app->name => 'foo', http_only => 0);
+    return ( $self->app->name, $self->dsl->app->name );
+};
+
+plugin_keywords 'test';
+
+1;

--- a/t/issues/gh-1449/gh-1449.t
+++ b/t/issues/gh-1449/gh-1449.t
@@ -1,0 +1,47 @@
+use strict;
+use warnings;
+use FindBin;
+use lib "$FindBin::Bin/";
+
+use Test::More;
+
+{
+    package App1;
+    use Dancer2;
+    use TestPlugin;
+    set logger => 'null';
+    get '/' => sub {
+        my @apps = test();
+        ::is( $apps[0], $apps[1], 'Plugin reports the same app' );
+        ::is( $apps[0], app->name, 'Plugin reports the correct app' );
+        return 'Cookie: ' . (response()->headers()->header('Set-Cookie') // '');
+
+    };
+
+    package App2;
+    use Dancer2;
+    use TestPlugin;
+    set logger => 'null';
+    get '/' => sub {
+        my @apps = test();
+        ::is( $apps[0], $apps[1], 'Plugin reports the same app' );
+        ::is( $apps[0], app->name, 'Plugin reports the correct app' );
+        return 'Cookie: ' . (response()->headers()->header('Set-Cookie') // '');
+    };
+}
+
+use Plack::Test;
+use Plack::Builder;
+use HTTP::Request::Common;
+
+my $app1 = Plack::Test->create( App1->to_app() );
+my $app2 = Plack::Test->create( App2->to_app() );
+
+my $cookie = $app1->request(GET '/')->header('Set-Cookie');
+is($cookie, 'App1=foo; Path=/', 'Got cookie from app1');
+$cookie = $app2->request(GET '/')->header('Set-Cookie');
+is($cookie, 'App2=foo; Path=/', 'Got cookie from app2');
+$cookie = $app1->request(GET '/')->header('Set-Cookie');
+is($cookie, 'App1=foo; Path=/', 'Got cookie again from app1');
+
+done_testing();


### PR DESCRIPTION
Plugins were caching a single DSL instance at import time. In a multi‑app process, that meant `plugin->dsl` and bare dsl calls resolved to the DSL of the first app that loaded the plugin, breaking per‑app behavior.

This change makes the plugin `dsl` accessor resolve dynamically on each call by walking the call stack to find the consuming app's DSL, and explicitly skips plugin packages to avoid recursion.  This preserves compatibility with bare `dsl` usage while restoring correct per‑app resolution.

This approach keeps the existing API (including bareword `dsl`) as is.