### PR TITLE
Turn off strict config for noisy tests

### DIFF
--- a/t/app/t1/config.yml
+++ b/t/app/t1/config.yml
@@ -1,2 +1,5 @@
 app:
     config: ok
+
+strict_config: 0
+

--- a/t/app/t2/config.yml
+++ b/t/app/t2/config.yml
@@ -1,2 +1,5 @@
 app:
     config: ok
+
+strict_config: 0
+

--- a/t/app/t3/lib/config.yml
+++ b/t/app/t3/lib/config.yml
@@ -1,3 +1,5 @@
 logger : capture
 log    : core 
 
+strict_config: 0
+

--- a/t/app/t_config_file_extended/config.yml
+++ b/t/app/t_config_file_extended/config.yml
@@ -3,3 +3,5 @@ app:
 extended:
     one: ${ENV:DANCER_FILE_EXTENDED_ONE}
     two: Begin ${ENV:DANCER_FILE_EXTENDED_TWO} End
+strict_config: 0
+

--- a/t/config.yml
+++ b/t/config.yml
@@ -1,5 +1,6 @@
 log: "info"
 logger: "Note"
+strict_config: 0
 
 plugins:
   "FooPlugin":

--- a/t/config/config.yml
+++ b/t/config/config.yml
@@ -1,6 +1,7 @@
 main: 1
 charset: 'UTF-8'
 show_stacktrace: 1
+strict_config: 0
 
 application:
    some_feature: foo

--- a/t/config/environments/merging.yml
+++ b/t/config/environments/merging.yml
@@ -1,3 +1,5 @@
 application:
   some_feature: bar
   another_setting: baz
+strict_config: 0
+

--- a/t/config/environments/production.yml
+++ b/t/config/environments/production.yml
@@ -1,2 +1,3 @@
 show_stacktrace: 0
 logger: "console"
+strict_config: 0

--- a/t/config2/config.yml
+++ b/t/config2/config.yml
@@ -1,6 +1,7 @@
 main: 1
 charset: 'UTF-8'
 show_stacktrace: 1
+strict_config: 0
 
 application:
    feature_1: foo

--- a/t/config2/config_local.yml
+++ b/t/config2/config_local.yml
@@ -2,3 +2,4 @@ application:
     feature_2: alpha
     feature_5: beta
     feature_6: gamma
+strict_config: 0

--- a/t/config2/environments/lconfig.yml
+++ b/t/config2/environments/lconfig.yml
@@ -1,3 +1,4 @@
 application:
    feature_6: bar
    feature_7: baz
+strict_config: 0

--- a/t/config2/environments/lconfig_local.yml
+++ b/t/config2/environments/lconfig_local.yml
@@ -1,3 +1,4 @@
 application:
    feature_3: replacement
    feature_8: goober
+strict_config: 0

--- a/t/dsl/extend_config/config.yml
+++ b/t/dsl/extend_config/config.yml
@@ -1,1 +1,2 @@
 dsl_class: 'Dancer2::Test::ExtendedDSL'
+strict_config: 0


### PR DESCRIPTION
The purpose of these particular tests is not to exercise strict_config, so disable it and make for cleaner test output.