### PR TITLE
Default strict_config to false

### DIFF
--- a/lib/Dancer2/Core/App.pm
+++ b/lib/Dancer2/Core/App.pm
@@ -741,7 +741,7 @@ sub _build_default_config {
         appdir         => $self->location,
         public_dir     => $public,
         template       => 'Tiny',
-        strict_config => 1,
+        strict_config  => 0, # We can look at changing this in a future version
         route_handlers => [
             [
                 AutoPage => 1

--- a/lib/Dancer2/Manual/Config.pod
+++ b/lib/Dancer2/Manual/Config.pod
@@ -399,7 +399,7 @@ die occurs. (Internally sets Carp::Verbose). Default to false.
 
 =head3 strict_config (boolean)
 
-If set to true (the default), Dancer2 will warn about unknown configuration
+If set to true, Dancer2 will warn about unknown configuration
 keys at the top level and about unknown keys in built-in engine sections where
 the options are known. Set this to false if you intentionally store
 application-specific settings at the top level or use custom engines with

--- a/share/skel/default/config.yml
+++ b/share/skel/default/config.yml
@@ -16,6 +16,11 @@ layout: "main"
 # about unicode within your app when this setting is set (recommended).
 charset: "UTF-8"
 
+# When strict_config is true, Dancer2 will warn you about unknown
+# top-level configuration keys, and warn about unknown engine
+# configuration options.
+strict_config: 1
+
 # === Engines ===
 #
 # NOTE: All the engine configurations need to be under a single "engines:"

--- a/t/strict_config.t
+++ b/t/strict_config.t
@@ -55,6 +55,7 @@ sub _read_config_with_warnings {
 
 subtest 'warns on unknown keys' => sub {
     my $warnings = _read_config_with_warnings({
+        strict_config => 1,
         typo => 1,
         engines => {
             logger => {
@@ -118,6 +119,7 @@ subtest 'can disable warnings' => sub {
 
 subtest 'can allow specific top-level keys' => sub {
     my $warnings = _read_config_with_warnings({
+        strict_config => 1,
         strict_config_allow => [ 'typo', 'extra_top_level' ],
         typo                     => 1,
         extra_top_level          => 1,


### PR DESCRIPTION
So as not to blow up the logs for existing applications, restore the default to false. To encourage use of `strict_config` however, change the default for newly-generated apps to true.