### PR TITLE
Prevent urlencoded content `foo=bar` from being deserialized when serializer is set to JSON

### DIFF
--- a/lib/Dancer2/Core/Request.pm
+++ b/lib/Dancer2/Core/Request.pm
@@ -190,6 +190,16 @@ sub deserialize {
         return;
     }
 
+    # don't attempt to deserialize if the form is 'application/x-www-form-urlencoded'
+    if (
+        $self->content_type
+        && $self->content_type =~ /^application\/x-www-form-urlencoded/i
+        && $self->body
+        && $self->body !~ /^\s*[[{]/   # Not JSON
+        && $self->body =~ /=/    # has an '='
+    ) {
+        return;
+    }
 
     my $serializer = $self->serializer
         or return;

--- a/t/classes/Dancer2-Core-Request/serializers.t
+++ b/t/classes/Dancer2-Core-Request/serializers.t
@@ -71,4 +71,41 @@ subtest 'Testing with JSON' => sub {
     );
 };
 
+{
+    package App::UrlEncoded;
+    use Dancer2;
+
+    # Due to the random hash order, the response will randomly fail the test.
+    # Turn on canonical to mitigate the problem.
+    set engines => {
+        serializer => {
+            JSON => {
+                canonical => 1
+            }
+        }
+    };
+
+    set serializer => 'JSON';
+
+    post '/' => sub {
+        my %body_parameters = body_parameters->flatten;
+        ::is_deeply(\%body_parameters, { foo => 'bar', bar => '' }, 'Correct body parameters');
+        return \%body_parameters;
+    };
+}
+
+subtest 'Testing with Form-UrlEncoded Data' => sub {
+    my $app = Plack::Test->create( App::UrlEncoded->to_app );
+    my $res = $app->request(
+        POST '/',
+        Content_Type => 'application/x-www-form-urlencoded',
+        Content      => 'foo=bar&bar='
+    );
+    is(
+        $res->content,
+        '{"bar":"","foo":"bar"}',
+        "Successful response"
+    );
+};
+
 done_testing();


### PR DESCRIPTION
This PR will allow sending requests with URL-encoded content, eg: `foo=bar`, to the Dancer2 route, even when the serializer is set to JSON

Test added to support this new behavior.

Resolve ##1770 