### PR TITLE
Restore pre-Path::Tiny HasLocation upward traversal semantics

### DIFF
--- a/lib/Dancer2/Core/Role/HasLocation.pm
+++ b/lib/Dancer2/Core/Role/HasLocation.pm
@@ -76,9 +76,11 @@ sub _build_location {
             last;
         }
 
-        $subdir = $subdir->parent;
+        # Preserve pre-Path::Tiny traversal behavior: keep walking "up"
+        # even when current subdir is ".".
+        $subdir = Path::Tiny::path( $subdir, '..' );
 
-        last if $subdir->realpath->stringify eq Path::Tiny->rootdir->stringify;
+        last if $subdir->absolute->stringify eq Path::Tiny->rootdir->stringify;
     }
 
     my $path = $subdir_found ? $subdir : $location;


### PR DESCRIPTION
A regression in app root detection was introduced by the `Path::Tiny` migration in `Dancer2::Core::Role::HasLocation`.

When walking up parent directories to find an app root (`lib`+`bin` or `.dancer`), switching to `$subdir->parent` changed behavior for relative paths (notably `.`), which could stop effective upward traversal and lead to incorrect root selection on some systems.

Fix by restoring pre-migration traversal behavior:

* advance with `Path::Tiny::path($subdir, '..')` each iteration
* stop at filesystem root via absolute-path comparison

This keeps existing caller semantics intact while fixing template/public/config resolution failures caused by misdetected app location.