### PR TITLE
1784 json serializer decode hashref

### DIFF
--- a/lib/Dancer2/Serializer/JSON.pm
+++ b/lib/Dancer2/Serializer/JSON.pm
@@ -84,6 +84,7 @@ sub _ensure_characters {
     }
 
     if ( is_plain_hashref($entity) ) {
+        my %ret;
         for my $key ( keys %{$entity} ) {
             my $value = $entity->{$key};
             my $decoded_key = _ensure_scalar( $key, $strict_utf8, $self );
@@ -92,12 +93,12 @@ sub _ensure_characters {
 
             if ( $decoded_key ne $key ) {
                 delete $entity->{$key};
-                $entity->{$decoded_key} = $decoded_value;
+                $ret{$decoded_key} = $decoded_value;
             } else {
-                $entity->{$key} = $decoded_value;
+                $ret{$key} = $decoded_value;
             }
         }
-        return $entity;
+        return \%ret;
     }
 
     return $entity;

--- a/lib/Dancer2/Serializer/JSON.pm
+++ b/lib/Dancer2/Serializer/JSON.pm
@@ -2,7 +2,7 @@ package Dancer2::Serializer::JSON;
 # ABSTRACT: Serializer for handling JSON data
 
 use Moo;
-use Ref::Util qw< is_arrayref is_hashref >;
+use Ref::Util qw< is_plain_arrayref is_plain_hashref >;
 use JSON::MaybeXS ();
 use Encode qw(decode FB_CROAK);
 use Scalar::Util 'blessed';
@@ -76,14 +76,14 @@ sub _ensure_characters {
     return $entity if !defined $entity;
     return _ensure_scalar( $entity, $strict_utf8, $self ) if !ref $entity;
 
-    if ( is_arrayref($entity) ) {
+    if ( is_plain_arrayref($entity) ) {
         for my $i ( 0 .. $#{$entity} ) {
             $entity->[$i] = _ensure_characters( $entity->[$i], $strict_utf8, $self );
         }
         return $entity;
     }
 
-    if ( is_hashref($entity) ) {
+    if ( is_plain_hashref($entity) ) {
         for my $key ( keys %{$entity} ) {
             my $value = $entity->{$key};
             my $decoded_key = _ensure_scalar( $key, $strict_utf8, $self );

--- a/t/serializer_json.t
+++ b/t/serializer_json.t
@@ -18,7 +18,8 @@ use Dancer2::Serializer::JSON;
     set engines => {
         serializer => {
             JSON => {
-                pretty => 1,
+                canonical => 1,
+                pretty    => 1,
             }
         }
     };
@@ -31,16 +32,16 @@ use Dancer2::Serializer::JSON;
 
 my @tests = (
     {   entity  => { a      => 1, b => 2, },
-        options => { pretty => 1 },
+        options => { canonical => 1, pretty => 1 },
         name    => "basic hash",
     },
     {   entity  =>
           { c => [ { d => 3, e => { f => 4, g => 'word', } } ], h => 6 },
-        options => { pretty => 1 },
+        options => { canonical => 1, pretty => 1 },
         name    => "nested",
     },
     {   entity  => { data => "\x{2620}" x 10 },
-        options => { pretty => 1, utf8 => 1 },
+        options => { canonical => 1, pretty => 1, utf8 => 1 },
         name    => "utf8",
     }
 );


### PR DESCRIPTION
Fixes for JSON serializer `_ensure_characters`:
* don't recurse into blessed objects. Resolves #1789
* create a new hash in case keys were marked read-only. Resolves #1784

The test suite will likely fail due to hash randomization with this applied, so require sorted keys (canonical representation) in encoded json (string) comparisons.