### PR TITLE
Correct error codes for file checks in send_file

### DIFF
--- a/lib/Dancer2/Core/App.pm
+++ b/lib/Dancer2/Core/App.pm
@@ -1182,8 +1182,8 @@ sub send_file {
         $err_response->(403) if !$dir->realpath->subsumes($file_path);
 
         # other error checks
-        $err_response->(403) if !$file_path->exists;
-        $err_response->(404) if !$file_path->is_file;
+        $err_response->(404) if !$file_path->exists;
+        $err_response->(403) if !$file_path->is_file;
         $err_response->(403) if !-r $file_path;
 
         # Read file content as bytes


### PR DESCRIPTION
Back in 8caaf43f9cbdb , the return codes for send_file on a missing file was altered.

If a file doesn't exist, the obvious return code should be 404, and if you're trying to do send_file on something that's not a file , 403 is a sane return code.