### PR TITLE
Add strict_utf8 to known config keys

### DIFF
--- a/lib/Dancer2/ConfigReader.pm
+++ b/lib/Dancer2/ConfigReader.pm
@@ -53,6 +53,7 @@ my %KNOWN_CORE_KEYS = map +( $_ => 1 ), qw(
     traces
     type_library
     views
+    strict_utf8
     strict_config
     strict_config_allow
 );


### PR DESCRIPTION
Fix to https://github.com/PerlDancer/Dancer2/issues/1795