### PR TITLE
Fix path()/dirname() dropping first path segment

### DIFF
--- a/Changes
+++ b/Changes
@@ -6,6 +6,7 @@
     * GH #1790: Fix infinite recursion into blessed objects in JSON
       Serializer (Russell @veryrusty Jenkins)
     * PR #1791: Send correct error codes in send_file (Anton Lundin)
+    * Fix path()/dirname() DSL keywords dropping their first argument (Mike Weisenborn)
 
     [ ENHANCEMENTS ]
     * None

--- a/lib/Dancer2/Core/DSL.pm
+++ b/lib/Dancer2/Core/DSL.pm
@@ -145,7 +145,7 @@ sub error   { shift->app->log( error   => @_ ) }
 sub true  {1}
 sub false {0}
 
-sub _path_obj { shift and Path::Tiny::path(@_) }
+sub _path_obj { Path::Tiny::path(@_) }
 sub dirname { shift and _path_obj(@_)->parent->stringify }
 sub path    { shift and _path_obj(@_)->stringify }
 

--- a/t/dsl_path_dirname.t
+++ b/t/dsl_path_dirname.t
@@ -1,0 +1,53 @@
+use strict;
+use warnings;
+use Test::More;
+
+# Dancer2 2.1.0 regression: the `path` (and `dirname`) DSL keywords silently
+# drop their first argument when called with 2+ path segments.
+#
+# Root cause (Dancer2::Core::DSL, 2.1.0):
+#   sub _path_obj { shift and Path::Tiny::path(@_) }
+#   sub path      { shift and _path_obj(@_)->stringify }
+#
+# path() already shifts off its DSL invocant before calling _path_obj(@_).
+# _path_obj then shifts *again*, as if it too were called as a method, but
+# it's a plain function call -- so it eats the first real path segment
+# instead of an invocant. dirname() shares the same broken helper.
+#
+# Documented behavior (Dancer2::Manual::Keywords, "path"): "Concatenates
+# multiple paths together" -- i.e. path('t','views') should be 't/views'.
+# Confirmed correct under Dancer2 2.0.1; broken under 2.1.0.
+
+package TestApp;
+use Dancer2;
+package main;
+
+my $dsl = TestApp->dsl;
+
+is( $dsl->path('t', 'views'), 't/views',
+    'path() with 2 segments keeps all segments (documented: concatenates)' );
+
+is( $dsl->path('a', 'b', 'c'), 'a/b/c',
+    'path() with 3 segments keeps all segments' );
+
+# Single-argument calls are even worse: _path_obj's spurious shift eats the
+# only argument, leaving Path::Tiny::path() with zero args, which dies
+# outright instead of returning a wrong-but-harmless string.
+my $single_arg_result = eval { $dsl->dirname('t/views/x.tt') };
+my $single_arg_error  = $@;
+ok( defined $single_arg_result && !$single_arg_error,
+    'dirname() with a single argument does not crash' )
+    or diag("dirname('t/views/x.tt') died: $single_arg_error");
+
+is( $single_arg_result, 't/views',
+    'dirname() of a single-argument path is correct' ) if defined $single_arg_result;
+
+# Knock-on effect: this is exactly how Dancer2::Plugin::FlashNote's test
+# suite sets its views directory (t/01-default.t):
+#   setting views => path( 't', 'views' );
+# Under the bug, `views` silently becomes just 'views' (the 't' is lost),
+# so every template lookup 404s and every route handler that renders a
+# template returns a 500 -- which is what caused ~114/160 FlashNote
+# subtests to fail under 2.1.0 while the plugin's own code never changed.
+
+done_testing();


### PR DESCRIPTION
# Title

`path`/`dirname` DSL keywords silently drop their first argument (or crash) in 2.1.0

# Body

## Summary

In 2.1.0, the `path` and `dirname` DSL keywords no longer concatenate all
given path segments as documented. With 2+ arguments, the first segment is
silently dropped. With exactly 1 argument, the call dies outright.

This is a regression from 2.0.1, where both keywords worked correctly.

## Root cause

`lib/Dancer2/Core/DSL.pm` introduced a shared helper in 2.1.0:

```perl
sub _path_obj { shift and Path::Tiny::path(@_) }
sub dirname   { shift and _path_obj(@_)->parent->stringify }
sub path      { shift and _path_obj(@_)->stringify }
```

`path()`/`dirname()` each `shift` off the DSL invocant (`$self`) before
calling `_path_obj(@_)`. But `_path_obj` *also* `shift`s, as though it were
itself called as a method with its own invocant to remove. It isn't - it's a
plain function call - so that `shift` eats the first real path segment
instead.

For comparison, 2.0.1's `path()` called `Dancer2::FileUtils::path(@_)`
directly, with no such double-shift.

## Documented behavior

From `Dancer2::Manual::Keywords`:

> **path** — Concatenates multiple paths together without worrying about the
> underlying operating system.

`path('t', 'views')` is documented to produce `t/views`.

## Reproduction

```perl
use strict;
use warnings;
package TestApp;
use Dancer2;
package main;

my $dsl = TestApp->dsl;

print $dsl->path('t', 'views'), "\n";        # expected: t/views
print $dsl->path('a', 'b', 'c'), "\n";       # expected: a/b/c
print $dsl->dirname('t/views/x.tt'), "\n";   # expected: t/views
```

**Expected (2.0.1):**
```
t/views
a/b/c
t/views
```

**Actual (2.1.0):**
```
views
b/c
Path::Tiny paths require defined, positive-length parts at .../Dancer2/Core/DSL.pm line 148.
```

The first two calls silently drop their leading segment. The third -
`dirname()` with a single argument - dies, because `_path_obj`'s spurious
`shift` leaves `Path::Tiny::path()` with zero arguments.

## Real-world impact

Any app that builds a filesystem path from `path()`/`dirname()` with the
segments split out (a common pattern for `views`, e.g.
`setting views => path( 't', 'views' )`) silently gets the wrong directory
under 2.1.0, and every template lookup subsequently fails with `file error -
<template>: not found`, turning into a 500 on any route that renders a
template.

We hit this concretely: `Dancer2::Plugin::FlashNote`'s test suite sets
`setting views => path( 't', 'views' )` in its test app. Under 2.1.0 this
silently becomes `views` (the `t` is dropped), so 13 of its 15 test files
fail (114/160 subtests), all with `Failed to render template: file error -
*.tt: not found`. The plugin's own code is untouched - the failure is
entirely caused by this DSL regression. Confirmed with a minimal
FlashNote-free reproduction using only core Dancer2 as shown above.

## Environment

- Dancer2 2.1.0 (also present on current GitHub `master`, unreleased)
- Confirmed absent in Dancer2 2.0.1
- Perl 5.44.0

## Suggested fix

`_path_obj` shouldn't `shift` at all, since it's never called as a method:

```perl
sub _path_obj { Path::Tiny::path(@_) }
```

Applying this one-line change:

- Fixes all three reproduction cases above.
- Dancer2::Plugin::FlashNote's test suite goes from 114/160 failing subtests
  (13/15 files) to 160/160 passing.
- Dancer2's original bundled test suite (`t/*.t`, 88 files / 863 tests) passes
  identically before and after the patch (863/863 both times, output
  byte-identical apart from timing) - i.e. the fix introduces no
  regressions, and also confirms this code path currently has no test
  coverage of its own, which is presumably how the regression shipped
  unnoticed.
- the new test added fails before the patch and succeeds after